### PR TITLE
test: Use Keycloak version 26.3 for tests

### DIFF
--- a/api/v1/keycloakclient_types.go
+++ b/api/v1/keycloakclient_types.go
@@ -132,7 +132,8 @@ type KeycloakClientSpec struct {
 	AuthorizationServicesEnabled bool `json:"authorizationServicesEnabled,omitempty"`
 
 	// AdminFineGrainedPermissionsEnabled enable/disable fine-grained admin permissions for a client.
-	// Feature flag ADMIN_FINE_GRAINED_AUTHZ should be enabled in Keycloak server.
+	// Feature flag admin-fine-grained-authz:v1 should be enabled in Keycloak server.
+	// Important: FGAP:V1 Keycloak feature remains in preview and may be deprecated and removed in a future releases.
 	// +optional
 	AdminFineGrainedPermissionsEnabled bool `json:"adminFineGrainedPermissionsEnabled,omitempty"`
 

--- a/bundle/manifests/edp-keycloak-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/edp-keycloak-operator.clusterserviceversion.yaml
@@ -454,12 +454,11 @@ metadata:
             "name": "keycloakrealmidentityprovider-sample"
           },
           "spec": {
-            "alias": "instagram",
+            "alias": "github",
             "authenticateByDefault": false,
             "config": {
               "clientId": "foo",
               "clientSecret": "$secretName:secretKey",
-              "hideOnLoginPage": "true",
               "syncMode": "IMPORT",
               "useJwksUrl": "true"
             },
@@ -471,7 +470,7 @@ metadata:
                   "role": "role-tr",
                   "syncMode": "INHERIT"
                 },
-                "identityProviderAlias": "instagram",
+                "identityProviderAlias": "github",
                 "identityProviderMapper": "oidc-hardcoded-role-idp-mapper",
                 "name": "test3212"
               },
@@ -481,12 +480,12 @@ metadata:
                   "attribute.value": "bar",
                   "syncMode": "IMPORT"
                 },
-                "identityProviderAlias": "instagram",
+                "identityProviderAlias": "github",
                 "identityProviderMapper": "hardcoded-attribute-idp-mapper",
                 "name": "test-33221"
               }
             ],
-            "providerId": "instagram",
+            "providerId": "github",
             "realmRef": {
               "kind": "KeycloakRealm",
               "name": "keycloakrealm-sample"

--- a/config/crd/bases/v1.edp.epam.com_keycloakclients.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakclients.yaml
@@ -47,7 +47,8 @@ spec:
               adminFineGrainedPermissionsEnabled:
                 description: |-
                   AdminFineGrainedPermissionsEnabled enable/disable fine-grained admin permissions for a client.
-                  Feature flag ADMIN_FINE_GRAINED_AUTHZ should be enabled in Keycloak server.
+                  Feature flag admin-fine-grained-authz:v1 should be enabled in Keycloak server.
+                  Important: FGAP:V1 Keycloak feature remains in preview and may be deprecated and removed in a future releases.
                 type: boolean
               adminUrl:
                 description: |-

--- a/config/samples/v1_v1_keycloakrealmidentityprovider.yaml
+++ b/config/samples/v1_v1_keycloakrealmidentityprovider.yaml
@@ -6,27 +6,26 @@ spec:
   realmRef:
     name: keycloakrealm-sample
     kind: KeycloakRealm
-  alias: instagram
+  alias: github
   authenticateByDefault: false
   enabled: true
   firstBrokerLoginFlowAlias: "first broker login"
-  providerId: "instagram"
+  providerId: "github"
   config:
     clientId: "foo"
     clientSecret: "$secretName:secretKey"
-    hideOnLoginPage: "true"
     syncMode: "IMPORT"
     useJwksUrl: "true"
   mappers:
     - name: "test3212"
       identityProviderMapper: "oidc-hardcoded-role-idp-mapper"
-      identityProviderAlias: "instagram"
+      identityProviderAlias: "github"
       config:
         role: "role-tr"
         syncMode: "INHERIT"
     - name: "test-33221"
       identityProviderMapper: "hardcoded-attribute-idp-mapper"
-      identityProviderAlias: "instagram"
+      identityProviderAlias: "github"
       config:
         attribute: "foo"
         "attribute.value": "bar"

--- a/deploy-templates/Chart.yaml
+++ b/deploy-templates/Chart.yaml
@@ -183,30 +183,29 @@ annotations:
     - apiVersion: v1.edp.epam.com/v1
       kind: KeycloakRealmIdentityProvider
       metadata:
-        name: instagram-test
+        name: github-test
       spec:
         realm: d2-id-k8s-realm-name
-        alias: instagram
+        alias: github
         authenticateByDefault: false
         enabled: true
         firstBrokerLoginFlowAlias: "first broker login"
-        providerId: "instagram"
+        providerId: "github"
         config:
           clientId: "foo"
           clientSecret: "bar"
-          hideOnLoginPage: "true"
           syncMode: "IMPORT"
           useJwksUrl: "true"
         mappers:
           - name: "test3212"
             identityProviderMapper: "oidc-hardcoded-role-idp-mapper"
-            identityProviderAlias: "instagram"
+            identityProviderAlias: "github"
             config:
               role: "role-tr"
               syncMode: "INHERIT"
           - name: "test-33221"
             identityProviderMapper: "hardcoded-attribute-idp-mapper"
-            identityProviderAlias: "instagram"
+            identityProviderAlias: "github"
             config:
               attribute: "foo"
               "attribute.value": "bar"

--- a/deploy-templates/_crd_examples/keycloakrealmidentityprovider.yaml
+++ b/deploy-templates/_crd_examples/keycloakrealmidentityprovider.yaml
@@ -6,21 +6,20 @@ spec:
   realmRef:
     kind: KeycloakRealm
     name: keycloakrealm-sample
-  alias: instagram
+  alias: github
   authenticateByDefault: false
   enabled: true
   firstBrokerLoginFlowAlias: "first broker login"
-  providerId: "instagram"
+  providerId: "github"
   config:
     clientId: "foo"
     clientSecret: "$secretName:secretKey"
-    hideOnLoginPage: "true"
     syncMode: "IMPORT"
     useJwksUrl: "true"
   mappers:
     - name: "test-33221"
       identityProviderMapper: "hardcoded-attribute-idp-mapper"
-      identityProviderAlias: "instagram"
+      identityProviderAlias: "github"
       config:
         attribute: "foo"
         "attribute.value": "bar"

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakclients.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakclients.yaml
@@ -47,7 +47,8 @@ spec:
               adminFineGrainedPermissionsEnabled:
                 description: |-
                   AdminFineGrainedPermissionsEnabled enable/disable fine-grained admin permissions for a client.
-                  Feature flag ADMIN_FINE_GRAINED_AUTHZ should be enabled in Keycloak server.
+                  Feature flag admin-fine-grained-authz:v1 should be enabled in Keycloak server.
+                  Important: FGAP:V1 Keycloak feature remains in preview and may be deprecated and removed in a future releases.
                 type: boolean
               adminUrl:
                 description: |-

--- a/docs/api.md
+++ b/docs/api.md
@@ -1967,7 +1967,8 @@ KeycloakClientSpec defines the desired state of KeycloakClient.
         <td>boolean</td>
         <td>
           AdminFineGrainedPermissionsEnabled enable/disable fine-grained admin permissions for a client.
-Feature flag ADMIN_FINE_GRAINED_AUTHZ should be enabled in Keycloak server.<br/>
+Feature flag admin-fine-grained-authz:v1 should be enabled in Keycloak server.
+Important: FGAP:V1 Keycloak feature remains in preview and may be deprecated and removed in a future releases.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/internal/controller/keycloakrealmidentityprovider/keycloakrealmidentityprovider_controller_integration_test.go
+++ b/internal/controller/keycloakrealmidentityprovider/keycloakrealmidentityprovider_controller_integration_test.go
@@ -45,7 +45,7 @@ var _ = Describe("KeycloakRealmIdentityProvider controller", func() {
 					Name: KeycloakRealmCR,
 					Kind: keycloakApi.KeycloakRealmKind,
 				},
-				ProviderID: "instagram",
+				ProviderID: "github",
 				Alias:      "new-provider",
 				Config: map[string]string{
 					"clientId":     "provider-client",
@@ -95,7 +95,7 @@ var _ = Describe("KeycloakRealmIdentityProvider controller", func() {
 					Name: KeycloakRealmCR,
 					Kind: keycloakApi.KeycloakRealmKind,
 				},
-				ProviderID:                "instagram",
+				ProviderID:                "github",
 				Alias:                     "identity-provider-with-preserve-resources-on-deletion",
 				Enabled:                   true,
 				DisplayName:               "New provider",

--- a/tests/e2e/helm-success-path/01-install-keycloak-server.yaml
+++ b/tests/e2e/helm-success-path/01-install-keycloak-server.yaml
@@ -62,7 +62,7 @@ spec:
           - name: configs
             mountPath: /etc/nginx/conf.d
         - name: keycloak
-          image: quay.io/keycloak/keycloak:24.0.4
+          image: quay.io/keycloak/keycloak:26.3
           args:
             - "start-dev"
             - "--proxy-headers"
@@ -70,12 +70,12 @@ spec:
             - "--http-enabled"
             - "true"
           env:
-            - name: KEYCLOAK_ADMIN
+            - name: KC_BOOTSTRAP_ADMIN_USERNAME
               value: "admin"
-            - name: KEYCLOAK_ADMIN_PASSWORD
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD
               value: "admin"
             - name: KC_FEATURES
-              value: admin-fine-grained-authz
+              value: admin-fine-grained-authz:v1
           ports:
             - name: http
               containerPort: 8080

--- a/tests/e2e/helm-success-path/05-assert-identityprovider.yaml
+++ b/tests/e2e/helm-success-path/05-assert-identityprovider.yaml
@@ -4,8 +4,8 @@ metadata:
   name: keycloakrealmidentityprovider-sample
 spec:
   enabled: true
-  providerId: instagram
-  alias: instagram
+  providerId: github
+  alias: github
   config:
     clientId: foo
     clientSecret: $secret-name:secretKey

--- a/tests/e2e/helm-success-path/05-install-identityprovider.yaml
+++ b/tests/e2e/helm-success-path/05-install-identityprovider.yaml
@@ -16,21 +16,20 @@ spec:
   realmRef:
     kind: KeycloakRealm
     name: keycloakrealm-sample
-  alias: instagram
+  alias: github
   authenticateByDefault: false
   enabled: true
   firstBrokerLoginFlowAlias: "first broker login"
-  providerId: "instagram"
+  providerId: "github"
   config:
     clientId: "foo"
     clientSecret: "$secret-name:secretKey"
-    hideOnLoginPage: "true"
     syncMode: "IMPORT"
     useJwksUrl: "true"
   mappers:
     - name: "test-33221"
       identityProviderMapper: "hardcoded-attribute-idp-mapper"
-      identityProviderAlias: "instagram"
+      identityProviderAlias: "github"
       config:
         attribute: "foo"
         "attribute.value": "bar"
@@ -54,7 +53,6 @@ spec:
   config:
     clientId: "bar"
     clientSecret: "password-in-clear-form"
-    hideOnLoginPage: "true"
     syncMode: "IMPORT"
     useJwksUrl: "true"
   mappers:

--- a/tests/e2e/keycloak-selfsigned-certificates/01-install-keycloak-server.yaml
+++ b/tests/e2e/keycloak-selfsigned-certificates/01-install-keycloak-server.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:24.0.4
+          image: quay.io/keycloak/keycloak:26.3
           args:
             - "start-dev"
             - "--https-port=8443"
@@ -38,12 +38,12 @@ spec:
             - containerPort: 8080
             - containerPort: 8443
           env:
-            - name: KEYCLOAK_ADMIN
+            - name: KC_BOOTSTRAP_ADMIN_USERNAME
               value: "admin"
-            - name: KEYCLOAK_ADMIN_PASSWORD
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD
               value: "admin"
             - name: KC_FEATURES
-              value: admin-fine-grained-authz
+              value: admin-fine-grained-authz:v1
           volumeMounts:
             - name: certs
               mountPath: "/etc/certs"


### PR DESCRIPTION
# Pull Request Template

## Description
- Updated Keycloak version to 26.3  for test cases.
- Tests: changed the alias and providerId from "instagram" to "github" because the "instagram" provider was deprecated and isn't available by default.
- Added a note about the FGAP:V1 for KeycloakClient.Spec.AdminFineGrainedPermissionsEnabled. More details: https://www.keycloak.org/docs/latest/upgrading/index.html#migrating-to-26-2-0

Fixes #192

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.