### PR TITLE
chore: Bump GitHub Actions runner image to 22.04(#150)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   e2e-tests:
     name: End-to-end tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -43,7 +43,7 @@ jobs:
         run: make start-kind KUBE_VERSION=$KUBE_VERSION && make e2e
 
   e2e-tests-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always()
     needs: [e2e-tests]
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
 
   check-commit-message:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
 
   helm-docs:
     needs: [check-commit-message]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
 
   helm-lint:
     needs: [helm-docs]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
      CHART_DIR: "deploy-templates"
      CT_CONFIGS_DIR: "."
@@ -94,7 +94,7 @@ jobs:
 
   build-and-lint:
     needs: [helm-lint]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
 
   docker-lint:
     needs: [build-and-lint]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -124,7 +124,7 @@ jobs:
   e2e-tests:
     name: End-to-end tests
     needs: [docker-lint]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -153,7 +153,7 @@ jobs:
         run: make start-kind KUBE_VERSION=$KUBE_VERSION && make e2e
 
   e2e-tests-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always()
     needs: [e2e-tests]
     steps:


### PR DESCRIPTION
This PR updates the GitHub Actions runner image from ubuntu-20.04 to ubuntu-22.04 across all relevant workflow files.
The change ensures compatibility with the latest Ubuntu environment and takes advantage of security updates, newer packages, and long-term support from GitHub-hosted runners.

Fixes #(#150 )

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
CI pipelines were triggered automatically for this PR and completed successfully, confirming that workflows continue to function correctly on ubuntu-22.04.

All dependent jobs (e.g., build, lint, e2e tests) executed without errors after the update.

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.
