### PR TITLE
feat: Add postBrokerLoginFlowAlias to KeycloakRealmIdentityProvider

### DIFF
--- a/api/v1/keycloakrealmidentityprovider_types.go
+++ b/api/v1/keycloakrealmidentityprovider_types.go
@@ -43,6 +43,10 @@ type KeycloakRealmIdentityProviderSpec struct {
 	// +optional
 	FirstBrokerLoginFlowAlias string `json:"firstBrokerLoginFlowAlias,omitempty"`
 
+	// PostBrokerLoginFlowAlias is a post broker login flow alias.
+	// +optional
+	PostBrokerLoginFlowAlias string `json:"postBrokerLoginFlowAlias,omitempty"`
+
 	// LinkOnly is a flag to link only.
 	// +optional
 	LinkOnly bool `json:"linkOnly,omitempty"`

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealmidentityproviders.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealmidentityproviders.yaml
@@ -128,6 +128,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              postBrokerLoginFlowAlias:
+                description: PostBrokerLoginFlowAlias is a post broker login flow
+                  alias.
+                type: string
               providerId:
                 description: ProviderID is a provider ID of identity provider.
                 type: string

--- a/deploy-templates/_crd_examples/keycloakrealmidentityprovider.yaml
+++ b/deploy-templates/_crd_examples/keycloakrealmidentityprovider.yaml
@@ -10,10 +10,11 @@ spec:
   authenticateByDefault: false
   enabled: true
   firstBrokerLoginFlowAlias: "first broker login"
+  postBrokerLoginFlowAlias: "browser"
   providerId: "github"
   config:
     clientId: "foo"
-    clientSecret: "$secretName:secretKey"
+    clientSecret: "$test-idp-secret:secret"
     syncMode: "IMPORT"
     useJwksUrl: "true"
   mappers:
@@ -24,3 +25,13 @@ spec:
         attribute: "foo"
         "attribute.value": "bar"
         syncMode: "IMPORT"
+
+---
+  
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-idp-secret
+type: Opaque
+data:
+  secret: "c2VjcmV0"  # base64 encoded value of "secret"

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealmidentityproviders.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealmidentityproviders.yaml
@@ -128,6 +128,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              postBrokerLoginFlowAlias:
+                description: PostBrokerLoginFlowAlias is a post broker login flow
+                  alias.
+                type: string
               providerId:
                 description: ProviderID is a provider ID of identity provider.
                 type: string

--- a/docs/api.md
+++ b/docs/api.md
@@ -4541,6 +4541,13 @@ Important: FGAP:V1 Keycloak feature remains in preview and may be deprecated and
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>postBrokerLoginFlowAlias</b></td>
+        <td>string</td>
+        <td>
+          PostBrokerLoginFlowAlias is a post broker login flow alias.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>storeToken</b></td>
         <td>boolean</td>
         <td>

--- a/internal/controller/keycloakrealmidentityprovider/chain/put_idp.go
+++ b/internal/controller/keycloakrealmidentityprovider/chain/put_idp.go
@@ -78,6 +78,7 @@ func createKeycloakIDPFromSpec(spec *keycloakApi.KeycloakRealmIdentityProviderSp
 		AuthenticateByDefault:     spec.AuthenticateByDefault,
 		DisplayName:               spec.DisplayName,
 		FirstBrokerLoginFlowAlias: spec.FirstBrokerLoginFlowAlias,
+		PostBrokerLoginFlowAlias:  spec.PostBrokerLoginFlowAlias,
 		LinkOnly:                  spec.LinkOnly,
 		StoreToken:                spec.StoreToken,
 		TrustEmail:                spec.TrustEmail,

--- a/pkg/client/keycloak/adapter/identity_provider.go
+++ b/pkg/client/keycloak/adapter/identity_provider.go
@@ -16,6 +16,7 @@ type IdentityProvider struct {
 	DisplayName               string            `json:"displayName"`
 	Enabled                   bool              `json:"enabled"`
 	FirstBrokerLoginFlowAlias string            `json:"firstBrokerLoginFlowAlias"`
+	PostBrokerLoginFlowAlias  string            `json:"postBrokerLoginFlowAlias"`
 	LinkOnly                  bool              `json:"linkOnly"`
 	StoreToken                bool              `json:"storeToken"`
 	TrustEmail                bool              `json:"trustEmail"`

--- a/tests/e2e/helm-success-path/05-install-identityprovider.yaml
+++ b/tests/e2e/helm-success-path/05-install-identityprovider.yaml
@@ -20,6 +20,7 @@ spec:
   authenticateByDefault: false
   enabled: true
   firstBrokerLoginFlowAlias: "first broker login"
+  postBrokerLoginFlowAlias: "browser"
   providerId: "github"
   config:
     clientId: "foo"


### PR DESCRIPTION
# Pull Request Template

## Description
Add postBrokerLoginFlowAlias to KeycloakRealmIdentityProvider.
Example
```yaml
apiVersion: v1.edp.epam.com/v1
kind: KeycloakRealmIdentityProvider
metadata:
  name: keycloakrealmidentityprovider-sample
spec:
  realmRef:
    kind: KeycloakRealm
    name: keycloakrealm-sample
  alias: github
  authenticateByDefault: false
  enabled: true
  firstBrokerLoginFlowAlias: "first broker login"
  postBrokerLoginFlowAlias: "browser"
  providerId: "github"
```

Fixes #231 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Integration tests
- e2e tests

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.