### PR TITLE
fix: Reconciliation KeycloakAuthFlow fails - authFlowConfig not found

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "go.testEnvVars": {
-        "KUBEBUILDER_ASSETS": "${workspaceFolder}/bin/k8s/1.31.0-darwin-amd64",
-        "TEST_KEYCLOAK_URL": "http://localhost:8026"
+        "KUBEBUILDER_ASSETS": "${workspaceFolder}/bin/k8s/1.33.0-darwin-arm64",
+        "TEST_KEYCLOAK_URL": "http://localhost:8086"
     }
 }

--- a/pkg/client/keycloak/adapter/gocloak_adapter_auth_flow.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_auth_flow.go
@@ -250,14 +250,6 @@ func (a GoCloakAdapter) clearFlowExecutions(realmName, flowAlias string) error {
 		if err := a.deleteFlowExecution(realmName, execs[i].ID); err != nil {
 			return fmt.Errorf("unable to delete flow execution: %w", err)
 		}
-
-		// after deleting flow execution, we need to delete its config as well
-		// as it is not deleted automatically
-		if execs[i].AuthenticationConfig != "" {
-			if err := a.deleteAuthFlowConfig(realmName, execs[i].AuthenticationConfig); err != nil {
-				return fmt.Errorf("unable to delete flow execution config: %w", err)
-			}
-		}
 	}
 
 	return nil

--- a/pkg/client/keycloak/adapter/gocloak_adapter_auth_flow_test.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_auth_flow_test.go
@@ -1180,42 +1180,6 @@ func (e *ExecFlowTestSuite) TestClearFlowExecutions_ErrorDeletingFlowExecution()
 	assert.Contains(e.T(), err.Error(), "unable to delete flow execution")
 }
 
-func (e *ExecFlowTestSuite) TestClearFlowExecutions_ErrorDeletingFlowExecutionConfig() {
-	execID := "exec-id-1"
-	configID := "config-id-1"
-
-	e.setupServerWithConfig(&ServerConfig{
-		Handlers: map[string]map[string]ServerHandler{
-			http.MethodGet: {
-				e.pathBuilder.AuthFlowExecution("test-flow"): func(w http.ResponseWriter, r *http.Request) {
-					setJSONContentType(w)
-					w.WriteHeader(http.StatusOK)
-					_ = json.NewEncoder(w).Encode([]FlowExecution{
-						{
-							AuthenticationFlow:   false,
-							ID:                   execID,
-							Level:                0,
-							AuthenticationConfig: configID, // Has config to delete
-						},
-					})
-				},
-			},
-			http.MethodDelete: {
-				e.pathBuilder.AuthFlowExecutionDelete(execID): func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(http.StatusOK)
-				},
-				e.pathBuilder.AuthFlowConfig(configID): func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(http.StatusInternalServerError)
-				},
-			},
-		},
-	})
-
-	err := e.adapter.clearFlowExecutions(e.realmName, "test-flow")
-	assert.Error(e.T(), err)
-	assert.Contains(e.T(), err.Error(), "unable to delete flow execution config")
-}
-
 // Error scenario tests for validateChildFlowsCreated
 func (e *ExecFlowTestSuite) TestValidateChildFlowsCreated_ErrorGettingFlowExecutions() {
 	flow := &KeycloakAuthFlow{


### PR DESCRIPTION
# Pull Request Template

## Description
In Keycloak versions 25 and 26, authFlowConfig for authenticationExecutions is automatically removed by Keycloak. Removing it manually produces a "not found" error.

This fix removes the manual authFlowConfig deletion to align with the new Keycloak behavior.

Related: https://github.com/keycloak/keycloak/issues/24795

Fixes #234 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Manually

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits