### PR TITLE
fix: Unable to create userProfileConfig without a group

### DIFF
--- a/internal/controller/keycloakrealm/chain/user_profile.go
+++ b/internal/controller/keycloakrealm/chain/user_profile.go
@@ -184,9 +184,12 @@ func userProfileConfigAttributeSpecToModel(v *common.UserProfileAttribute) keycl
 
 	attr := keycloakgoclient.UserProfileAttribute{
 		DisplayName: &v.DisplayName,
-		Group:       &v.Group,
 		Name:        &v.Name,
 		Multivalued: &v.Multivalued,
+	}
+
+	if v.Group != "" {
+		attr.Group = &v.Group
 	}
 
 	annotations := make(map[string]interface{}, len(v.Annotations))

--- a/internal/controller/keycloakrealm/keycloakrealm_controller_integration_test.go
+++ b/internal/controller/keycloakrealm/keycloakrealm_controller_integration_test.go
@@ -122,6 +122,21 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 								},
 							},
 						},
+						{
+							Name:        "attr2",
+							DisplayName: "Attribute 2",
+							Permissions: &common.UserProfileAttributePermissions{
+								Edit: []string{"admin"},
+								View: []string{"admin"},
+							},
+							Validations: map[string]map[string]common.UserProfileAttributeValidation{
+								"options": {
+									"options": {
+										SliceVal: []string{"option1", "option2"},
+									},
+								},
+							},
+						},
 					},
 					Groups: []common.UserProfileGroup{
 						{


### PR DESCRIPTION
# Pull Request Template

## Description
Fixed issue - Unable to create Realm userProfileConfig without a group.

Fixes #165

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Manually

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.