### PR TITLE
feature: Add imagePullSecrets to enable private repository

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -136,6 +136,7 @@ Development versions are also available from the [snapshot helm chart repository
 | image.repository | string | `"epamedp/keycloak-operator"` | EDP keycloak-operator Docker image name. The released image can be found on [Dockerhub](https://hub.docker.com/r/epamedp/keycloak-operator) |
 | image.tag | string | `nil` | EDP keycloak-operator Docker image tag. The released image can be found on [Dockerhub](https://hub.docker.com/r/epamedp/keycloak-operator/tags) |
 | imagePullPolicy | string | `"IfNotPresent"` | If defined, a imagePullPolicy applied to the deployment |
+| imagePullSecrets | list | `[]` | If defined, imagePullSecrets are applied to deployment |
 | name | string | `"keycloak-operator"` | Application name string |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | resources | object | `{"limits":{"memory":"192Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | Resource limits and requests for the pod |

--- a/deploy-templates/templates/deployment.yaml
+++ b/deploy-templates/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
           # Replace this with the built image name
           image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - /manager
           securityContext:

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -16,6 +16,8 @@ image:
   tag:
 # -- If defined, a imagePullPolicy applied to the deployment
 imagePullPolicy: "IfNotPresent"
+# -- If defined, imagePullSecrets are applied to deployment
+imagePullSecrets: []
 
 # -- Resource limits and requests for the pod
 resources:


### PR DESCRIPTION
# Pull Request Template

## Description
When deployment in many environments the images are provided via a private repository.
Private repository's require imagePullSecrets.
This PR adds imagePullSecrets to the values file of the chart AND uses it to provide the imagePullSecrets to the deployment.
If no secrets are provided (default) the imagePullSecrets is not applied to the deployment.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits

## Screenshots (if appropriate):

## Additional context
Add any other context or screenshots about the feature request here.