### PR TITLE
feat: Remove ownerReference from Keycloak resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ To prevent the operator from deleting resources from Keycloak, add the `edp.epam
        kind: Keycloak
    ```
 
+#### Resources deletion
+
+To avoid resources getting stuck during deletion, it is important to delete them in the correct order:
+
+1. **First**, remove realm resources `KeycloakClient`, `KeycloakRealmUser`, etc.
+2. **Then**, remove `KeycloakRealm`/`ClusterKeycloakRealm`.
+3. **Finally**, remove `Keycloak`/`ClusterKeycloak`.
+
 ## Local Development
 
 To develop the operator, first set up a local environment, and refer to the [Local Development](https://epam.github.io/edp-install/developer-guide/local-development/) page.

--- a/controllers/clusterkeycloakrealm/clusterkeycloakrealm_controller.go
+++ b/controllers/clusterkeycloakrealm/clusterkeycloakrealm_controller.go
@@ -23,7 +23,6 @@ type Helper interface {
 	SetFailureCount(fc helper.FailureCountable) time.Duration
 	TryToDelete(ctx context.Context, obj client.Object, terminator helper.Terminator, finalizer string) (isDeleted bool, resultErr error)
 	CreateKeycloakClientFromClusterRealm(ctx context.Context, realm *keycloakAlpha.ClusterKeycloakRealm) (keycloak.Client, error)
-	SetKeycloakOwnerRef(ctx context.Context, object helper.ObjectWithKeycloakRef) error
 	InvalidateKeycloakClientTokenSecret(ctx context.Context, namespace, rootKeycloakName string) error
 }
 
@@ -59,10 +58,6 @@ func (r *ClusterKeycloakRealmReconciler) Reconcile(ctx context.Context, req ctrl
 		}
 
 		return ctrl.Result{}, fmt.Errorf("unable to get cluster realm: %w", err)
-	}
-
-	if err := r.helper.SetKeycloakOwnerRef(ctx, clusterRealm); err != nil {
-		return ctrl.Result{}, fmt.Errorf("unable to set keycloak owner ref: %w", err)
 	}
 
 	kClient, err := r.helper.CreateKeycloakClientFromClusterRealm(ctx, clusterRealm)

--- a/controllers/helper/controller_helper_test.go
+++ b/controllers/helper/controller_helper_test.go
@@ -8,138 +8,16 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-resty/resty/v2"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
-	testifymock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/mock"
 	"github.com/epam/edp-keycloak-operator/pkg/fakehttp"
 )
-
-func TestHelper_GetOrCreateRealmOwnerRef(t *testing.T) {
-	mc := K8SClientMock{}
-
-	sch := runtime.NewScheme()
-	utilruntime.Must(keycloakApi.AddToScheme(sch))
-
-	helper := MakeHelper(&mc, sch, "default")
-
-	kcGroup := keycloakApi.KeycloakRealmGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "test",
-		},
-		Spec: keycloakApi.KeycloakRealmGroupSpec{
-			RealmRef: common.RealmRef{
-				Kind: keycloakApi.KeycloakRealmKind,
-				Name: "realm",
-			},
-		},
-	}
-
-	mc.On("Get", types.NamespacedName{
-		Namespace: "test",
-		Name:      "realm",
-	}, &keycloakApi.KeycloakRealm{}).Return(nil)
-	mc.On("Update", testifymock.Anything, testifymock.Anything).Return(nil)
-
-	err := helper.SetRealmOwnerRef(context.Background(), &kcGroup)
-	require.NoError(t, err)
-
-	kcGroup = keycloakApi.KeycloakRealmGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "test",
-		},
-		Spec: keycloakApi.KeycloakRealmGroupSpec{
-			Realm: "foo13",
-			RealmRef: common.RealmRef{
-				Kind: keycloakApi.KeycloakRealmKind,
-				Name: "realm",
-			},
-		},
-	}
-
-	mc.On("Get", types.NamespacedName{
-		Namespace: "test",
-		Name:      "foo13",
-	}, &keycloakApi.KeycloakRealm{}).Return(nil)
-
-	err = helper.SetRealmOwnerRef(context.Background(), &kcGroup)
-	require.NoError(t, err)
-}
-
-func TestHelper_GetOrCreateRealmOwnerRef_Failure(t *testing.T) {
-	mc := K8SClientMock{}
-
-	sch := runtime.NewScheme()
-	utilruntime.Must(keycloakApi.AddToScheme(sch))
-
-	helper := MakeHelper(&mc, sch, "default")
-
-	kcGroup := keycloakApi.KeycloakRealmGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "test",
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					Name: "foo",
-					Kind: "KeycloakRealm",
-				},
-			},
-		},
-		Spec: keycloakApi.KeycloakRealmGroupSpec{
-			RealmRef: common.RealmRef{
-				Kind: keycloakApi.KeycloakRealmKind,
-				Name: "realm",
-			},
-		},
-	}
-
-	mockErr := errors.New("mock error")
-
-	mc.On("Get", types.NamespacedName{
-		Namespace: "test",
-		Name:      kcGroup.Spec.RealmRef.Name,
-	}, &keycloakApi.KeycloakRealm{}).Return(mockErr)
-
-	err := helper.SetRealmOwnerRef(context.Background(), &kcGroup)
-	if err == nil {
-		t.Fatal("no error on k8s client get fatal")
-	}
-
-	assert.ErrorIs(t, err, mockErr)
-
-	kcGroup = keycloakApi.KeycloakRealmGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "test",
-		},
-		Spec: keycloakApi.KeycloakRealmGroupSpec{
-			RealmRef: common.RealmRef{
-				Kind: keycloakApi.KeycloakRealmKind,
-				Name: "realm",
-			},
-		},
-	}
-
-	mc.On("Get", types.NamespacedName{
-		Namespace: "test",
-		Name:      kcGroup.Spec.RealmRef.Name,
-	}, &keycloakApi.KeycloakRealm{}).Return(mockErr)
-
-	err = helper.SetRealmOwnerRef(context.Background(), &kcGroup)
-	if err == nil {
-		t.Fatal("no error on k8s client get fatal")
-	}
-
-	assert.ErrorIs(t, err, mockErr)
-}
 
 func TestMakeHelper(t *testing.T) {
 	rCl := resty.New()

--- a/controllers/keycloakauthflow/keycloakauthflow_controller.go
+++ b/controllers/keycloakauthflow/keycloakauthflow_controller.go
@@ -30,7 +30,6 @@ type Helper interface {
 	SetFailureCount(fc helper.FailureCountable) time.Duration
 	TryToDelete(ctx context.Context, obj client.Object, terminator helper.Terminator, finalizer string) (isDeleted bool, resultErr error)
 	CreateKeycloakClientFromRealmRef(ctx context.Context, object helper.ObjectWithRealmRef) (keycloak.Client, error)
-	SetRealmOwnerRef(ctx context.Context, object helper.ObjectWithRealmRef) error
 	GetKeycloakRealmFromRef(ctx context.Context, object helper.ObjectWithRealmRef, kcClient keycloak.Client) (*gocloak.RealmRepresentation, error)
 }
 
@@ -127,10 +126,6 @@ func (r *Reconcile) Reconcile(ctx context.Context, request reconcile.Request) (r
 }
 
 func (r *Reconcile) tryReconcile(ctx context.Context, instance *keycloakApi.KeycloakAuthFlow) error {
-	if err := r.helper.SetRealmOwnerRef(ctx, instance); err != nil {
-		return fmt.Errorf("unable to set realm owner ref: %w", err)
-	}
-
 	kClient, err := r.helper.CreateKeycloakClientFromRealmRef(ctx, instance)
 	if err != nil {
 		return fmt.Errorf("unable to create keycloak client from realm ref: %w", err)

--- a/controllers/keycloakclient/keycloakclient_controller.go
+++ b/controllers/keycloakclient/keycloakclient_controller.go
@@ -26,7 +26,6 @@ import (
 type Helper interface {
 	SetFailureCount(fc helper.FailureCountable) time.Duration
 	TryToDelete(ctx context.Context, obj client.Object, terminator helper.Terminator, finalizer string) (isDeleted bool, resultErr error)
-	SetRealmOwnerRef(ctx context.Context, object helper.ObjectWithRealmRef) error
 	CreateKeycloakClientFromRealmRef(ctx context.Context, object helper.ObjectWithRealmRef) (keycloak.Client, error)
 	GetKeycloakRealmFromRef(ctx context.Context, object helper.ObjectWithRealmRef, kcClient keycloak.Client) (*gocloak.RealmRepresentation, error)
 }
@@ -118,11 +117,6 @@ func (r *ReconcileKeycloakClient) Reconcile(ctx context.Context, request reconci
 }
 
 func (r *ReconcileKeycloakClient) tryReconcile(ctx context.Context, keycloakClient *keycloakApi.KeycloakClient) error {
-	err := r.helper.SetRealmOwnerRef(ctx, keycloakClient)
-	if err != nil {
-		return fmt.Errorf("unable to set realm owner ref: %w", err)
-	}
-
 	kClient, err := r.helper.CreateKeycloakClientFromRealmRef(ctx, keycloakClient)
 	if err != nil {
 		return fmt.Errorf("unable to create keycloak client from realm ref: %w", err)

--- a/controllers/keycloakclientscope/keycloakclientscope_controller.go
+++ b/controllers/keycloakclientscope/keycloakclientscope_controller.go
@@ -30,7 +30,6 @@ const finalizerName = "keycloak.clientscope.operator.finalizer.name"
 type Helper interface {
 	SetFailureCount(fc helper.FailureCountable) time.Duration
 	TryToDelete(ctx context.Context, obj client.Object, terminator helper.Terminator, finalizer string) (isDeleted bool, resultErr error)
-	SetRealmOwnerRef(ctx context.Context, object helper.ObjectWithRealmRef) error
 	GetKeycloakRealmFromRef(ctx context.Context, object helper.ObjectWithRealmRef, kcClient keycloak.Client) (*gocloak.RealmRepresentation, error)
 	CreateKeycloakClientFromRealmRef(ctx context.Context, object helper.ObjectWithRealmRef) (keycloak.Client, error)
 }
@@ -131,11 +130,6 @@ func (r *Reconcile) Reconcile(ctx context.Context, request reconcile.Request) (r
 }
 
 func (r *Reconcile) tryReconcile(ctx context.Context, instance *keycloakApi.KeycloakClientScope) (string, error) {
-	err := r.helper.SetRealmOwnerRef(ctx, instance)
-	if err != nil {
-		return "", fmt.Errorf("unable to set realm owner ref: %w", err)
-	}
-
 	cl, err := r.helper.CreateKeycloakClientFromRealmRef(ctx, instance)
 	if err != nil {
 		return "", fmt.Errorf("unable to create keycloak client from realm ref: %w", err)

--- a/controllers/keycloakrealm/keycloakrealm_controller.go
+++ b/controllers/keycloakrealm/keycloakrealm_controller.go
@@ -29,7 +29,6 @@ type Helper interface {
 	SetFailureCount(fc helper.FailureCountable) time.Duration
 	TryToDelete(ctx context.Context, obj client.Object, terminator helper.Terminator, finalizer string) (isDeleted bool, resultErr error)
 	CreateKeycloakClientFromRealm(ctx context.Context, realm *keycloakApi.KeycloakRealm) (keycloak.Client, error)
-	SetKeycloakOwnerRef(ctx context.Context, object helper.ObjectWithKeycloakRef) error
 	InvalidateKeycloakClientTokenSecret(ctx context.Context, namespace, rootKeycloakName string) error
 }
 
@@ -123,10 +122,6 @@ func (r *ReconcileKeycloakRealm) Reconcile(ctx context.Context, request reconcil
 }
 
 func (r *ReconcileKeycloakRealm) tryReconcile(ctx context.Context, realm *keycloakApi.KeycloakRealm) error {
-	if err := r.helper.SetKeycloakOwnerRef(ctx, realm); err != nil {
-		return fmt.Errorf("failed to set keycloak owner reference: %w", err)
-	}
-
 	kClient, err := r.helper.CreateKeycloakClientFromRealm(ctx, realm)
 	if err != nil {
 		return fmt.Errorf("failed to create keycloak client for realm: %w", err)

--- a/controllers/keycloakrealmcomponent/keycloakrealmcomponent_controller_test.go
+++ b/controllers/keycloakrealmcomponent/keycloakrealmcomponent_controller_test.go
@@ -62,7 +62,6 @@ func TestReconcile_Reconcile(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(&comp).Build()
 	h := helpermock.NewControllerHelper(t)
 
-	h.On("SetRealmOwnerRef", testifymock.Anything, testifymock.Anything).Return(nil)
 	h.On("CreateKeycloakClientFromRealmRef", testifymock.Anything, testifymock.Anything).Return(kcAdapter, nil)
 	h.On("TryToDelete", testifymock.Anything, testifymock.Anything, testifymock.Anything, testifymock.Anything).
 		Return(false, nil)

--- a/controllers/keycloakrealmgroup/keycloakrealmgroup_controller.go
+++ b/controllers/keycloakrealmgroup/keycloakrealmgroup_controller.go
@@ -26,7 +26,6 @@ const keyCloakRealmGroupOperatorFinalizerName = "keycloak.realmgroup.operator.fi
 type Helper interface {
 	SetFailureCount(fc helper.FailureCountable) time.Duration
 	TryToDelete(ctx context.Context, obj client.Object, terminator helper.Terminator, finalizer string) (isDeleted bool, resultErr error)
-	SetRealmOwnerRef(ctx context.Context, object helper.ObjectWithRealmRef) error
 	GetKeycloakRealmFromRef(ctx context.Context, object helper.ObjectWithRealmRef, kcClient keycloak.Client) (*gocloak.RealmRepresentation, error)
 	CreateKeycloakClientFromRealmRef(ctx context.Context, object helper.ObjectWithRealmRef) (keycloak.Client, error)
 }
@@ -115,11 +114,6 @@ func (r *ReconcileKeycloakRealmGroup) Reconcile(ctx context.Context, request rec
 }
 
 func (r *ReconcileKeycloakRealmGroup) tryReconcile(ctx context.Context, keycloakRealmGroup *keycloakApi.KeycloakRealmGroup) error {
-	err := r.helper.SetRealmOwnerRef(ctx, keycloakRealmGroup)
-	if err != nil {
-		return fmt.Errorf("unable to set realm owner ref: %w", err)
-	}
-
 	kClient, err := r.helper.CreateKeycloakClientFromRealmRef(ctx, keycloakRealmGroup)
 	if err != nil {
 		return fmt.Errorf("unable to create keycloak client from realm ref: %w", err)

--- a/controllers/keycloakrealmgroup/keycloakrealmgroup_controller_test.go
+++ b/controllers/keycloakrealmgroup/keycloakrealmgroup_controller_test.go
@@ -58,7 +58,6 @@ func TestReconcileKeycloakRealmGroup_Reconcile(t *testing.T) {
 	h := helpermock.NewControllerHelper(t)
 	kcMock := mocks.NewMockClient(t)
 
-	h.On("SetRealmOwnerRef", testifymock.Anything, testifymock.Anything).Return(nil)
 	h.On("CreateKeycloakClientFromRealmRef", testifymock.Anything, testifymock.Anything).Return(kcMock, nil)
 	h.On("GetKeycloakRealmFromRef", testifymock.Anything, testifymock.Anything, testifymock.Anything).
 		Return(&gocloak.RealmRepresentation{

--- a/controllers/keycloakrealmidentityprovider/keycloakrealmidentityprovider_controller.go
+++ b/controllers/keycloakrealmidentityprovider/keycloakrealmidentityprovider_controller.go
@@ -30,7 +30,6 @@ const finalizerName = "keycloak.realmidp.operator.finalizer.name"
 type Helper interface {
 	SetFailureCount(fc helper.FailureCountable) time.Duration
 	TryToDelete(ctx context.Context, obj client.Object, terminator helper.Terminator, finalizer string) (isDeleted bool, resultErr error)
-	SetRealmOwnerRef(ctx context.Context, object helper.ObjectWithRealmRef) error
 	GetKeycloakRealmFromRef(ctx context.Context, object helper.ObjectWithRealmRef, kcClient keycloak.Client) (*gocloak.RealmRepresentation, error)
 	CreateKeycloakClientFromRealmRef(ctx context.Context, object helper.ObjectWithRealmRef) (keycloak.Client, error)
 }
@@ -139,11 +138,6 @@ func (r *Reconcile) Reconcile(ctx context.Context, request reconcile.Request) (r
 }
 
 func (r *Reconcile) tryReconcile(ctx context.Context, keycloakRealmIDP *keycloakApi.KeycloakRealmIdentityProvider) error {
-	err := r.helper.SetRealmOwnerRef(ctx, keycloakRealmIDP)
-	if err != nil {
-		return fmt.Errorf("unable to set realm owner ref: %w", err)
-	}
-
 	kClient, err := r.helper.CreateKeycloakClientFromRealmRef(ctx, keycloakRealmIDP)
 	if err != nil {
 		return fmt.Errorf("unable to create keycloak client from realm ref: %w", err)

--- a/controllers/keycloakrealmrole/keycloakrealmrole_controller.go
+++ b/controllers/keycloakrealmrole/keycloakrealmrole_controller.go
@@ -29,7 +29,6 @@ const keyCloakRealmRoleOperatorFinalizerName = "keycloak.realmrole.operator.fina
 type Helper interface {
 	SetFailureCount(fc helper.FailureCountable) time.Duration
 	TryToDelete(ctx context.Context, obj client.Object, terminator helper.Terminator, finalizer string) (isDeleted bool, resultErr error)
-	SetRealmOwnerRef(ctx context.Context, object helper.ObjectWithRealmRef) error
 	GetKeycloakRealmFromRef(ctx context.Context, object helper.ObjectWithRealmRef, kcClient keycloak.Client) (*gocloak.RealmRepresentation, error)
 	CreateKeycloakClientFromRealmRef(ctx context.Context, object helper.ObjectWithRealmRef) (keycloak.Client, error)
 }
@@ -139,11 +138,6 @@ func (r *ReconcileKeycloakRealmRole) Reconcile(ctx context.Context, request reco
 }
 
 func (r *ReconcileKeycloakRealmRole) tryReconcile(ctx context.Context, keycloakRealmRole *keycloakApi.KeycloakRealmRole) (string, error) {
-	err := r.helper.SetRealmOwnerRef(ctx, keycloakRealmRole)
-	if err != nil {
-		return "", fmt.Errorf("unable to set realm owner ref: %w", err)
-	}
-
 	kClient, err := r.helper.CreateKeycloakClientFromRealmRef(ctx, keycloakRealmRole)
 	if err != nil {
 		return "", fmt.Errorf("unable to create keycloak client from realm ref: %w", err)

--- a/controllers/keycloakrealmrolebatch/keycloakrealmrolebatch_controller.go
+++ b/controllers/keycloakrealmrolebatch/keycloakrealmrolebatch_controller.go
@@ -27,7 +27,6 @@ const keyCloakRealmRoleBatchOperatorFinalizerName = "keycloak.realmrolebatch.ope
 
 type Helper interface {
 	TryToDelete(ctx context.Context, obj client.Object, terminator helper.Terminator, finalizer string) (isDeleted bool, resultErr error)
-	SetRealmOwnerRef(ctx context.Context, object helper.ObjectWithRealmRef) error
 	SetFailureCount(fc helper.FailureCountable) time.Duration
 }
 
@@ -201,11 +200,6 @@ func (r *ReconcileKeycloakRealmRoleBatch) putRoles(
 }
 
 func (r *ReconcileKeycloakRealmRoleBatch) tryReconcile(ctx context.Context, batch *keycloakApi.KeycloakRealmRoleBatch) error {
-	err := r.helper.SetRealmOwnerRef(ctx, batch)
-	if err != nil {
-		return fmt.Errorf("unable to set realm owner ref: %w", err)
-	}
-
 	createdRoles, err := r.putRoles(ctx, batch)
 	if err != nil {
 		return errors.Wrap(err, "unable to put roles batch")

--- a/controllers/keycloakrealmuser/keycloakrealmuser_controller.go
+++ b/controllers/keycloakrealmuser/keycloakrealmuser_controller.go
@@ -30,7 +30,6 @@ const finalizer = "keycloak.realmuser.operator.finalizer.name"
 type Helper interface {
 	SetFailureCount(fc helper.FailureCountable) time.Duration
 	TryToDelete(ctx context.Context, obj client.Object, terminator helper.Terminator, finalizer string) (isDeleted bool, resultErr error)
-	SetRealmOwnerRef(ctx context.Context, object helper.ObjectWithRealmRef) error
 	GetKeycloakRealmFromRef(ctx context.Context, object helper.ObjectWithRealmRef, kcClient keycloak.Client) (*gocloak.RealmRepresentation, error)
 	CreateKeycloakClientFromRealmRef(ctx context.Context, object helper.ObjectWithRealmRef) (keycloak.Client, error)
 }
@@ -117,11 +116,6 @@ func (r *Reconcile) Reconcile(ctx context.Context, request reconcile.Request) (c
 }
 
 func (r *Reconcile) tryReconcile(ctx context.Context, instance *keycloakApi.KeycloakRealmUser) error {
-	err := r.helper.SetRealmOwnerRef(ctx, instance)
-	if err != nil {
-		return fmt.Errorf("unable to set realm owner ref: %w", err)
-	}
-
 	kClient, err := r.helper.CreateKeycloakClientFromRealmRef(ctx, instance)
 	if err != nil {
 		return fmt.Errorf("unable to create keycloak client from ref: %w", err)

--- a/hack/install-kuttl.sh
+++ b/hack/install-kuttl.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.15.0/kubectl-kuttl_0.15.0_linux_x86_64
+sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.18.0/kubectl-kuttl_0.18.0_linux_x86_64
 sudo chmod +x /usr/local/bin/kubectl-kuttl
 export PATH=$PATH:/usr/local/bin

--- a/tests/e2e/helm-success-path/99-cleanup.yaml
+++ b/tests/e2e/helm-success-path/99-cleanup.yaml
@@ -7,11 +7,13 @@ commands:
     namespaced: true
   - command: kubectl delete keycloakrealmidentityprovider keycloakrealmidentityprovider-sample keycloakrealmidentityprovider-sample-with-pass
     namespaced: true
-  - command: kubectl delete keycloakrealmcomponent component-sample
+  - command: kubectl delete keycloakrealmcomponent component-sample component-sample-child
     namespaced: true
   - command: kubectl delete keycloakrealmuser keycloakrealmuser-sample
     namespaced: true
   - command: kubectl delete keycloakrealm keycloakrealm-sample
+    namespaced: true
+  - command: kubectl delete keycloak keycloak
     namespaced: true
     # we have to uninstall helm since clusterwide resources, like ClusterRole are preserved
   - command: helm uninstall keycloak-operator-e2e


### PR DESCRIPTION
# Pull Request Template

## Description
Setting ownerReference with controller:true for Keycloak resources has disadvantages:
- `controller: true` should be set for resources created by a controller. For example, we create a Deployment, and the controller creates a ReplicaSet with an `ownerReference` to the Deployment. In our case, we create resources separately, and the Keycloak controller isn't responsible for their creation.
- ArgoCD doesn't remove resources with `controller: true`. It considers another controller responsible for them. If we remove the ArgoCD environment that contains KeycloakClient, this CR won't be removed by either ArgoCD or the Keycloak operator.

This change breaks the automatic deletion of CRs if related Keycloak/KeycloakRealm is removed.
Now, it isn't the responsibility of the keycloak operator.

Fixes #71 
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits
