### PR TITLE
feat: Enhance deletion logic to skip non-existent resources

### DIFF
--- a/internal/controller/clusterkeycloakrealm/terminator.go
+++ b/internal/controller/clusterkeycloakrealm/terminator.go
@@ -7,6 +7,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
 )
 
 type terminator struct {
@@ -25,6 +26,12 @@ func (t *terminator) DeleteResource(ctx context.Context) error {
 	log.Info("Start deleting keycloak realm")
 
 	if err := t.kClient.DeleteRealm(ctx, t.realmName); err != nil {
+		if adapter.IsErrNotFound(err) {
+			log.Info("Realm not found, skipping deletion.")
+
+			return nil
+		}
+
 		return fmt.Errorf("failed to delete keycloak realm: %w", err)
 	}
 

--- a/internal/controller/keycloakauthflow/terminator.go
+++ b/internal/controller/keycloakauthflow/terminator.go
@@ -61,6 +61,12 @@ func (t *terminator) DeleteResource(ctx context.Context) error {
 	log.Info("Start deleting auth flow")
 
 	if err := t.kClient.DeleteAuthFlow(t.realmName, t.keycloakAuthFlow); err != nil {
+		if adapter.IsErrNotFound(err) {
+			log.Info("Auth flow not found, skipping deletion.")
+
+			return nil
+		}
+
 		return fmt.Errorf("unable to delete auth flow: %w", err)
 	}
 

--- a/internal/controller/keycloakauthflow/terminator_test.go
+++ b/internal/controller/keycloakauthflow/terminator_test.go
@@ -88,3 +88,20 @@ func TestTerminatorDeleteResourceWithChildErr(t *testing.T) {
 	err := term.DeleteResource(context.Background())
 	assert.Error(t, err)
 }
+
+func TestTerminatorDeleteResourceNotFound(t *testing.T) {
+	sch := runtime.NewScheme()
+	assert.NoError(t, keycloakApi.AddToScheme(sch))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(sch).Build()
+	kClient := mocks.NewMockClient(t)
+
+	keycloakAuthFlow := adapter.KeycloakAuthFlow{Alias: "foo"}
+
+	term := makeTerminator("realm", "realmCR", &keycloakAuthFlow, fakeClient, kClient, false)
+
+	kClient.On("DeleteAuthFlow", "realm", &keycloakAuthFlow).Return(adapter.NotFoundError("not found")).Once()
+
+	err := term.DeleteResource(context.Background())
+	require.NoError(t, err)
+}

--- a/internal/controller/keycloakclient/terminator.go
+++ b/internal/controller/keycloakclient/terminator.go
@@ -7,6 +7,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
 )
 
 type terminator struct {
@@ -34,6 +35,12 @@ func (t *terminator) DeleteResource(ctx context.Context) error {
 	log.Info("Start deleting keycloak client")
 
 	if err := t.kClient.DeleteClient(ctx, t.clientID, t.realmName); err != nil {
+		if adapter.IsErrNotFound(err) {
+			log.Info("Client not found, skipping deletion.")
+
+			return nil
+		}
+
 		return fmt.Errorf("failed to delete keycloak client: %w", err)
 	}
 

--- a/internal/controller/keycloakclient/terminator_test.go
+++ b/internal/controller/keycloakclient/terminator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/mocks"
 )
 
@@ -35,6 +36,17 @@ func TestTerminatorSkipDeletion(t *testing.T) {
 		nil,
 		true,
 	)
+
+	err := term.DeleteResource(context.Background())
+	require.NoError(t, err)
+}
+
+func TestTerminatorDeleteResourceNotFound(t *testing.T) {
+	kClient := mocks.NewMockClient(t)
+
+	term := makeTerminator("realm", "client", kClient, false)
+
+	kClient.On("DeleteClient", mock.Anything, "realm", "client").Return(adapter.NotFoundError("not found")).Once()
 
 	err := term.DeleteResource(context.Background())
 	require.NoError(t, err)

--- a/internal/controller/keycloakclientscope/terminator.go
+++ b/internal/controller/keycloakclientscope/terminator.go
@@ -7,6 +7,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
 )
 
 type terminator struct {
@@ -34,6 +35,12 @@ func (t *terminator) DeleteResource(ctx context.Context) error {
 	log.Info("Start deleting client scope")
 
 	if err := t.kClient.DeleteClientScope(ctx, t.realmName, t.scopeID); err != nil {
+		if adapter.IsErrNotFound(err) {
+			log.Info("Client scope not found, skipping deletion.")
+
+			return nil
+		}
+
 		return fmt.Errorf("failed to delete client scope: %w", err)
 	}
 

--- a/internal/controller/keycloakclientscope/terminator_test.go
+++ b/internal/controller/keycloakclientscope/terminator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/mock"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/mocks"
 )
@@ -38,6 +39,21 @@ func TestTerminatorSkipDeletion(t *testing.T) {
 		"realm",
 		"scope",
 		true,
+	)
+
+	err := term.DeleteResource(context.Background())
+	require.NoError(t, err)
+}
+
+func TestTerminatorDeleteResourceNotFound(t *testing.T) {
+	kClient := mocks.NewMockClient(t)
+	kClient.On("DeleteClientScope", testifymock.Anything, "realm", "scope").Return(adapter.NotFoundError("not found")).Once()
+
+	term := makeTerminator(
+		kClient,
+		"realm",
+		"scope",
+		false,
 	)
 
 	err := term.DeleteResource(context.Background())

--- a/internal/controller/keycloakrealm/terminator.go
+++ b/internal/controller/keycloakrealm/terminator.go
@@ -7,6 +7,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
 )
 
 type terminator struct {
@@ -25,6 +26,12 @@ func (t *terminator) DeleteResource(ctx context.Context) error {
 	log.Info("Start deleting keycloak realm")
 
 	if err := t.kClient.DeleteRealm(ctx, t.realmName); err != nil {
+		if adapter.IsErrNotFound(err) {
+			log.Info("Realm not found, skipping deletion.")
+
+			return nil
+		}
+
 		return fmt.Errorf("failed to delete keycloak realm: %w", err)
 	}
 

--- a/internal/controller/keycloakrealm/terminator_test.go
+++ b/internal/controller/keycloakrealm/terminator_test.go
@@ -1,0 +1,50 @@
+package keycloakrealm
+
+import (
+	"context"
+	"testing"
+
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/mocks"
+	"github.com/stretchr/testify/assert"
+	testifymock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func Test_terminator_DeleteResource(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, keycloakApi.AddToScheme(scheme))
+
+	tests := []struct {
+		name                        string
+		realmName                   string
+		kClient                     func(t *testing.T) keycloak.Client
+		preserveResourcesOnDeletion bool
+		wantErr                     assert.ErrorAssertionFunc
+	}{
+		{
+			name:      "realm does not exist",
+			realmName: "realm",
+			kClient: func(t *testing.T) keycloak.Client {
+				m := mocks.NewMockClient(t)
+
+				m.On("DeleteRealm", testifymock.Anything, "realm").Return(adapter.NotFoundError("not found"))
+
+				return m
+			},
+			preserveResourcesOnDeletion: false,
+			wantErr:                     assert.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			te := makeTerminator(tt.realmName, tt.kClient(t), tt.preserveResourcesOnDeletion)
+			gotErr := te.DeleteResource(context.Background())
+			tt.wantErr(t, gotErr)
+		})
+	}
+}

--- a/internal/controller/keycloakrealmcomponent/terminator.go
+++ b/internal/controller/keycloakrealmcomponent/terminator.go
@@ -7,6 +7,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
 )
 
 type terminator struct {
@@ -35,6 +36,12 @@ func (t *terminator) DeleteResource(ctx context.Context) error {
 	log.Info("Start deleting KeycloakRealmComponent")
 
 	if err := t.kClient.DeleteComponent(ctx, t.realmName, t.componentName); err != nil {
+		if adapter.IsErrNotFound(err) {
+			log.Info("Realm component not found, skipping deletion.")
+
+			return nil
+		}
+
 		return fmt.Errorf("unable to delete realm component %w", err)
 	}
 

--- a/internal/controller/keycloakrealmcomponent/terminator_test.go
+++ b/internal/controller/keycloakrealmcomponent/terminator_test.go
@@ -7,6 +7,7 @@ import (
 	testifymock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/mocks"
 )
 
@@ -15,6 +16,16 @@ func TestTerminator_DeleteResource(t *testing.T) {
 
 	kcAdapter.On("DeleteComponent", testifymock.Anything, "foo", "bar").Return(nil)
 	term := makeTerminator("foo", "bar", kcAdapter, false)
+	err := term.DeleteResource(context.Background())
+	require.NoError(t, err)
+}
+
+func TestTerminatorDeleteResourceNotFound(t *testing.T) {
+	kClient := mocks.NewMockClient(t)
+	kClient.On("DeleteComponent", testifymock.Anything, "realm", "component").Return(adapter.NotFoundError("not found")).Once()
+
+	term := makeTerminator("realm", "component", kClient, false)
+
 	err := term.DeleteResource(context.Background())
 	require.NoError(t, err)
 }

--- a/internal/controller/keycloakrealmidentityprovider/terminator.go
+++ b/internal/controller/keycloakrealmidentityprovider/terminator.go
@@ -7,6 +7,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
 )
 
 type terminator struct {
@@ -35,6 +36,12 @@ func (t *terminator) DeleteResource(ctx context.Context) error {
 	log.Info("Start deleting keycloak realm idp")
 
 	if err := t.kClient.DeleteIdentityProvider(ctx, t.realmName, t.idpAlias); err != nil {
+		if adapter.IsErrNotFound(err) {
+			log.Info("Realm idp not found, skipping deletion.")
+
+			return nil
+		}
+
 		return fmt.Errorf("unable to delete realm idp %w", err)
 	}
 

--- a/internal/controller/keycloakrealmidentityprovider/terminator_test.go
+++ b/internal/controller/keycloakrealmidentityprovider/terminator_test.go
@@ -9,6 +9,7 @@ import (
 	testifymock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/mocks"
 )
 
@@ -27,4 +28,14 @@ func TestTerminator_DeleteResource(t *testing.T) {
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), "delete res fatal")
+}
+
+func TestTerminatorDeleteResourceNotFound(t *testing.T) {
+	kClient := mocks.NewMockClient(t)
+	kClient.On("DeleteIdentityProvider", testifymock.Anything, "realm", "alias1").Return(adapter.NotFoundError("not found")).Once()
+
+	term := makeTerminator("realm", "alias1", kClient, false)
+
+	err := term.DeleteResource(context.Background())
+	require.NoError(t, err)
 }

--- a/internal/controller/keycloakrealmrole/terminator.go
+++ b/internal/controller/keycloakrealmrole/terminator.go
@@ -7,6 +7,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
 )
 
 type terminator struct {
@@ -25,6 +26,12 @@ func (t *terminator) DeleteResource(ctx context.Context) error {
 	log.Info("Start deleting keycloak realm role")
 
 	if err := t.kClient.DeleteRealmRole(ctx, t.realmName, t.realmRoleName); err != nil {
+		if adapter.IsErrNotFound(err) {
+			log.Info("Realm role not found, skipping deletion.")
+
+			return nil
+		}
+
 		return fmt.Errorf("unable to delete realm role %w", err)
 	}
 

--- a/internal/controller/keycloakrealmrole/terminator_test.go
+++ b/internal/controller/keycloakrealmrole/terminator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/mock"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/mocks"
 )
@@ -42,6 +43,16 @@ func TestTerminatorSkipDeletion(t *testing.T) {
 		nil,
 		true,
 	)
+
+	err := term.DeleteResource(context.Background())
+	require.NoError(t, err)
+}
+
+func TestTerminatorDeleteResourceNotFound(t *testing.T) {
+	kClient := mocks.NewMockClient(t)
+	kClient.On("DeleteRealmRole", testifymock.Anything, "realm", "role").Return(adapter.NotFoundError("not found")).Once()
+
+	term := makeTerminator("realm", "role", kClient, false)
 
 	err := term.DeleteResource(context.Background())
 	require.NoError(t, err)

--- a/internal/controller/keycloakrealmrolebatch/terminator.go
+++ b/internal/controller/keycloakrealmrolebatch/terminator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -27,6 +28,12 @@ func (t *terminator) DeleteResource(ctx context.Context) error {
 
 	for i := range t.childRoles {
 		if err := t.client.Delete(ctx, &t.childRoles[i]); err != nil {
+			if k8sErrors.IsNotFound(err) {
+				log.Info("KeycloakRealmRole not found, skipping deletion.", "role name", t.childRoles[i].Name)
+
+				continue
+			}
+
 			return fmt.Errorf("unable to delete realm role %w", err)
 		}
 	}

--- a/internal/controller/keycloakrealmrolebatch/terminator_test.go
+++ b/internal/controller/keycloakrealmrolebatch/terminator_test.go
@@ -1,0 +1,48 @@
+package keycloakrealmrolebatch
+
+import (
+	"context"
+	"testing"
+
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Test_terminator_DeleteResource(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, keycloakApi.AddToScheme(scheme))
+
+	tests := []struct {
+		name                        string
+		k8sClient                   func(t *testing.T) client.Client
+		childRoles                  []keycloakApi.KeycloakRealmRole
+		preserveResourcesOnDeletion bool
+		wantErr                     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "role does not exist",
+			k8sClient: func(t *testing.T) client.Client {
+				return fake.NewClientBuilder().WithScheme(scheme).WithObjects().Build()
+			},
+			childRoles: []keycloakApi.KeycloakRealmRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "role"},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			te := makeTerminator(tt.k8sClient(t), tt.childRoles, tt.preserveResourcesOnDeletion)
+			gotErr := te.DeleteResource(context.Background())
+			tt.wantErr(t, gotErr)
+		})
+	}
+}


### PR DESCRIPTION
# Pull Request Template

## Description
Updated the logic across multiple controllers to skip deletion of resources that are not found. 
This change prevents deleted resources from being stuck.

Fixes #238 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Unit tests.

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.