### PR TITLE
chore: Generate containerImage annotation for ClusterServiceVersion

### DIFF
--- a/config/manifests/bases/edp-keycloak-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/edp-keycloak-operator.clusterserviceversion.yaml
@@ -5,11 +5,11 @@ metadata:
     alm-examples: '[]'
     capabilities: Deep Insights
     categories: Security
-    containerImage: docker.io/epamedp/keycloak-operator:1.29.0
+    containerImage: controller:latest
     description: An Operator for managing Keycloak
     repository: https://github.com/epam/edp-keycloak-operator
     support: KubeRocketCI
-  name: edp-keycloak-operator.v1.29.0
+  name: edp-keycloak-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -187,4 +187,4 @@ spec:
   provider:
     name: KubeRocketCI
     url: https://docs.kuberocketci.io/
-  version: 1.29.0
+  version: 0.0.0

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -6,6 +6,19 @@ resources:
 - ../samples
 - ../scorecard
 
+# Replacements to populate the containerImage annotation with the operator image version.
+# This ensures the ClusterServiceVersion annotation matches the actual deployed image.
+replacements:
+- source:
+    kind: Deployment
+    name: controller-manager
+    fieldPath: spec.template.spec.containers.0.image
+  targets:
+  - select:
+      kind: ClusterServiceVersion
+    fieldPaths:
+    - metadata.annotations.containerImage
+
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
 # These patches remove the unnecessary "cert" volume and its manager container volumeMount.

--- a/docs/development.md
+++ b/docs/development.md
@@ -207,6 +207,13 @@ make helm-docs
 helm lint deploy-templates/
 ```
 
+### Bundle Generation
+
+```bash
+# Generate a new bundle version
+VERSION=1.29.0 CHANNELS="stable" DEFAULT_CHANNEL=stable make bundle
+```
+
 ## Running and Debugging Locally
 
 This section covers how to run and debug the operator locally during development.


### PR DESCRIPTION
# Pull Request Template

## Description
Automatically set containerImage annotation in the operator bundle ClusterServiceVersion using kustomize replacements when running `make bundle`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.