### PR TITLE
fix: Realm HTML Display Name not properly set

### DIFF
--- a/pkg/client/keycloak/adapter/gocloak_adapter_realms.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_realms.go
@@ -103,14 +103,6 @@ func setRealmSettings(realm *gocloak.RealmRepresentation, realmSettings *RealmSe
 		realm.PasswordPolicy = gocloak.StringP(strings.Join(policies, " and "))
 	}
 
-	if realmSettings.DisplayHTMLName != "" {
-		if realm.Attributes == nil {
-			realm.Attributes = &map[string]string{}
-		}
-
-		(*realm.Attributes)["displayHTMLName"] = realmSettings.DisplayHTMLName
-	}
-
 	if realmSettings.FrontendURL != "" {
 		if realm.Attributes == nil {
 			realm.Attributes = &map[string]string{}
@@ -120,6 +112,7 @@ func setRealmSettings(realm *gocloak.RealmRepresentation, realmSettings *RealmSe
 	}
 
 	realm.DisplayName = gocloak.StringP(realmSettings.DisplayName)
+	realm.DisplayNameHTML = gocloak.StringP(realmSettings.DisplayHTMLName)
 
 	if realmSettings.TokenSettings != nil {
 		realm.DefaultSignatureAlgorithm = gocloak.StringP(realmSettings.TokenSettings.DefaultSignatureAlgorithm)


### PR DESCRIPTION
# Pull Request Template

## Description
The HTML Display name was being set in the realm attributes incorrectly instead of using the existing realm representation field.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Created a realm with a display name. It properly is set via the Keycloak console

## Checklist:
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Pull Request contains one commit. I squash my commits.