### PR TITLE
bug: move imagePullSecrets to spec.template.spec

### DIFF
--- a/deploy-templates/templates/deployment.yaml
+++ b/deploy-templates/templates/deployment.yaml
@@ -21,15 +21,15 @@ spec:
       serviceAccountName: edp-{{ .Values.name }}
       securityContext:
         runAsNonRoot: true
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.name }}
           # Replace this with the built image name
           image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
-          {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           command:
             - /manager
           securityContext:


### PR DESCRIPTION
# Pull Request Template

## Description
The current template of imagePullSecrets places the pull secret within the container specification. This is not correct it should be part of the spec.metadata.spec definition.

When run with the imagePullSecrets defined the current implementation fails to apply to k8s as it is an invalid definition.

This PR corrects the imagePullSecrets definition to the correct location in the Deployment template.
No other changes are made

Fixes #73 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits

## Screenshots (if appropriate):

## Additional context
Add any other context or screenshots about the feature request here.