### PR TITLE
feat: Add validation for user identity provider

### DIFF
--- a/api/v1/keycloakrealmuser_types.go
+++ b/api/v1/keycloakrealmuser_types.go
@@ -83,7 +83,7 @@ type KeycloakRealmUserSpec struct {
 	// +optional
 	PasswordSecret PasswordSecret `json:"passwordSecret,omitempty"`
 
-	// IdentityProviders linked to the user.
+	// IdentityProviders is a list of identity providers aliases linked to the user.
 	// +nullable
 	// +optional
 	IdentityProviders *[]string `json:"identityProviders,omitempty"`

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml
@@ -88,7 +88,8 @@ spec:
                 nullable: true
                 type: array
               identityProviders:
-                description: IdentityProviders linked to the user.
+                description: IdentityProviders is a list of identity providers aliases
+                  linked to the user.
                 items:
                   type: string
                 nullable: true

--- a/deploy-templates/_crd_examples/keycloakrealmidentityprovider.yaml
+++ b/deploy-templates/_crd_examples/keycloakrealmidentityprovider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   realmRef:
     kind: KeycloakRealm
-    name: realm
+    name: keycloakrealm-sample
   alias: instagram
   authenticateByDefault: false
   enabled: true

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml
@@ -88,7 +88,8 @@ spec:
                 nullable: true
                 type: array
               identityProviders:
-                description: IdentityProviders linked to the user.
+                description: IdentityProviders is a list of identity providers aliases
+                  linked to the user.
                 items:
                   type: string
                 nullable: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -6154,7 +6154,7 @@ KeycloakRealmUserSpec defines the desired state of KeycloakRealmUser.
         <td><b>identityProviders</b></td>
         <td>[]string</td>
         <td>
-          IdentityProviders linked to the user.<br/>
+          IdentityProviders is a list of identity providers aliases linked to the user.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/client/keycloak/adapter/gocloak_adapter_user.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_user.go
@@ -448,6 +448,15 @@ func (a GoCloakAdapter) addMissingIdentityProviders(
 			continue
 		}
 
+		exists, err := a.IdentityProviderExists(ctx, realmName, provider)
+		if err != nil {
+			return fmt.Errorf("unable to check if identity provider exists: %w", err)
+		}
+
+		if !exists {
+			return fmt.Errorf("identity provider %s does not exist", provider)
+		}
+
 		federatedIdentity := gocloak.FederatedIdentityRepresentation{
 			IdentityProvider: &provider,
 			UserID:           &userID,


### PR DESCRIPTION
# Pull Request Template

## Description
Problem
When assigning a non-existent identity provider, Keycloak returns a 409 Conflict error. This error message is confusing and doesn't indicate that the root cause is a missing identity provider. 
Change
Added explicit identity provider existence validation before attempting to create a user federated identity to prevent confusing 409 Conflict errors and provide more explicit error messages.

Fixes #183 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Unit test

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.