### PR TITLE
fix: Spelling mistake in keycloak client deletion

### DIFF
--- a/controllers/keycloakclient/keycloakclient_controller.go
+++ b/controllers/keycloakclient/keycloakclient_controller.go
@@ -141,7 +141,7 @@ func (r *ReconcileKeycloakClient) tryReconcile(ctx context.Context, keycloakClie
 		keyCloakClientOperatorFinalizerName,
 	)
 	if err != nil {
-		return fmt.Errorf("deliting keycloak client: %w", err)
+		return fmt.Errorf("deleting keycloak client: %w", err)
 	}
 
 	if deleted {


### PR DESCRIPTION
# Pull Request Template

## Description
When failing to delete a keycloak client it says `deliting` instead of `deleting`

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Pull Request contains one commit. I squash my commits.