### PR TITLE
chore: Remove explicit caching in workflows (#34)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  GOLANG_VERSION: '1.20'
+
 jobs:
   e2e-tests:
     name: End-to-end tests
@@ -23,23 +26,13 @@ jobs:
        - "1.27"
 
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.20"
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Get cache
-        uses: actions/cache@v3
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version: ${{ env.GOLANG_VERSION }}
 
       - name: "install kuttl"
         run: ./hack/install-kuttl.sh
@@ -49,14 +42,6 @@ jobs:
           KUBE_VERSION: ${{ matrix.kube-version }}
         run: make start-kind KUBE_VERSION=$KUBE_VERSION && make e2e
 
-      - name: Save cache
-        id: cache-save
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
   e2e-tests-check:
     runs-on: ubuntu-20.04
     if: always()

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GOLANG_VERSION }}
 
@@ -98,18 +98,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Get cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GOLANG_VERSION }}
 
@@ -118,15 +108,6 @@ jobs:
 
       - name: Make Lint
         run: make lint
-
-      - name: Save cache
-        id: cache-save
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
   docker-lint:
     needs: [build-and-lint]
@@ -154,24 +135,13 @@ jobs:
        - "1.27"
 
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GOLANG_VERSION }}
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Get cache
-        uses: actions/cache@v3
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
+          go-version: ${{ env.GOLANG_VERSION }}
 
       - name: "install kuttl"
         run: ./hack/install-kuttl.sh
@@ -180,15 +150,6 @@ jobs:
         env:
           KUBE_VERSION: ${{ matrix.kube-version }}
         run: make start-kind KUBE_VERSION=$KUBE_VERSION && make e2e
-
-      - name: Save cache
-        id: cache-save
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
   e2e-tests-check:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,12 +16,12 @@ jobs:
       SOURCE_TAG: ${{ github.ref }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: '0'
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GOLANG_VERSION }}
 


### PR DESCRIPTION
# Pull Request Template

## Description

The PR removes explicit caching `actions/caching` in workflows because `actions/setup-go@v4` has built-in caching. For more information, visit https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs

The cache added in the commit https://github.com/epam/edp-keycloak-operator/commit/77584cf1459b19a9635a1eb5396949ae139422f0.

Additionally, the PR updates the versions of the actions: `setup-go` to `v5` and `checkout` to `v4`. It also reorders them so that `checkout` comes before `setup-go`.

For consistency with `pr.yaml` and `release.yaml`, this PR introduces `env.GOLANG_VERSION`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Pull Request contain one commit. I squash my commits

## Screenshots (if appropriate):

## Additional context

Here is the screenshot of [`build-and-lint` job](https://github.com/alexandear/edp-keycloak-operator/actions/runs/8143838565/job/22256642141?pr=1#step:3:11), demonstrating the use of cache following changes in this PR:

<img width="1096" alt="image" src="https://github.com/epam/edp-keycloak-operator/assets/3228886/7dcb5903-ac80-4944-a79f-ffa5f413caac">
