### PR TITLE
Add support for optional client scopes

### DIFF
--- a/api/v1/keycloakclient_types.go
+++ b/api/v1/keycloakclient_types.go
@@ -98,6 +98,11 @@ type KeycloakClientSpec struct {
 	// +optional
 	DefaultClientScopes []string `json:"defaultClientScopes,omitempty"`
 
+	// OptionalClientScopes is a list of optional client scopes assigned to client.
+	// +nullable
+	// +optional
+	OptionalClientScopes []string `json:"optionalClientScopes,omitempty"`
+
 	// RedirectUris is a list of valid URI pattern a browser can redirect to after a successful login.
 	// Simple wildcards are allowed such as 'https://example.com/*'.
 	// Relative path can be specified too, such as /my/relative/path/*. Relative paths are relative to the client root URL.

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -591,6 +591,11 @@ func (in *KeycloakClientSpec) DeepCopyInto(out *KeycloakClientSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.OptionalClientScopes != nil {
+		in, out := &in.OptionalClientScopes, &out.OptionalClientScopes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.RedirectUris != nil {
 		in, out := &in.RedirectUris, &out.RedirectUris
 		*out = make([]string, len(*in))

--- a/config/crd/bases/v1.edp.epam.com_keycloakclients.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakclients.yaml
@@ -396,6 +396,13 @@ spec:
               name:
                 description: Name is a client name.
                 type: string
+              optionalClientScopes:
+                description: OptionalClientScopes is a list of optional client scopes
+                  assigned to client.
+                items:
+                  type: string
+                nullable: true
+                type: array
               protocol:
                 description: Protocol is a client protocol.
                 nullable: true

--- a/controllers/keycloakclient/chain/put_client_scope.go
+++ b/controllers/keycloakclient/chain/put_client_scope.go
@@ -27,17 +27,50 @@ func (el *PutClientScope) Serve(ctx context.Context, keycloakClient *keycloakApi
 }
 
 func (el *PutClientScope) putClientScope(ctx context.Context, keycloakClient *keycloakApi.KeycloakClient, realmName string) error {
+	if err := el.putDefaultClientScope(ctx, keycloakClient, realmName); err != nil {
+		return err
+	}
+
+	if err := el.putOptionalClientScope(ctx, keycloakClient, realmName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (el *PutClientScope) putDefaultClientScope(ctx context.Context, keycloakClient *keycloakApi.KeycloakClient, realmName string) error {
 	kCloakSpec := keycloakClient.Spec
+
 	if len(kCloakSpec.DefaultClientScopes) == 0 {
 		return nil
 	}
 
-	scopes, err := el.keycloakApiClient.GetClientScopesByNames(ctx, realmName, kCloakSpec.DefaultClientScopes)
+	defaultScopes, err := el.keycloakApiClient.GetClientScopesByNames(ctx, realmName, kCloakSpec.DefaultClientScopes)
 	if err != nil {
 		return errors.Wrap(err, "error during GetClientScope")
 	}
 
-	err = el.keycloakApiClient.AddDefaultScopeToClient(ctx, realmName, kCloakSpec.ClientId, scopes)
+	err = el.keycloakApiClient.AddDefaultScopeToClient(ctx, realmName, kCloakSpec.ClientId, defaultScopes)
+	if err != nil {
+		return fmt.Errorf("failed to add default scope to client %s: %w", keycloakClient.Name, err)
+	}
+
+	return nil
+}
+
+func (el *PutClientScope) putOptionalClientScope(ctx context.Context, keycloakClient *keycloakApi.KeycloakClient, realmName string) error {
+	kCloakSpec := keycloakClient.Spec
+
+	if len(kCloakSpec.OptionalClientScopes) == 0 {
+		return nil
+	}
+
+	optionalScopes, err := el.keycloakApiClient.GetClientScopesByNames(ctx, realmName, kCloakSpec.OptionalClientScopes)
+	if err != nil {
+		return errors.Wrap(err, "error during GetClientScope")
+	}
+
+	err = el.keycloakApiClient.AddOptionalScopeToClient(ctx, realmName, kCloakSpec.ClientId, optionalScopes)
 	if err != nil {
 		return fmt.Errorf("failed to add default scope to client %s: %w", keycloakClient.Name, err)
 	}

--- a/controllers/keycloakclient/chain/put_client_scope_test.go
+++ b/controllers/keycloakclient/chain/put_client_scope_test.go
@@ -1,0 +1,114 @@
+package chain
+
+import (
+	"context"
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/mocks"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func TestPutClientScope_Serve(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		client            func(t *testing.T) client.Client
+		keycloakClient    client.ObjectKey
+		keycloakApiClient func(t *testing.T) *mocks.MockClient
+		wantErr           require.ErrorAssertionFunc
+	}{
+		{
+			name: "with default scopes",
+			client: func(t *testing.T) client.Client {
+				s := runtime.NewScheme()
+				require.NoError(t, keycloakApi.AddToScheme(s))
+				require.NoError(t, corev1.AddToScheme(s))
+
+				return fake.NewClientBuilder().WithScheme(s).WithObjects(
+					&keycloakApi.KeycloakClient{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-client",
+							Namespace: "default",
+						},
+						Spec: keycloakApi.KeycloakClientSpec{
+							ClientId:            "test-client-id",
+							DefaultClientScopes: []string{"default-scope"},
+						},
+					}).Build()
+			},
+			keycloakClient: client.ObjectKey{
+				Name:      "test-client",
+				Namespace: "default",
+			},
+			keycloakApiClient: func(t *testing.T) *mocks.MockClient {
+				m := mocks.NewMockClient(t)
+
+				m.On("GetClientScopesByNames", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+				m.On("AddDefaultScopeToClient", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				return m
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "with optional scopes",
+			client: func(t *testing.T) client.Client {
+				s := runtime.NewScheme()
+				require.NoError(t, keycloakApi.AddToScheme(s))
+				require.NoError(t, corev1.AddToScheme(s))
+
+				return fake.NewClientBuilder().WithScheme(s).WithObjects(
+					&keycloakApi.KeycloakClient{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-client",
+							Namespace: "default",
+						},
+						Spec: keycloakApi.KeycloakClientSpec{
+							ClientId:             "test-client-id",
+							OptionalClientScopes: []string{"optional-scope"},
+						},
+					}).Build()
+			},
+			keycloakClient: client.ObjectKey{
+				Name:      "test-client",
+				Namespace: "default",
+			},
+			keycloakApiClient: func(t *testing.T) *mocks.MockClient {
+				m := mocks.NewMockClient(t)
+
+				m.On("GetClientScopesByNames", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+				m.On("AddOptionalScopeToClient", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				return m
+			},
+			wantErr: require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cl := &keycloakApi.KeycloakClient{}
+			require.NoError(t, tt.client(t).Get(context.Background(), tt.keycloakClient, cl))
+
+			el := NewPutClientScope(tt.keycloakApiClient(t))
+			err := el.Serve(
+				ctrl.LoggerInto(context.Background(), logr.Discard()),
+				cl,
+				"realm",
+			)
+			tt.wantErr(t, err)
+		})
+	}
+}

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakclients.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakclients.yaml
@@ -396,6 +396,13 @@ spec:
               name:
                 description: Name is a client name.
                 type: string
+              optionalClientScopes:
+                description: OptionalClientScopes is a list of optional client scopes
+                  assigned to client.
+                items:
+                  type: string
+                nullable: true
+                type: array
               protocol:
                 description: Protocol is a client protocol.
                 nullable: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -1302,6 +1302,13 @@ KeycloakClientSpec defines the desired state of KeycloakClient.
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>optionalClientScopes</b></td>
+        <td>[]string</td>
+        <td>
+          OptionalClientScopes is a list of optional client scopes assigned to client.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>protocol</b></td>
         <td>string</td>
         <td>

--- a/pkg/client/keycloak/adapter/gocloak.go
+++ b/pkg/client/keycloak/adapter/gocloak.go
@@ -42,6 +42,8 @@ type GoCloakClients interface {
 	GetClientScope(ctx context.Context, token, realm, scopeID string) (*gocloak.ClientScope, error)
 	GetClientsDefaultScopes(ctx context.Context, token, realm, clientID string) ([]*gocloak.ClientScope, error)
 	AddDefaultScopeToClient(ctx context.Context, token, realm, clientID, scopeID string) error
+	GetClientsOptionalScopes(ctx context.Context, token, realm, clientID string) ([]*gocloak.ClientScope, error)
+	AddOptionalScopeToClient(ctx context.Context, token, realm, clientID, scopeID string) error
 	GetClientScopes(ctx context.Context, token, realm string) ([]*gocloak.ClientScope, error)
 
 	GetScopes(ctx context.Context, token, realm, idOfClient string, params gocloak.GetScopeParams) ([]*gocloak.ScopeRepresentation, error)

--- a/pkg/client/keycloak/adapter/mocks/gocloak_mock.go
+++ b/pkg/client/keycloak/adapter/mocks/gocloak_mock.go
@@ -176,6 +176,56 @@ func (_c *MockGoCloak_AddDefaultScopeToClient_Call) RunAndReturn(run func(contex
 	return _c
 }
 
+// AddOptionalScopeToClient provides a mock function with given fields: ctx, token, realm, clientID, scopeID
+func (_m *MockGoCloak) AddOptionalScopeToClient(ctx context.Context, token string, realm string, clientID string, scopeID string) error {
+	ret := _m.Called(ctx, token, realm, clientID, scopeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddOptionalScopeToClient")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) error); ok {
+		r0 = rf(ctx, token, realm, clientID, scopeID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockGoCloak_AddOptionalScopeToClient_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddOptionalScopeToClient'
+type MockGoCloak_AddOptionalScopeToClient_Call struct {
+	*mock.Call
+}
+
+// AddOptionalScopeToClient is a helper method to define mock.On call
+//   - ctx context.Context
+//   - token string
+//   - realm string
+//   - clientID string
+//   - scopeID string
+func (_e *MockGoCloak_Expecter) AddOptionalScopeToClient(ctx interface{}, token interface{}, realm interface{}, clientID interface{}, scopeID interface{}) *MockGoCloak_AddOptionalScopeToClient_Call {
+	return &MockGoCloak_AddOptionalScopeToClient_Call{Call: _e.mock.On("AddOptionalScopeToClient", ctx, token, realm, clientID, scopeID)}
+}
+
+func (_c *MockGoCloak_AddOptionalScopeToClient_Call) Run(run func(ctx context.Context, token string, realm string, clientID string, scopeID string)) *MockGoCloak_AddOptionalScopeToClient_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string))
+	})
+	return _c
+}
+
+func (_c *MockGoCloak_AddOptionalScopeToClient_Call) Return(_a0 error) *MockGoCloak_AddOptionalScopeToClient_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockGoCloak_AddOptionalScopeToClient_Call) RunAndReturn(run func(context.Context, string, string, string, string) error) *MockGoCloak_AddOptionalScopeToClient_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // AddRealmRoleComposite provides a mock function with given fields: ctx, token, realm, roleName, roles
 func (_m *MockGoCloak) AddRealmRoleComposite(ctx context.Context, token string, realm string, roleName string, roles []gocloak.Role) error {
 	ret := _m.Called(ctx, token, realm, roleName, roles)
@@ -2106,6 +2156,67 @@ func (_c *MockGoCloak_GetClientsDefaultScopes_Call) Return(_a0 []*gocloak.Client
 }
 
 func (_c *MockGoCloak_GetClientsDefaultScopes_Call) RunAndReturn(run func(context.Context, string, string, string) ([]*gocloak.ClientScope, error)) *MockGoCloak_GetClientsDefaultScopes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetClientsOptionalScopes provides a mock function with given fields: ctx, token, realm, clientID
+func (_m *MockGoCloak) GetClientsOptionalScopes(ctx context.Context, token string, realm string, clientID string) ([]*gocloak.ClientScope, error) {
+	ret := _m.Called(ctx, token, realm, clientID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetClientsOptionalScopes")
+	}
+
+	var r0 []*gocloak.ClientScope
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) ([]*gocloak.ClientScope, error)); ok {
+		return rf(ctx, token, realm, clientID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) []*gocloak.ClientScope); ok {
+		r0 = rf(ctx, token, realm, clientID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*gocloak.ClientScope)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, token, realm, clientID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockGoCloak_GetClientsOptionalScopes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetClientsOptionalScopes'
+type MockGoCloak_GetClientsOptionalScopes_Call struct {
+	*mock.Call
+}
+
+// GetClientsOptionalScopes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - token string
+//   - realm string
+//   - clientID string
+func (_e *MockGoCloak_Expecter) GetClientsOptionalScopes(ctx interface{}, token interface{}, realm interface{}, clientID interface{}) *MockGoCloak_GetClientsOptionalScopes_Call {
+	return &MockGoCloak_GetClientsOptionalScopes_Call{Call: _e.mock.On("GetClientsOptionalScopes", ctx, token, realm, clientID)}
+}
+
+func (_c *MockGoCloak_GetClientsOptionalScopes_Call) Run(run func(ctx context.Context, token string, realm string, clientID string)) *MockGoCloak_GetClientsOptionalScopes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *MockGoCloak_GetClientsOptionalScopes_Call) Return(_a0 []*gocloak.ClientScope, _a1 error) *MockGoCloak_GetClientsOptionalScopes_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockGoCloak_GetClientsOptionalScopes_Call) RunAndReturn(run func(context.Context, string, string, string) ([]*gocloak.ClientScope, error)) *MockGoCloak_GetClientsOptionalScopes_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/client/keycloak/keycloak_client.go
+++ b/pkg/client/keycloak/keycloak_client.go
@@ -83,6 +83,7 @@ type KCloakClients interface {
 		client *dto.Client, crMappers []gocloak.ProtocolMapperRepresentation, addOnly bool) error
 	GetClientID(clientID, realm string) (string, error)
 	AddDefaultScopeToClient(ctx context.Context, realmName, clientName string, scopes []adapter.ClientScope) error
+	AddOptionalScopeToClient(ctx context.Context, realmName, clientName string, scopes []adapter.ClientScope) error
 
 	GetScopes(ctx context.Context, realm, idOfClient string) (map[string]gocloak.ScopeRepresentation, error)
 	CreateScope(ctx context.Context, realm, idOfClient string, scope string) (*gocloak.ScopeRepresentation, error)

--- a/pkg/client/keycloak/mocks/client_mock.go
+++ b/pkg/client/keycloak/mocks/client_mock.go
@@ -127,6 +127,55 @@ func (_c *MockClient_AddDefaultScopeToClient_Call) RunAndReturn(run func(context
 	return _c
 }
 
+// AddOptionalScopeToClient provides a mock function with given fields: ctx, realmName, clientName, scopes
+func (_m *MockClient) AddOptionalScopeToClient(ctx context.Context, realmName string, clientName string, scopes []adapter.ClientScope) error {
+	ret := _m.Called(ctx, realmName, clientName, scopes)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddOptionalScopeToClient")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, []adapter.ClientScope) error); ok {
+		r0 = rf(ctx, realmName, clientName, scopes)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockClient_AddOptionalScopeToClient_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddOptionalScopeToClient'
+type MockClient_AddOptionalScopeToClient_Call struct {
+	*mock.Call
+}
+
+// AddOptionalScopeToClient is a helper method to define mock.On call
+//   - ctx context.Context
+//   - realmName string
+//   - clientName string
+//   - scopes []adapter.ClientScope
+func (_e *MockClient_Expecter) AddOptionalScopeToClient(ctx interface{}, realmName interface{}, clientName interface{}, scopes interface{}) *MockClient_AddOptionalScopeToClient_Call {
+	return &MockClient_AddOptionalScopeToClient_Call{Call: _e.mock.On("AddOptionalScopeToClient", ctx, realmName, clientName, scopes)}
+}
+
+func (_c *MockClient_AddOptionalScopeToClient_Call) Run(run func(ctx context.Context, realmName string, clientName string, scopes []adapter.ClientScope)) *MockClient_AddOptionalScopeToClient_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].([]adapter.ClientScope))
+	})
+	return _c
+}
+
+func (_c *MockClient_AddOptionalScopeToClient_Call) Return(_a0 error) *MockClient_AddOptionalScopeToClient_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClient_AddOptionalScopeToClient_Call) RunAndReturn(run func(context.Context, string, string, []adapter.ClientScope) error) *MockClient_AddOptionalScopeToClient_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // AddRealmRoleToUser provides a mock function with given fields: ctx, realmName, username, roleName
 func (_m *MockClient) AddRealmRoleToUser(ctx context.Context, realmName string, username string, roleName string) error {
 	ret := _m.Called(ctx, realmName, username, roleName)


### PR DESCRIPTION
# Pull Request Template

## Description
The change adds support for optional client scopes. This is required because it's a common use-case to only add certain claims on explicitly requested scopes.

I couldn't find any issues that requested this feature.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
I've built and deployed this in a local kind cluster, and tested by adding clients with both default and optional scopes. Additionally, I've added two unit tests, which might be on the short side coverage wise, but I'll gladly improve on this, if wanted.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits
