### PR TITLE
feat: Allow finalizer cleanup when realm is already deleted

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -323,7 +323,6 @@ func enableOwnerRef() bool {
 	b, err := strconv.ParseBool(val)
 	if err != nil {
 		setupLog.Error(err, "unable to parse ENABLE_OWNER_REF. Using default value false")
-
 		return false
 	}
 

--- a/internal/controller/helper/controller_helper_auth.go
+++ b/internal/controller/helper/controller_helper_auth.go
@@ -25,6 +25,7 @@ const (
 )
 
 var ErrKeycloakIsNotAvailable = errors.New("keycloak is not available")
+var ErrKeycloakRealmNotFound = errors.New("keycloak realm is not available")
 
 // KeycloakAuthData contains data for keycloak authentication.
 type KeycloakAuthData struct {
@@ -220,6 +221,10 @@ func (h *Helper) getKeycloakAuthDataFromRealmRef(ctx context.Context, object Obj
 	case keycloakApi.KeycloakRealmKind:
 		realm := &keycloakApi.KeycloakRealm{}
 		if err := h.client.Get(ctx, types.NamespacedName{Name: name, Namespace: object.GetNamespace()}, realm); err != nil {
+			if k8sErrors.IsNotFound(err) && object.GetDeletionTimestamp() != nil {
+				return nil, ErrKeycloakRealmNotFound
+			}
+
 			return nil, fmt.Errorf("unable to get realm: %w", err)
 		}
 
@@ -227,6 +232,10 @@ func (h *Helper) getKeycloakAuthDataFromRealmRef(ctx context.Context, object Obj
 	case keycloakAlpha.ClusterKeycloakRealmKind:
 		clusterRealm := &keycloakAlpha.ClusterKeycloakRealm{}
 		if err := h.client.Get(ctx, types.NamespacedName{Name: name}, clusterRealm); err != nil {
+			if k8sErrors.IsNotFound(err) && object.GetDeletionTimestamp() != nil {
+				return nil, ErrKeycloakRealmNotFound
+			}
+
 			return nil, fmt.Errorf("unable to get cluster realm: %w", err)
 		}
 

--- a/internal/controller/keycloakclient/keycloakclient_controller.go
+++ b/internal/controller/keycloakclient/keycloakclient_controller.go
@@ -24,6 +24,7 @@ import (
 
 type Helper interface {
 	SetFailureCount(fc helper.FailureCountable) time.Duration
+	TryRemoveFinalizer(ctx context.Context, obj client.Object, finalizer string) error
 	TryToDelete(ctx context.Context, obj client.Object, terminator helper.Terminator, finalizer string) (isDeleted bool, resultErr error)
 	SetRealmOwnerRef(ctx context.Context, object helper.ObjectWithRealmRef) error
 	CreateKeycloakClientFromRealmRef(ctx context.Context, object helper.ObjectWithRealmRef) (keycloak.Client, error)
@@ -125,6 +126,15 @@ func (r *ReconcileKeycloakClient) tryReconcile(ctx context.Context, keycloakClie
 
 	kClient, err := r.helper.CreateKeycloakClientFromRealmRef(ctx, keycloakClient)
 	if err != nil {
+		// if the realm is already deleted try to delete finalizer
+		if errors.Is(err, helper.ErrKeycloakRealmNotFound) {
+			if removeErr := r.helper.TryRemoveFinalizer(ctx, keycloakClient, keyCloakClientOperatorFinalizerName); removeErr != nil {
+				return fmt.Errorf("unable to remove finalizer: %w", removeErr)
+			}
+
+			return nil
+		}
+
 		return fmt.Errorf("unable to create keycloak client from realm ref: %w", err)
 	}
 

--- a/internal/controller/keycloakclientscope/keycloakclientscope_controller.go
+++ b/internal/controller/keycloakclientscope/keycloakclientscope_controller.go
@@ -28,6 +28,7 @@ const finalizerName = "keycloak.clientscope.operator.finalizer.name"
 
 type Helper interface {
 	SetFailureCount(fc helper.FailureCountable) time.Duration
+	TryRemoveFinalizer(ctx context.Context, obj client.Object, finalizer string) error
 	TryToDelete(ctx context.Context, obj client.Object, terminator helper.Terminator, finalizer string) (isDeleted bool, resultErr error)
 	SetRealmOwnerRef(ctx context.Context, object helper.ObjectWithRealmRef) error
 	GetKeycloakRealmFromRef(ctx context.Context, object helper.ObjectWithRealmRef, kcClient keycloak.Client) (*gocloak.RealmRepresentation, error)
@@ -131,6 +132,15 @@ func (r *Reconcile) tryReconcile(ctx context.Context, instance *keycloakApi.Keyc
 
 	cl, err := r.helper.CreateKeycloakClientFromRealmRef(ctx, instance)
 	if err != nil {
+		// if the realm is already deleted try to delete finalizer
+		if errors.Is(err, helper.ErrKeycloakRealmNotFound) {
+			if removeErr := r.helper.TryRemoveFinalizer(ctx, instance, finalizerName); removeErr != nil {
+				return "", fmt.Errorf("unable to remove finalizer: %w", removeErr)
+			}
+
+			return "", nil
+		}
+
 		return "", fmt.Errorf("unable to create keycloak client from realm ref: %w", err)
 	}
 

--- a/internal/controller/keycloakrealmidentityprovider/keycloakrealmidentityprovider_controller.go
+++ b/internal/controller/keycloakrealmidentityprovider/keycloakrealmidentityprovider_controller.go
@@ -28,6 +28,7 @@ const finalizerName = "keycloak.realmidp.operator.finalizer.name"
 
 type Helper interface {
 	SetFailureCount(fc helper.FailureCountable) time.Duration
+	TryRemoveFinalizer(ctx context.Context, obj client.Object, finalizer string) error
 	TryToDelete(ctx context.Context, obj client.Object, terminator helper.Terminator, finalizer string) (isDeleted bool, resultErr error)
 	SetRealmOwnerRef(ctx context.Context, object helper.ObjectWithRealmRef) error
 	GetKeycloakRealmFromRef(ctx context.Context, object helper.ObjectWithRealmRef, kcClient keycloak.Client) (*gocloak.RealmRepresentation, error)
@@ -139,6 +140,15 @@ func (r *Reconcile) tryReconcile(ctx context.Context, keycloakRealmIDP *keycloak
 
 	kClient, err := r.helper.CreateKeycloakClientFromRealmRef(ctx, keycloakRealmIDP)
 	if err != nil {
+		// if the realm is already deleted try to delete finalizer
+		if errors.Is(err, helper.ErrKeycloakRealmNotFound) {
+			if removeErr := r.helper.TryRemoveFinalizer(ctx, keycloakRealmIDP, finalizerName); removeErr != nil {
+				return fmt.Errorf("unable to remove finalizer: %w", removeErr)
+			}
+
+			return nil
+		}
+
 		return fmt.Errorf("unable to create keycloak client from realm ref: %w", err)
 	}
 

--- a/internal/controller/keycloakrealmrole/keycloakrealmrole_controller.go
+++ b/internal/controller/keycloakrealmrole/keycloakrealmrole_controller.go
@@ -27,6 +27,7 @@ const keyCloakRealmRoleOperatorFinalizerName = "keycloak.realmrole.operator.fina
 
 type Helper interface {
 	SetFailureCount(fc helper.FailureCountable) time.Duration
+	TryRemoveFinalizer(ctx context.Context, obj client.Object, finalizer string) error
 	TryToDelete(ctx context.Context, obj client.Object, terminator helper.Terminator, finalizer string) (isDeleted bool, resultErr error)
 	SetRealmOwnerRef(ctx context.Context, object helper.ObjectWithRealmRef) error
 	GetKeycloakRealmFromRef(ctx context.Context, object helper.ObjectWithRealmRef, kcClient keycloak.Client) (*gocloak.RealmRepresentation, error)
@@ -138,6 +139,15 @@ func (r *ReconcileKeycloakRealmRole) tryReconcile(ctx context.Context, keycloakR
 
 	kClient, err := r.helper.CreateKeycloakClientFromRealmRef(ctx, keycloakRealmRole)
 	if err != nil {
+		// if the realm is already deleted try to delete finalizer
+		if errors.Is(err, helper.ErrKeycloakRealmNotFound) {
+			if removeErr := r.helper.TryRemoveFinalizer(ctx, keycloakRealmRole, keyCloakRealmRoleOperatorFinalizerName); removeErr != nil {
+				return "", fmt.Errorf("unable to remove finalizer: %w", removeErr)
+			}
+
+			return "", nil
+		}
+
 		return "", fmt.Errorf("unable to create keycloak client from realm ref: %w", err)
 	}
 

--- a/internal/controller/keycloakrealmuser/keycloakrealmuser_controller.go
+++ b/internal/controller/keycloakrealmuser/keycloakrealmuser_controller.go
@@ -24,10 +24,11 @@ import (
 	"github.com/epam/edp-keycloak-operator/pkg/objectmeta"
 )
 
-const finalizer = "keycloak.realmuser.operator.finalizer.name"
+const finalizerName = "keycloak.realmuser.operator.finalizer.name"
 
 type Helper interface {
 	SetFailureCount(fc helper.FailureCountable) time.Duration
+	TryRemoveFinalizer(ctx context.Context, obj client.Object, finalizer string) error
 	TryToDelete(ctx context.Context, obj client.Object, terminator helper.Terminator, finalizer string) (isDeleted bool, resultErr error)
 	SetRealmOwnerRef(ctx context.Context, object helper.ObjectWithRealmRef) error
 	GetKeycloakRealmFromRef(ctx context.Context, object helper.ObjectWithRealmRef, kcClient keycloak.Client) (*gocloak.RealmRepresentation, error)
@@ -117,6 +118,15 @@ func (r *Reconcile) tryReconcile(ctx context.Context, instance *keycloakApi.Keyc
 
 	kClient, err := r.helper.CreateKeycloakClientFromRealmRef(ctx, instance)
 	if err != nil {
+		// if the realm is already deleted try to delete finalizer
+		if errors.Is(err, helper.ErrKeycloakRealmNotFound) {
+			if removeErr := r.helper.TryRemoveFinalizer(ctx, instance, finalizerName); removeErr != nil {
+				return fmt.Errorf("unable to remove finalizer: %w", removeErr)
+			}
+
+			return nil
+		}
+
 		return fmt.Errorf("unable to create keycloak client from ref: %w", err)
 	}
 
@@ -133,7 +143,7 @@ func (r *Reconcile) tryReconcile(ctx context.Context, instance *keycloakApi.Keyc
 				kClient,
 				objectmeta.PreserveResourcesOnDeletion(instance),
 			),
-			finalizer,
+			finalizerName,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to delete keycloak realm user: %w", err)


### PR DESCRIPTION
# Pull Request Template

## Description
This PR fixes an issue where deleting a custom resource (e.g., KeycloakClient, KeycloakGroup, etc.) that references a KeycloakRealm CR which has already been deleted results in a permanent reconciliation failure.

Currently, when a child resource is deleted, the controller tries to instantiate a Keycloak client by fetching the corresponding KeycloakRealm CR. If the realm CR has already been deleted, the controller throws a NotFound error, and the resource remains stuck in a terminating state because the finalizer is never removed.

This patch ensures that if the referenced realm no longer exists, the finalizer is still properly removed, allowing the resource to be garbage collected.

Fixes #173 

## Type of change
- [✓ ] Enhancement (non-breaking change which improves an existing feature or documentation)

## How Has This Been Tested?
- Deployed the operator in a development environment with CAPI-generated clusters and Keycloak running.
- Created a KeycloakRealm and a related KeycloakClient.
- Deleted the KeycloakRealm before the KeycloakClient.
- Verified that the KeycloakClient finalizer was correctly removed, and the resource was deleted without manual intervention.
- Added test case in keycloakclient_controller_integration_test

## Checklist:
- [✓] I have performed a self-review of my code
- [✓] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [✓] My changes generate no new warnings
- [✓] I have added tests that prove my fix is effective or that my feature works
- [✓] New and existing unit tests pass locally with my changes
- [✓] Pull Request contains one commit. I squash my commits.
