### PR TITLE
feat: Add Browser and Direct Grant Flow fields to Keycloak Client

### DIFF
--- a/api/v1/keycloakclient_types.go
+++ b/api/v1/keycloakclient_types.go
@@ -181,6 +181,14 @@ type KeycloakClientSpec struct {
 	// +nullable
 	// +optional
 	Authorization *Authorization `json:"authorization,omitempty"`
+
+	// BrowserAuthFlow client browser auth flow override
+	// +optional
+	BrowserAuthFlow string `json:"browserAuthFlow,omitempty"`
+
+	// DirectGrantAuthFlow client direct grant auth flow override
+	// +optional
+	DirectGrantAuthFlow string `json:"directGrantAuthFlow,omitempty"`
 }
 
 type ServiceAccount struct {

--- a/config/crd/bases/v1.edp.epam.com_keycloakclients.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakclients.yaml
@@ -398,6 +398,9 @@ spec:
               bearerOnly:
                 description: BearerOnly is a flag to enable bearer-only.
                 type: boolean
+              browserAuthFlow:
+                description: BrowserAuthFlow client browser auth flow override
+                type: string
               clientAuthenticatorType:
                 default: client-secret
                 description: ClientAuthenticatorType is a client authenticator type.
@@ -429,6 +432,9 @@ spec:
               directAccess:
                 description: DirectAccess is a flag to set client as direct access.
                 type: boolean
+              directGrantAuthFlow:
+                description: DirectGrantAuthFlow client direct grant auth flow override
+                type: string
               enabled:
                 default: true
                 description: Enabled is a flag to enable client.

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakclients.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakclients.yaml
@@ -398,6 +398,9 @@ spec:
               bearerOnly:
                 description: BearerOnly is a flag to enable bearer-only.
                 type: boolean
+              browserAuthFlow:
+                description: BrowserAuthFlow client browser auth flow override
+                type: string
               clientAuthenticatorType:
                 default: client-secret
                 description: ClientAuthenticatorType is a client authenticator type.
@@ -429,6 +432,9 @@ spec:
               directAccess:
                 description: DirectAccess is a flag to set client as direct access.
                 type: boolean
+              directGrantAuthFlow:
+                description: DirectGrantAuthFlow client direct grant auth flow override
+                type: string
               enabled:
                 default: true
                 description: Enabled is a flag to enable client.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1976,6 +1976,13 @@ If empty - WebUrl will be used.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>browserAuthFlow</b></td>
+        <td>string</td>
+        <td>
+          BrowserAuthFlow client browser auth flow override<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>clientAuthenticatorType</b></td>
         <td>string</td>
         <td>
@@ -2017,6 +2024,13 @@ If empty - WebUrl will be used.<br/>
         <td>boolean</td>
         <td>
           DirectAccess is a flag to set client as direct access.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>directGrantAuthFlow</b></td>
+        <td>string</td>
+        <td>
+          DirectGrantAuthFlow client direct grant auth flow override<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/client/keycloak/dto/keycloak_dto.go
+++ b/pkg/client/keycloak/dto/keycloak_dto.go
@@ -97,6 +97,8 @@ type Client struct {
 	RegistrationAccessToken      string
 	StandardFlowEnabled          bool
 	SurrogateAuthRequired        bool
+	BrowserAuthFlow              string
+	DirectGrantAuthFlow          string
 }
 
 type PrimaryRealmRole struct {
@@ -144,6 +146,8 @@ func ConvertSpecToClient(spec *keycloakApi.KeycloakClientSpec, clientSecret, rea
 		Name:                         spec.Name,
 		StandardFlowEnabled:          spec.StandardFlowEnabled,
 		SurrogateAuthRequired:        spec.SurrogateAuthRequired,
+		BrowserAuthFlow:              spec.BrowserAuthFlow,
+		DirectGrantAuthFlow:          spec.DirectGrantAuthFlow,
 	}
 }
 


### PR DESCRIPTION
# Pull Request Template

## Description
I needed the ability to use a client specific setup for browser and direct grant flows. This allows overriding those two auth flows on a client basis.

Fixes #116 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Pull Request contains one commit. I squash my commits.