### PR TITLE
fix: Deletion resources related to subgroup

### DIFF
--- a/controllers/keycloakrealmgroup/terminator.go
+++ b/controllers/keycloakrealmgroup/terminator.go
@@ -7,6 +7,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
 )
 
 type terminator struct {
@@ -26,6 +27,12 @@ func (t *terminator) DeleteResource(ctx context.Context) error {
 	log.Info("Start deleting group")
 
 	if err := t.kClient.DeleteGroup(ctx, t.realmName, t.groupName); err != nil {
+		if adapter.IsErrNotFound(err) {
+			log.Info("Group not found, skipping deletion")
+
+			return nil
+		}
+
 		return fmt.Errorf("unable to delete group %w", err)
 	}
 


### PR DESCRIPTION
# Pull Request Template

## Description
Problem:
If we delete the subgroup before deleting the resources that contain this subgroup
(Example: KeycloakRealmGroup.spec.subGroup/KeycloakRealmUser.spec.groups) deletion of KeycloakRealmGroup/KeycloakRealmUser blocks with an error. This happens because we are syncing KeycloakRealmUser/KeycloakRealmGroup before deletion, and syncing can't be processed without a subgroup. 
Solution:
Moved deletion of KeycloakRealmUser/KeycloakRealmGroup before syncing. We don't need to sync objects that are marked for deletion.

Fixes #95 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
- Integration tests
- Manual testing

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ x I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits