### PR TITLE
fix: Unable to set realm userProfileConfig

### DIFF
--- a/pkg/client/keycloak/adapter/gocloak_adapter_user.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_user.go
@@ -338,7 +338,7 @@ func (a GoCloakAdapter) UpdateUsersProfile(
 	httpClient := a.client.RestyClient().GetClient()
 
 	cl, err := keycloak_go_client.NewClient(
-		a.basePath,
+		a.buildPath(""),
 		keycloak_go_client.WithToken(a.token.AccessToken),
 		keycloak_go_client.WithHTTPClient(httpClient),
 	)


### PR DESCRIPTION
# Pull Request Template

## Description
Fixed the issue where operator fails to set userProfileConfig for realm when keycloak instance is configured with relative path `/auth`. The issue appears because we use custom keycloak client for setting userProfileConfig. This custom client didn't handle relative path `/auth` as standard client.

Fixes #221 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Manually

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.