### PR TITLE
docs: add kubectl wait example for Keycloak status check (#243)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ To install the Keycloak Operator, follow the steps below:
 
     Wait for the `.status` field with  `status.connected: true`
 
+    ```bash
+    # Check the current status
+    kubectl get keycloak keycloak-sample -n  -o jsonpath='{.status.connected}'
+    
+    # Or wait automatically until connected
+    kubectl wait --for=jsonpath='{.status.connected}'=true keycloak/keycloak-sample -n  --timeout=300s
+    ```
+
 4. Create Keycloak realm and group using Custom Resources:
 
    ```yaml


### PR DESCRIPTION
# Pull Request Template

## Description
Added documentation for checking the Keycloak custom resource status using `kubectl` commands.

## Changes
- Added example commands to check the `status.connected` field
- Included both manual check (`kubectl get`) and automatic wait (`kubectl wait`) options

Fixes [#243](https://github.com/epam/edp-keycloak-operator/issues/243)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):

## Additional context
Add any other context or screenshots about the feature request here.