### PR TITLE
fix: KeycloakRealmIdentityProvider policies not being added to permissions

### DIFF
--- a/internal/controller/keycloakrealmidentityprovider/chain/put_client_admin_fine_grained_perms.go
+++ b/internal/controller/keycloakrealmidentityprovider/chain/put_client_admin_fine_grained_perms.go
@@ -75,6 +75,11 @@ func (el *PutAdminFineGrainedPermissions) putKeycloakIDPAdminPermissionPolicies(
 	reqLog := ctrl.LoggerFrom(ctx)
 	reqLog.Info("Start put keycloak idp admin permission policies")
 
+	idp, err := el.keycloakApiClient.GetIdentityProvider(ctx, realmName, keycloakIDP.Spec.Alias)
+	if err != nil {
+		return fmt.Errorf("failed to get idp: %w", err)
+	}
+
 	realmManagementClientID, err := el.keycloakApiClient.GetClientID(RealmManagementClient, realmName)
 	if err != nil {
 		return fmt.Errorf("failed to get %s client id: %w", RealmManagementClient, err)
@@ -100,7 +105,7 @@ func (el *PutAdminFineGrainedPermissions) putKeycloakIDPAdminPermissionPolicies(
 			return fmt.Errorf("scope %s not found in permissions", name)
 		}
 
-		permissionName := fmt.Sprintf("%s.permission.idp.%s", name, keycloakIDP.Spec.Alias)
+		permissionName := fmt.Sprintf("%s.permission.idp.%s", name, idp.InternalID)
 
 		if permission, ok := realmManagementPermissions[permissionName]; ok {
 			permission.Policies = &keycloakIDP.Spec.Permission.ScopePermissions[i].Policies

--- a/internal/controller/keycloakrealmidentityprovider/chain/put_client_admin_fine_grained_perms_test.go
+++ b/internal/controller/keycloakrealmidentityprovider/chain/put_client_admin_fine_grained_perms_test.go
@@ -76,6 +76,10 @@ func TestPutAdminFineGrainedPermissions_Serve(t *testing.T) {
 					Return("567", nil).
 					Once()
 
+				m.On("GetIdentityProvider", ctrl.LoggerInto(context.Background(), logr.Discard()), "realm", "test-idp").
+					Return(&adapter.IdentityProvider{InternalID: "12345"}, nil).
+					Once()
+
 				m.On("UpdateIDPManagementPermissions", "realm", "test-idp", adapter.ManagementPermissionRepresentation{
 					Enabled: gocloak.BoolP(true),
 				}).

--- a/pkg/client/keycloak/adapter/identity_provider.go
+++ b/pkg/client/keycloak/adapter/identity_provider.go
@@ -7,6 +7,7 @@ import (
 )
 
 type IdentityProvider struct {
+	InternalID                string            `json:"internalId,omitempty"`
 	ProviderID                string            `json:"providerId"`
 	Config                    map[string]string `json:"config"`
 	AddReadTokenRoleOnCreate  bool              `json:"addReadTokenRoleOnCreate"`


### PR DESCRIPTION
# Pull Request Template

## Description

When adding policies to a KeycloakRealmIdentityProvider it is not added to the scope permission. The controller was using the alias instead of the internalID of the IDP for the permission name

Fixes #216 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

Tested on deployed EKS cluster

## Checklist:
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Pull Request contains one commit. I squash my commits.