### PR TITLE
fix: KeycloakClient service account users groups aren't being populated correctly

### DIFF
--- a/internal/controller/keycloakclient/chain/service_account.go
+++ b/internal/controller/keycloakclient/chain/service_account.go
@@ -38,17 +38,17 @@ func (el *ServiceAccount) Serve(_ context.Context, keycloakClient *keycloakApi.K
 		return errors.Wrap(err, "unable to sync service account roles")
 	}
 
+	if keycloakClient.Spec.ServiceAccount.Groups != nil {
+		if err := el.keycloakApiClient.SyncServiceAccountGroups(realmName,
+			keycloakClient.Status.ClientID, keycloakClient.Spec.ServiceAccount.Groups, addOnly); err != nil {
+			return errors.Wrap(err, "unable to sync service account groups")
+		}
+	}
+
 	if keycloakClient.Spec.ServiceAccount.Attributes != nil {
 		if err := el.keycloakApiClient.SetServiceAccountAttributes(realmName, keycloakClient.Status.ClientID,
 			keycloakClient.Spec.ServiceAccount.Attributes, addOnly); err != nil {
 			return errors.Wrap(err, "unable to set service account attributes")
-		}
-	}
-
-	if keycloakClient.Spec.ServiceAccount.Groups != nil {
-		if err := el.keycloakApiClient.SetServiceAccountGroups(realmName,
-			keycloakClient.Status.ClientID, keycloakClient.Spec.ServiceAccount.Groups, addOnly); err != nil {
-			return errors.Wrap(err, "unable to sync service account groups")
 		}
 	}
 

--- a/internal/controller/keycloakclient/chain/service_account_test.go
+++ b/internal/controller/keycloakclient/chain/service_account_test.go
@@ -45,10 +45,10 @@ func TestServiceAccount_Serve(t *testing.T) {
 		kc.Spec.ServiceAccount.RealmRoles,
 		map[string][]string{
 			kc.Spec.ServiceAccount.ClientRoles[0].ClientID: kc.Spec.ServiceAccount.ClientRoles[0].Roles}, false).Return(nil)
+	apiClient.On("SyncServiceAccountGroups", realmName, kc.Status.ClientID,
+		kc.Spec.ServiceAccount.Groups, false).Return(nil)
 	apiClient.On("SetServiceAccountAttributes", realmName, kc.Status.ClientID,
 		kc.Spec.ServiceAccount.Attributes, false).Return(nil)
-	apiClient.On("SetServiceAccountGroups", realmName, kc.Status.ClientID,
-		kc.Spec.ServiceAccount.Groups, false).Return(nil)
 
 	sa := NewServiceAccount(apiClient)
 

--- a/internal/controller/keycloakclient/keycloakclient_controller_integration_test.go
+++ b/internal/controller/keycloakclient/keycloakclient_controller_integration_test.go
@@ -95,6 +95,15 @@ var _ = Describe("KeycloakClient controller", Ordered, func() {
 		}, timeout, interval).Should(BeTrue(), "KeycloakClient should be deleted")
 	})
 	It("Should create KeycloakClient with empty secret", func() {
+		By("Creating keycloak api client")
+		client := gocloak.NewClient(keycloakURL)
+		token, err := client.LoginAdmin(ctx, "admin", "admin", "master")
+		Expect(err).ShouldNot(HaveOccurred())
+		By("Creating group for service account")
+		_, err = client.CreateGroup(ctx, token.AccessToken, KeycloakRealmCR, gocloak.Group{
+			Name: gocloak.StringP("test-group"),
+		})
+		Expect(adapter.SkipAlreadyExistsErr(err)).ShouldNot(HaveOccurred())
 		By("Creating a KeycloakClient")
 		keycloakClient := &keycloakApi.KeycloakClient{
 			ObjectMeta: metav1.ObjectMeta{
@@ -187,7 +196,7 @@ var _ = Describe("KeycloakClient controller", Ordered, func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, clientSecret)).Should(Succeed())
-		By("Crating keycloak api client")
+		By("Creating keycloak api client")
 		client := gocloak.NewClient(keycloakURL)
 		token, err := client.LoginAdmin(ctx, "admin", "admin", "master")
 		Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/client/keycloak/keycloak_client.go
+++ b/pkg/client/keycloak/keycloak_client.go
@@ -26,8 +26,8 @@ type Client interface {
 	GetOpenIdConfig(realm *dto.Realm) (string, error)
 	SyncServiceAccountRoles(realm, clientID string, realmRoles []string,
 		clientRoles map[string][]string, addOnly bool) error
+	SyncServiceAccountGroups(realm, clientID string, groups []string, addOnly bool) error
 	SetServiceAccountAttributes(realm, clientID string, attributes map[string]string, addOnly bool) error
-	SetServiceAccountGroups(realm, clientID string, groups []string, addOnly bool) error
 	ExportToken() ([]byte, error)
 }
 

--- a/pkg/client/keycloak/mocks/client_mock.go
+++ b/pkg/client/keycloak/mocks/client_mock.go
@@ -3721,55 +3721,6 @@ func (_c *MockClient_SetServiceAccountAttributes_Call) RunAndReturn(run func(str
 	return _c
 }
 
-// SetServiceAccountGroups provides a mock function with given fields: realm, clientID, groups, addOnly
-func (_m *MockClient) SetServiceAccountGroups(realm string, clientID string, groups []string, addOnly bool) error {
-	ret := _m.Called(realm, clientID, groups, addOnly)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SetServiceAccountGroups")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, []string, bool) error); ok {
-		r0 = rf(realm, clientID, groups, addOnly)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockClient_SetServiceAccountGroups_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetServiceAccountGroups'
-type MockClient_SetServiceAccountGroups_Call struct {
-	*mock.Call
-}
-
-// SetServiceAccountGroups is a helper method to define mock.On call
-//   - realm string
-//   - clientID string
-//   - groups []string
-//   - addOnly bool
-func (_e *MockClient_Expecter) SetServiceAccountGroups(realm interface{}, clientID interface{}, groups interface{}, addOnly interface{}) *MockClient_SetServiceAccountGroups_Call {
-	return &MockClient_SetServiceAccountGroups_Call{Call: _e.mock.On("SetServiceAccountGroups", realm, clientID, groups, addOnly)}
-}
-
-func (_c *MockClient_SetServiceAccountGroups_Call) Run(run func(realm string, clientID string, groups []string, addOnly bool)) *MockClient_SetServiceAccountGroups_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].([]string), args[3].(bool))
-	})
-	return _c
-}
-
-func (_c *MockClient_SetServiceAccountGroups_Call) Return(_a0 error) *MockClient_SetServiceAccountGroups_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockClient_SetServiceAccountGroups_Call) RunAndReturn(run func(string, string, []string, bool) error) *MockClient_SetServiceAccountGroups_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // SyncAuthFlow provides a mock function with given fields: realmName, flow
 func (_m *MockClient) SyncAuthFlow(realmName string, flow *adapter.KeycloakAuthFlow) error {
 	ret := _m.Called(realmName, flow)
@@ -4063,6 +4014,55 @@ func (_c *MockClient_SyncRealmUser_Call) Return(_a0 error) *MockClient_SyncRealm
 }
 
 func (_c *MockClient_SyncRealmUser_Call) RunAndReturn(run func(context.Context, string, *adapter.KeycloakUser, bool) error) *MockClient_SyncRealmUser_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SyncServiceAccountGroups provides a mock function with given fields: realm, clientID, groups, addOnly
+func (_m *MockClient) SyncServiceAccountGroups(realm string, clientID string, groups []string, addOnly bool) error {
+	ret := _m.Called(realm, clientID, groups, addOnly)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SyncServiceAccountGroups")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, []string, bool) error); ok {
+		r0 = rf(realm, clientID, groups, addOnly)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockClient_SyncServiceAccountGroups_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SyncServiceAccountGroups'
+type MockClient_SyncServiceAccountGroups_Call struct {
+	*mock.Call
+}
+
+// SyncServiceAccountGroups is a helper method to define mock.On call
+//   - realm string
+//   - clientID string
+//   - groups []string
+//   - addOnly bool
+func (_e *MockClient_Expecter) SyncServiceAccountGroups(realm interface{}, clientID interface{}, groups interface{}, addOnly interface{}) *MockClient_SyncServiceAccountGroups_Call {
+	return &MockClient_SyncServiceAccountGroups_Call{Call: _e.mock.On("SyncServiceAccountGroups", realm, clientID, groups, addOnly)}
+}
+
+func (_c *MockClient_SyncServiceAccountGroups_Call) Run(run func(realm string, clientID string, groups []string, addOnly bool)) *MockClient_SyncServiceAccountGroups_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string), args[2].([]string), args[3].(bool))
+	})
+	return _c
+}
+
+func (_c *MockClient_SyncServiceAccountGroups_Call) Return(_a0 error) *MockClient_SyncServiceAccountGroups_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClient_SyncServiceAccountGroups_Call) RunAndReturn(run func(string, string, []string, bool) error) *MockClient_SyncServiceAccountGroups_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Description
For some reason the UpdateUser function isn't properly updating the groups for the service account user.
Reusing the `syncUserGroups` has working locally for me instead.
 
Fixes #162 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Pull Request contains one commit. I squash my commits.