### PR TITLE
fix: Add Resty HTTP client to keycloak_go_client.Client

### DIFF
--- a/controllers/keycloakrealm/chain/user_profile.go
+++ b/controllers/keycloakrealm/chain/user_profile.go
@@ -113,6 +113,10 @@ func userProfileConfigAttributeToMap(profile *keycloakgoclient.UserProfileConfig
 }
 
 func userProfileConfigGroupToMap(spec *keycloakgoclient.UserProfileConfig) map[string]keycloakgoclient.UserProfileGroup {
+	if spec.Groups == nil {
+		return make(map[string]keycloakgoclient.UserProfileGroup)
+	}
+
 	groups := make(map[string]keycloakgoclient.UserProfileGroup, len(*spec.Groups))
 
 	for _, v := range *spec.Groups {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-password v0.2.0
 	github.com/stretchr/testify v1.8.4
-	github.com/zmotso/keycloak-go-client v0.0.0-20241113095118-1d5b34e077a1
+	github.com/zmotso/keycloak-go-client v0.0.0-20250210093813-603460227832
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a
 	golang.org/x/sync v0.10.0
 	k8s.io/api v0.26.10

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,8 @@ github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQ
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zmotso/keycloak-go-client v0.0.0-20241113095118-1d5b34e077a1 h1:DuYSQTTDngQtUlcqESuNZ+IkQTdjrF9xVEoAKyYsycE=
-github.com/zmotso/keycloak-go-client v0.0.0-20241113095118-1d5b34e077a1/go.mod h1:PAvCkvb+irLo/9DRh+wpMR8+duFJcxthaixEveen2wU=
+github.com/zmotso/keycloak-go-client v0.0.0-20250210093813-603460227832 h1:hyHVk4QZcpVp+Q1lP0nwVuvk7RWLtAdByqF1vUPqUUo=
+github.com/zmotso/keycloak-go-client v0.0.0-20250210093813-603460227832/go.mod h1:PAvCkvb+irLo/9DRh+wpMR8+duFJcxthaixEveen2wU=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=

--- a/pkg/client/keycloak/adapter/gocloak_adapter_user.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_user.go
@@ -295,7 +295,9 @@ func (a GoCloakAdapter) UpdateUsersProfile(
 	realm string,
 	userProfile keycloak_go_client.UserProfileConfig,
 ) (*keycloak_go_client.UserProfileConfig, error) {
-	cl, err := keycloak_go_client.NewClient(a.basePath, keycloak_go_client.WithToken(a.token.AccessToken))
+	httpClient := a.client.RestyClient().GetClient()
+
+	cl, err := keycloak_go_client.NewClient(a.basePath, keycloak_go_client.WithToken(a.token.AccessToken), keycloak_go_client.WithHTTPClient(httpClient))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create keycloak_go_client client: %w", err)
 	}
@@ -312,7 +314,9 @@ func (a GoCloakAdapter) GetUsersProfile(
 	ctx context.Context,
 	realm string,
 ) (*keycloak_go_client.UserProfileConfig, error) {
-	cl, err := keycloak_go_client.NewClient(a.basePath, keycloak_go_client.WithToken(a.token.AccessToken))
+	httpClient := a.client.RestyClient().GetClient()
+
+	cl, err := keycloak_go_client.NewClient(a.basePath, keycloak_go_client.WithToken(a.token.AccessToken), keycloak_go_client.WithHTTPClient(httpClient))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create keycloak_go_client client: %w", err)
 	}

--- a/tests/e2e/keycloak-selfsigned-certificates/03-assert-keycloak-realm-resource.yaml
+++ b/tests/e2e/keycloak-selfsigned-certificates/03-assert-keycloak-realm-resource.yaml
@@ -1,0 +1,9 @@
+---
+
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealm
+metadata:
+  name: keycloak-user-profile-self-signed
+status:
+  available: true
+  value: OK

--- a/tests/e2e/keycloak-selfsigned-certificates/03-install-keycloak-realm-resource.yaml
+++ b/tests/e2e/keycloak-selfsigned-certificates/03-install-keycloak-realm-resource.yaml
@@ -1,0 +1,13 @@
+---
+
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealm
+metadata:
+  name: keycloak-user-profile-self-signed
+spec:
+  keycloakRef:
+    kind: Keycloak
+    name: keycloak-with-ca-cert-configmap
+  realmName: keycloak-user-profile-self-signed
+  userProfileConfig:
+    unmanagedAttributePolicy: ENABLED

--- a/tests/e2e/keycloak-selfsigned-certificates/99-cleanup.yaml
+++ b/tests/e2e/keycloak-selfsigned-certificates/99-cleanup.yaml
@@ -1,6 +1,8 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
+  - command: kubectl delete keycloakrealm keycloak-user-profile-self-signed
+    namespaced: true
   - command: kubectl delete keycloak keycloak-with-no-cert-check keycloak-with-insecure-skip-verify keycloak-with-ca-cert-secret keycloak-with-ca-cert-configmap
     namespaced: true
   - command: kubectl delete clusterkeycloak keycloak-with-ca-cert-secret keycloak-with-ca-cert-configmap


### PR DESCRIPTION
# Pull Request Template

## Description
Add Resty HTTP client to the Keycloak client for user profiles to support self signed certificates in Keycloak

Fixes #128 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Pull Request contains one commit. I squash my commits.