### PR TITLE
[EPMDEDP-12204]: fix: Allow non-interactive login with set password for KeycloakRealmUser

### DIFF
--- a/pkg/client/keycloak/adapter/gocloak_adapter_user.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_user.go
@@ -274,7 +274,7 @@ func (a GoCloakAdapter) setUserPassword(realmName, userID, password string) erro
 			keycloakApiParamId:    userID,
 		}).
 		SetBody(map[string]interface{}{
-			"temporary": true,
+			"temporary": false,
 			"type":      "password",
 			"value":     password,
 		}).


### PR DESCRIPTION
## Description

Fixes https://github.com/epam/edp-keycloak-operator/issues/6

When configuring a User with a desired password, either via `spec.password` or `.spec.passwordSecret`, the password cannot be used for login since the UPDATE_PASSWORD required action is always set, regardless of what was specified in `spec.requiredUserActions`. This makes the User CRD unusable for non-interactive logins by machine users (e.g. a User automatically created for a test job) until an admin manually removes the required Action. Logging in interactively via a browser will also clear the login blocking action, however since this will force a password change, the configured password can no longer be used for automatic logins.

This commit sets the "temporary" attribute of the password to false, the previous value of "true" was forcing the UPDATE_PASSWORD user action. If this behaviour is specifically desired (for example as part of an automated flow that provides initial passwords to human users), one should add "UPDATE_PASSWORD" to `.spec.requiredUserActions` explicitly.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- Ran all available tests including `make e2e` against kind with k8s v1.27.3
- Deployed build with fix in Dev at work where Bug was intially noticed, bug confirmed gone

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if appropriate):

## Additional context
Add any other context or screenshots about the feature request here.