### PR TITLE
include configID in deleteAuthFlowConfig error

### DIFF
--- a/pkg/client/keycloak/adapter/gocloak_adapter_auth_flow.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_auth_flow.go
@@ -632,7 +632,7 @@ func (a GoCloakAdapter) deleteAuthFlowConfig(realmName, configID string) error {
 		Delete(a.buildPath(authFlowConfig))
 
 	if err = a.checkError(err, rsp); err != nil {
-		return fmt.Errorf("unable to delete auth flow config: %w", err)
+		return fmt.Errorf("unable to delete auth flow config '%s': %w", configID, err)
 	}
 
 	return nil


### PR DESCRIPTION
# Pull Request Template

## Description
Log the config ID when deleting an auth flow config fails.
I wasted too much time breaking my head on which auth flow config it failed to delete.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

Build & push custom image, and use in deployed operator.

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):

## Additional context
Add any other context or screenshots about the feature request here.