### PR TITLE
feat: Add webhook validation for KeycloakRealm resources

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,8 @@
             "program": "${workspaceFolder}/cmd",
             "env": {
                 "WATCH_NAMESPACE": "",
-                "OPERATOR_NAMESPACE": "default"
+                "OPERATOR_NAMESPACE": "default",
+                "ENABLE_WEBHOOKS": "false"
             }
         }
     ]

--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,12 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 	echo "  com.redhat.openshift.versions: v4.7-v4.19" >> bundle/metadata/annotations.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
 
+.PHONY: build-installer
+build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
+	mkdir -p dist
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default > dist/install.yaml
+
 .PHONY: setup-envtest
 setup-envtest: envtest ## Download the binaries required for ENVTEST in the local bin directory.
 	@echo "Setting up envtest binaries for Kubernetes version $(ENVTEST_K8S_VERSION)..."

--- a/PROJECT
+++ b/PROJECT
@@ -65,6 +65,9 @@ resources:
   kind: KeycloakRealm
   path: github.com/epam/edp-keycloak-operator/api/v1
   version: v1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ _**NOTE:** Operator is platform-independent, which is why there is a unified ins
 
 1. Linux machine or Windows Subsystem for Linux instance with [Helm 3](https://helm.sh/docs/intro/install/) installed;
 2. Cluster admin access to the cluster;
+3. [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (required for webhook functionality, can be disabled via `enableWebhooks: false`);
 
 ## Installation Using Helm Chart
 

--- a/api/v1/keycloakrealm_types.go
+++ b/api/v1/keycloakrealm_types.go
@@ -9,6 +9,8 @@ import (
 // KeycloakRealmSpec defines the desired state of KeycloakRealm.
 type KeycloakRealmSpec struct {
 	// RealmName specifies the name of the realm.
+	// +required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	RealmName string `json:"realmName"`
 
 	// KeycloakRef is reference to Keycloak custom resource.

--- a/config/certmanager/certificate-metrics.yaml
+++ b/config/certmanager/certificate-metrics.yaml
@@ -1,20 +1,20 @@
-# The following manifests contain a self-signed issuer CR and a metrics certificate CR.
+# [METRICS]The following manifests contain a self-signed issuer CR and a metrics certificate CR.
 # More document can be found at https://docs.cert-manager.io
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: metrics-certs  # this name should match the one appeared in kustomizeconfig.yaml
-  namespace: system
-spec:
-  dnsNames:
-  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
-  # replacements in the config/default/kustomization.yaml file.
-  - SERVICE_NAME.SERVICE_NAMESPACE.svc
-  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
-  issuerRef:
-    kind: Issuer
-    name: selfsigned-issuer
-  secretName: metrics-server-cert
+# apiVersion: cert-manager.io/v1
+# kind: Certificate
+# metadata:
+#   labels:
+#     app.kubernetes.io/name: keycloak-operator
+#     app.kubernetes.io/managed-by: kustomize
+#   name: metrics-certs  # this name should match the one appeared in kustomizeconfig.yaml
+#   namespace: system
+# spec:
+#   dnsNames:
+#   # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+#   # replacements in the config/default/kustomization.yaml file.
+#   - SERVICE_NAME.SERVICE_NAMESPACE.svc
+#   - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+#   issuerRef:
+#     kind: Issuer
+#     name: selfsigned-issuer
+#   secretName: metrics-server-cert

--- a/config/certmanager/certificate-webhook.yaml
+++ b/config/certmanager/certificate-webhook.yaml
@@ -1,35 +1,20 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  labels:
-    app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: selfsigned-issuer
-  namespace: system
-spec:
-  selfSigned: {}
----
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    app.kubernetes.io/name: certificate
-    app.kubernetes.io/instance: serving-cert
-    app.kubernetes.io/component: certificate
-    app.kubernetes.io/created-by: keycloak-operator
-    app.kubernetes.io/part-of: keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
   # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+  # replacements in the config/default/kustomization.yaml file.
   dnsNames:
-    - SERVICE_NAME.SERVICE_NAMESPACE.svc
-    - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: webhook-server-cert

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
@@ -206,6 +206,9 @@ spec:
               realmName:
                 description: RealmName specifies the name of the realm.
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               smtp:
                 description: Smtp is the configuration for email in the realm.
                 nullable: true

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.
-#configurations:
-#- kustomizeconfig.yaml
+configurations:
+- kustomizeconfig.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: edp-keycloak-operator-system
+namespace: keycloak-operator-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: edp-keycloak-operator-
+namePrefix: keycloak-operator-
 
 # Labels to add to all resources and selectors.
 #labels:
@@ -20,7 +20,7 @@ resources:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-# - ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 # - ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
@@ -50,13 +50,13 @@ patches:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-# - path: manager_webhook_patch.yaml
-#   target:
-#     kind: Deployment
+- path: manager_webhook_patch.yaml
+  target:
+    kind: Deployment
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations
-# replacements:
+replacements:
 #  - source: # Uncomment the following block to enable certificates for metrics
 #      kind: Service
 #      version: v1
@@ -154,13 +154,13 @@ patches:
 #          index: 1
 #          create: true
 
-# - source: # Uncomment the following block if you have a ValidatingWebhook (--programmatic-validation)
+#  - source: # Uncomment the following block if you have a ValidatingWebhook (--programmatic-validation)
 #     kind: Certificate
 #     group: cert-manager.io
 #     version: v1
 #     name: serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets:
+#    targets:
 #     - select:
 #         kind: ValidatingWebhookConfiguration
 #       fieldPaths:
@@ -169,13 +169,13 @@ patches:
 #         delimiter: '/'
 #         index: 0
 #         create: true
-# - source:
+#  - source:
 #     kind: Certificate
 #     group: cert-manager.io
 #     version: v1
 #     name: serving-cert
 #     fieldPath: .metadata.name
-#   targets:
+#    targets:
 #     - select:
 #         kind: ValidatingWebhookConfiguration
 #       fieldPaths:
@@ -232,3 +232,14 @@ patches:
 #     fieldPath: .metadata.name
 #   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
 # +kubebuilder:scaffold:crdkustomizecainjectionname
+
+ - source: # [CUSTOM] Replace namespace in ValidatingWebhookConfiguration namespaceSelector
+     kind: Service
+     version: v1
+     name: webhook-service
+     fieldPath: metadata.namespace
+   targets:
+     - select:
+         kind: ValidatingWebhookConfiguration
+       fieldPaths:
+         - webhooks.0.namespaceSelector.matchExpressions.0.values.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,7 +76,8 @@ spec:
         ports: []
         securityContext:
           allowPrivilegeEscalation: false
-          drop:
+          capabilities:
+            drop:
             - "ALL"
         livenessProbe:
           httpGet:

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 - ../samples
 - ../scorecard
 
-# Replacements to populate the containerImage annotation with the operator image version.
+# [CUSTOM] Replacements to populate the containerImage annotation with the operator image version.
 # This ensures the ClusterServiceVersion annotation matches the actual deployed image.
 replacements:
 - source:
@@ -22,20 +22,19 @@ replacements:
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
 # These patches remove the unnecessary "cert" volume and its manager container volumeMount.
-#patches:
-#- target:
-#    group: apps
-#    version: v1
-#    kind: Deployment
-#    name: controller-manager
-#    namespace: system
-#  patch: |-
-#    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
-#    # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
-#    - op: remove
-
-#      path: /spec/template/spec/containers/0/volumeMounts/0
-#    # Remove the "cert" volume, since OLM will create and mount a set of certs.
-#    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
-#    - op: remove
-#      path: /spec/template/spec/volumes/0
+patches:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: controller-manager
+    namespace: system
+  patch: |-
+    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
+    # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
+    - op: remove
+      path: /spec/template/spec/containers/0/volumeMounts/0
+    # Remove the "cert" volume, since OLM will create and mount a set of certs.
+    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
+    - op: remove
+      path: /spec/template/spec/volumes/0

--- a/config/rbac/clusterkeycloak_admin_role.yaml
+++ b/config/rbac/clusterkeycloak_admin_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: clusterkeycloak-admin-role
 rules:

--- a/config/rbac/clusterkeycloakrealm_admin_role.yaml
+++ b/config/rbac/clusterkeycloakrealm_admin_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: clusterkeycloakrealm-admin-role
 rules:

--- a/config/rbac/keycloak_admin_role.yaml
+++ b/config/rbac/keycloak_admin_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: keycloak-admin-role
 rules:

--- a/config/rbac/keycloakauthflow_admin_role.yaml
+++ b/config/rbac/keycloakauthflow_admin_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: keycloakauthflow-admin-role
 rules:

--- a/config/rbac/keycloakclient_admin_role.yaml
+++ b/config/rbac/keycloakclient_admin_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: keycloakclient-admin-role
 rules:

--- a/config/rbac/keycloakclientscope_admin_role.yaml
+++ b/config/rbac/keycloakclientscope_admin_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: keycloakclientscope-admin-role
 rules:

--- a/config/rbac/keycloakorganization_admin_role.yaml
+++ b/config/rbac/keycloakorganization_admin_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: organization-admin-role
 rules:

--- a/config/rbac/keycloakorganization_editor_role.yaml
+++ b/config/rbac/keycloakorganization_editor_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: organization-editor-role
 rules:

--- a/config/rbac/keycloakorganization_viewer_role.yaml
+++ b/config/rbac/keycloakorganization_viewer_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: organization-viewer-role
 rules:

--- a/config/rbac/keycloakrealm_admin_role.yaml
+++ b/config/rbac/keycloakrealm_admin_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: keycloakrealm-admin-role
 rules:

--- a/config/rbac/keycloakrealmcomponent_admin_role.yaml
+++ b/config/rbac/keycloakrealmcomponent_admin_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: keycloakrealmcomponent-admin-role
 rules:

--- a/config/rbac/keycloakrealmgroup_admin_role.yaml
+++ b/config/rbac/keycloakrealmgroup_admin_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: keycloakrealmgroup-admin-role
 rules:

--- a/config/rbac/keycloakrealmidentityprovider_admin_role.yaml
+++ b/config/rbac/keycloakrealmidentityprovider_admin_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: keycloakrealmidentityprovider-admin-role
 rules:

--- a/config/rbac/keycloakrealmrole_admin_role.yaml
+++ b/config/rbac/keycloakrealmrole_admin_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: keycloakrealmrole-admin-role
 rules:

--- a/config/rbac/keycloakrealmrolebatch_admin_role.yaml
+++ b/config/rbac/keycloakrealmrolebatch_admin_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: keycloakrealmrolebatch-admin-role
 rules:

--- a/config/rbac/keycloakrealmuser_admin_role.yaml
+++ b/config/rbac/keycloakrealmuser_admin_role.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: edp-keycloak-operator
+    app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/managed-by: kustomize
   name: keycloakrealmuser-admin-role
 rules:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -41,6 +41,14 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - v1.edp.epam.com
+  resources:
+  - keycloakrealms
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/config/samples/v1_v1alpha1_clusterkeycloak.yaml
+++ b/config/samples/v1_v1alpha1_clusterkeycloak.yaml
@@ -3,10 +3,6 @@ kind: ClusterKeycloak
 metadata:
   labels:
     app.kubernetes.io/name: clusterkeycloak
-    app.kubernetes.io/instance: clusterkeycloak-sample
-    app.kubernetes.io/part-of: edp-keycloak-operator
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: edp-keycloak-operator
   name: clusterkeycloak-sample
 spec:
   secret: keycloak-access

--- a/config/samples/v1_v1alpha1_clusterkeycloakrealm.yaml
+++ b/config/samples/v1_v1alpha1_clusterkeycloakrealm.yaml
@@ -3,10 +3,6 @@ kind: ClusterKeycloakRealm
 metadata:
   labels:
     app.kubernetes.io/name: clusterkeycloakrealm
-    app.kubernetes.io/instance: clusterkeycloakrealm-sample
-    app.kubernetes.io/part-of: edp-keycloak-operator
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: edp-keycloak-operator
   name: clusterkeycloakrealm-sample
 spec:
   clusterKeycloakRef: clusterkeycloak-sample

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,12 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml
+
+# [CUSTOM] Namespace-scoped webhook validation to prevent cross-namespace conflicts.
+patches:
+- path: webhook_namespace_patch.yaml
+  target:
+    kind: ValidatingWebhookConfiguration

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,22 @@
+# the following config is for teaching kustomize where to look at when substituting nameReference.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-v1-edp-epam-com-v1-keycloakrealm
+  failurePolicy: Fail
+  name: vkeycloakrealm-v1.kb.io
+  rules:
+  - apiGroups:
+    - v1.edp.epam.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - keycloakrealms
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: keycloak-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager
+    app.kubernetes.io/name: keycloak-operator

--- a/config/webhook/webhook_namespace_patch.yaml
+++ b/config/webhook/webhook_namespace_patch.yaml
@@ -1,0 +1,8 @@
+- op: add
+  path: /webhooks/0/namespaceSelector
+  value:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - system

--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -16,6 +16,7 @@ _**NOTE:** Operator is platform-independent, which is why there is a unified ins
 
 1. Linux machine or Windows Subsystem for Linux instance with [Helm 3](https://helm.sh/docs/intro/install/) installed;
 2. Cluster admin access to the cluster;
+3. [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (required for webhook functionality, can be disabled via `enableWebhooks: false`);
 
 ## Installation Using Helm Chart
 
@@ -132,6 +133,7 @@ Development versions are also available from the [snapshot helm chart repository
 | clusterReconciliationEnabled | bool | `false` | If clusterReconciliationEnabled is true, the operator reconciles all Keycloak instances in the cluster;  otherwise, it only reconciles instances in the same namespace by default, and cluster-scoped resources are ignored. |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Container Security Context Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | enableOwnerRef | bool | `true` | If set to true, the operator will set the owner reference for all resources that have Keycloak or KeycloakRealm as reference. This is legacy behavior and not recommended for use. In the future, this will be set to false by default. |
+| enableWebhooks | bool | `true` | If set to true, enables webhook resources (ValidatingWebhookConfiguration, Service, and Certificate). Webhooks require cert-manager to be installed in the cluster. |
 | extraVolumeMounts | list | `[]` | Additional volumeMounts to be added to the container |
 | extraVolumes | list | `[]` | Additional volumes to be added to the pod |
 | image.registry | string | `""` | KubeRocketCI keycloak-operator Docker image registry. |

--- a/deploy-templates/README.md.gotmpl
+++ b/deploy-templates/README.md.gotmpl
@@ -17,6 +17,7 @@ _**NOTE:** Operator is platform-independent, which is why there is a unified ins
 
 1. Linux machine or Windows Subsystem for Linux instance with [Helm 3](https://helm.sh/docs/intro/install/) installed;
 2. Cluster admin access to the cluster;
+3. [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (required for webhook functionality, can be disabled via `enableWebhooks: false`);
 
 ## Installation Using Helm Chart
 

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
@@ -206,6 +206,9 @@ spec:
               realmName:
                 description: RealmName specifies the name of the realm.
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               smtp:
                 description: Smtp is the configuration for email in the realm.
                 nullable: true

--- a/deploy-templates/templates/deployment.yaml
+++ b/deploy-templates/templates/deployment.yaml
@@ -16,7 +16,9 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "keycloak-operator.selectorLabels" . | nindent 8 }}
         name: {{ .Values.name }}
+        control-plane: controller-manager
         {{- if hasKey .Values.podLabels "name" }}
         {{ fail "The 'name' key is not allowed in podLabels" }}
         {{- end }}
@@ -39,6 +41,13 @@ spec:
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
           command:
             - /manager
+          args:
+            - --metrics-bind-address=:8443
+            - --leader-elect
+            - --health-probe-bind-address=:8081
+            {{- if .Values.enableWebhooks }}
+            - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+            {{- end }}
           {{- if .Values.containerSecurityContext }}
           securityContext: {{ toYaml .Values.containerSecurityContext | nindent 12 }}
           {{- end }}
@@ -61,11 +70,24 @@ spec:
                   fieldPath: metadata.name
             - name: ENABLE_OWNER_REF
               value: {{ .Values.enableOwnerRef | quote }}
-        {{- if .Values.extraVolumeMounts }}
+            - name: ENABLE_WEBHOOKS
+              value: {{ .Values.enableWebhooks | quote }}
+        {{- if or .Values.extraVolumeMounts .Values.enableWebhooks }}
           volumeMounts:
+          {{- if .Values.enableWebhooks }}
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: webhook-certs
+              readOnly: true
+          {{- end }}
           {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
+        {{- end }}
+        {{- if .Values.enableWebhooks }}
+          ports:
+          - containerPort: 9443
+            name: webhook-server
+            protocol: TCP
         {{- end }}
           livenessProbe:
             httpGet:
@@ -81,8 +103,13 @@ spec:
             periodSeconds: 10
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-    {{- if .Values.extraVolumes }}
+    {{- if or .Values.extraVolumes .Values.enableWebhooks }}
       volumes:
+      {{- if .Values.enableWebhooks }}
+        - name: webhook-certs
+          secret:
+            secretName: webhook-server-cert
+      {{- end }}
       {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}

--- a/deploy-templates/templates/webhook/certmanager.yaml
+++ b/deploy-templates/templates/webhook/certmanager.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.enableWebhooks }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+      {{- include "keycloak-operator.labels" . | nindent 4 }}
+  name: {{ .Values.name }}-serving-cert
+spec:
+  dnsNames:
+  - {{ .Values.name }}-webhook-service.{{ .Release.Namespace }}.svc
+  - {{ .Values.name }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ .Values.name }}-selfsigned-issuer
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    {{- include "keycloak-operator.labels" . | nindent 4 }}
+  name: {{ .Values.name }}-selfsigned-issuer
+spec:
+  selfSigned: {}
+{{- end }}

--- a/deploy-templates/templates/webhook/manifest.yaml
+++ b/deploy-templates/templates/webhook/manifest.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.enableWebhooks }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+      {{- include "keycloak-operator.labels" . | nindent 4 }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Values.name }}-serving-cert
+  name: {{ .Values.name }}-validating-webhook-configuration-{{ .Release.Namespace }}
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ .Values.name }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-v1-edp-epam-com-v1-keycloakrealm
+  failurePolicy: Fail
+  name: vkeycloakrealm-v1.kb.io
+  {{- /* Namespace-scoped webhook validation to prevent cross-namespace conflicts. */ -}}
+  {{- if not .Values.clusterReconciliationEnabled }}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - {{ .Release.Namespace }}
+  {{- end }}
+  rules:
+  - apiGroups:
+    - v1.edp.epam.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - keycloakrealms
+  sideEffects: None
+{{- end }}

--- a/deploy-templates/templates/webhook/rbac.yaml
+++ b/deploy-templates/templates/webhook/rbac.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.enableWebhooks }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "keycloak-operator.labels" . | nindent 4 }}
+  name: edp-{{ .Release.Namespace }}-webhook-clusterrole
+rules:
+- apiGroups:
+  - v1.edp.epam.com
+  resources:
+  - keycloakrealms
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "keycloak-operator.labels" . | nindent 4 }}
+  name: edp-{{ .Release.Namespace }}-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edp-{{ .Release.Namespace }}-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: edp-{{ .Values.name }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy-templates/templates/webhook/service.yaml
+++ b/deploy-templates/templates/webhook/service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.enableWebhooks }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+      {{- include "keycloak-operator.labels" . | nindent 4 }}
+  name: {{ .Values.name }}-webhook-service
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    {{- include "keycloak-operator.selectorLabels" . | nindent 4 }}
+    control-plane: controller-manager
+{{- end }}

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -62,3 +62,7 @@ clusterReconciliationEnabled: false
 # -- If set to true, the operator will set the owner reference for all resources that have Keycloak or KeycloakRealm as reference.
 # This is legacy behavior and not recommended for use. In the future, this will be set to false by default.
 enableOwnerRef: true
+
+# -- If set to true, enables webhook resources (ValidatingWebhookConfiguration, Service, and Certificate).
+# Webhooks require cert-manager to be installed in the cluster.
+enableWebhooks: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -5424,6 +5424,8 @@ KeycloakRealmSpec defines the desired state of KeycloakRealm.
         <td>string</td>
         <td>
           RealmName specifies the name of the realm.<br/>
+          <br/>
+            <i>Validations</i>:<li>self == oldSelf: Value is immutable</li>
         </td>
         <td>true</td>
       </tr><tr>

--- a/internal/webhook/v1/keycloakrealm_webhook.go
+++ b/internal/webhook/v1/keycloakrealm_webhook.go
@@ -1,0 +1,77 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// keycloakrealmlog is for logging in this package.
+var keycloakrealmlog = logf.Log.WithName("keycloakrealm-resource")
+
+// SetupKeycloakRealmWebhookWithManager registers the webhook for KeycloakRealm in the manager.
+func SetupKeycloakRealmWebhookWithManager(mgr ctrl.Manager, k8sClient client.Client) error {
+	return ctrl.NewWebhookManagedBy(mgr).For(&keycloakApi.KeycloakRealm{}).
+		WithValidator(NewKeycloakRealmCustomValidator(k8sClient)).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/validate-v1-edp-epam-com-v1-keycloakrealm,mutating=false,failurePolicy=fail,sideEffects=None,groups=v1.edp.epam.com,resources=keycloakrealms,verbs=create,versions=v1,name=vkeycloakrealm-v1.kb.io,admissionReviewVersions=v1
+
+// KeycloakRealmCustomValidator struct is responsible for validating the KeycloakRealm resource
+// when it is created, updated, or deleted.
+type KeycloakRealmCustomValidator struct {
+	k8sclient client.Client
+}
+
+func NewKeycloakRealmCustomValidator(k8sclient client.Client) *KeycloakRealmCustomValidator {
+	return &KeycloakRealmCustomValidator{
+		k8sclient: k8sclient,
+	}
+}
+
+var _ webhook.CustomValidator = &KeycloakRealmCustomValidator{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type KeycloakRealm.
+func (v *KeycloakRealmCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	keycloakrealm, ok := obj.(*keycloakApi.KeycloakRealm)
+	if !ok {
+		return nil, fmt.Errorf("expected a KeycloakRealm object but got %T", obj)
+	}
+
+	keycloakrealmlog.Info("Validation for KeycloakRealm upon creation", "name", keycloakrealm.GetName())
+
+	// Check if keycloakrealm.Spec.RealmName is unique across all KeycloakRealm resources in the cluster.
+	existingKeycloakRealms := &keycloakApi.KeycloakRealmList{}
+	if err := v.k8sclient.List(ctx, existingKeycloakRealms); err != nil {
+		return nil, fmt.Errorf("failed to list KeycloakRealm resources: %w", err)
+	}
+
+	for _, existingRealm := range existingKeycloakRealms.Items {
+		isSameResource := existingRealm.Namespace == keycloakrealm.Namespace && existingRealm.Name == keycloakrealm.Name
+
+		if existingRealm.Spec.RealmName == keycloakrealm.Spec.RealmName && !isSameResource {
+			return nil, fmt.Errorf("realm name %s is already in use by another KeycloakRealm resource in namespace %s", keycloakrealm.Spec.RealmName, keycloakrealm.Namespace)
+		}
+	}
+
+	return nil, nil
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type KeycloakRealm.
+func (v *KeycloakRealmCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type KeycloakRealm.
+func (v *KeycloakRealmCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}

--- a/internal/webhook/v1/keycloakrealm_webhook_test.go
+++ b/internal/webhook/v1/keycloakrealm_webhook_test.go
@@ -1,0 +1,72 @@
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/epam/edp-keycloak-operator/api/common"
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("KeycloakRealm Webhook", func() {
+	var objInNs1 *keycloakApi.KeycloakRealm
+	BeforeEach(func() {
+		objInNs1 = &keycloakApi.KeycloakRealm{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-realm",
+				Namespace: "ns1",
+			},
+			Spec: keycloakApi.KeycloakRealmSpec{
+				RealmName: "test-realm",
+				KeycloakRef: common.KeycloakRef{
+					Name: "test-keycloak",
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, objInNs1)).Should(Succeed(), "failed to create initial KeycloakRealm in ns1")
+	})
+	AfterEach(func() {
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, objInNs1))).Should(Succeed(), "failed to delete initial KeycloakRealm in ns1")
+	})
+
+	Context("When creating KeycloakRealm", func() {
+		It("Should deny creation with the same RealmName in the same namespace", func() {
+			duplicateObj := &keycloakApi.KeycloakRealm{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "duplicate-realm",
+					Namespace: "ns1",
+				},
+				Spec: keycloakApi.KeycloakRealmSpec{
+					RealmName: "test-realm", // Same RealmName as the existing one in ns1
+					KeycloakRef: common.KeycloakRef{
+						Name: "test-keycloak",
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, duplicateObj)
+			Expect(err).Should(HaveOccurred(), "expected error when creating KeycloakRealm with duplicate RealmName in the same namespace")
+		})
+
+		It("Should deny creation with the same RealmName in a different namespace", func() {
+			objInNs2 := &keycloakApi.KeycloakRealm{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-realm-ns2",
+					Namespace: "ns2",
+				},
+				Spec: keycloakApi.KeycloakRealmSpec{
+					RealmName: "test-realm", // Same RealmName as the existing one but in a different namespace
+					KeycloakRef: common.KeycloakRef{
+						Name: "test-keycloak",
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, objInNs2)
+			Expect(err).Should(HaveOccurred(), "failed to create KeycloakRealm with same RealmName in different namespace")
+		})
+	})
+})

--- a/internal/webhook/v1/rbac.go
+++ b/internal/webhook/v1/rbac.go
@@ -1,0 +1,2 @@
+// +kubebuilder:rbac:groups=v1.edp.epam.com,resources=keycloakrealms,verbs=get;list;watch
+package v1

--- a/internal/webhook/v1/webhook_suite_test.go
+++ b/internal/webhook/v1/webhook_suite_test.go
@@ -1,0 +1,133 @@
+package v1
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/epam/edp-keycloak-operator/pkg/testutils"
+	// +kubebuilder:scaffold:imports
+)
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.Background())
+
+	var err error
+	err = keycloakApi.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook", "manifests.yaml")},
+		},
+		BinaryAssetsDirectory: testutils.GetFirstFoundEnvTestBinaryDir(),
+	}
+
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// start webhook server using Manager.
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = SetupKeycloakRealmWebhookWithManager(mgr, mgr.GetClient())
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:webhook
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// wait for the webhook server to get ready.
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+
+		return conn.Close()
+	}).Should(Succeed())
+
+	ns1 := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns1",
+		},
+	}
+	Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, &ns1))).Should(Succeed(), "failed to create namespace ns1")
+
+	ns2 := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns2",
+		},
+	}
+	Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, &ns2))).Should(Succeed(), "failed to create namespace ns2")
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/tests/e2e/helm-success-path/00-install-operator.yaml
+++ b/tests/e2e/helm-success-path/00-install-operator.yaml
@@ -1,5 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
+  - command: helm install cert-manager oci://quay.io/jetstack/charts/cert-manager --version v1.19.1 --namespace cert-manager --create-namespace --set crds.enabled=true --set prometheus.enabled=false --set prometheus.enabled=false
   - command: helm install --set image.repository=${CONTAINER_REGISTRY_URL}/${CONTAINER_REGISTRY_SPACE}/${E2E_IMAGE_REPOSITORY} --set image.tag=${E2E_IMAGE_TAG} --replace --wait keycloak-operator-e2e ../../../deploy-templates
     namespaced: true

--- a/tests/e2e/keycloak-selfsigned-certificates/00-install-operator.yaml
+++ b/tests/e2e/keycloak-selfsigned-certificates/00-install-operator.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: helm install --set image.repository=${CONTAINER_REGISTRY_URL}/${CONTAINER_REGISTRY_SPACE}/${E2E_IMAGE_REPOSITORY} --set image.tag=${E2E_IMAGE_TAG} --set clusterReconciliationEnabled=true --replace --wait keycloak-operator-e2e ../../../deploy-templates
+  - command: helm install --set image.repository=${CONTAINER_REGISTRY_URL}/${CONTAINER_REGISTRY_SPACE}/${E2E_IMAGE_REPOSITORY} --set image.tag=${E2E_IMAGE_TAG} --set clusterReconciliationEnabled=true --set enableWebhooks=false --replace --wait keycloak-operator-e2e ../../../deploy-templates
     namespaced: true


### PR DESCRIPTION
# Pull Request Template

## Description
Implement ValidatingWebhook for KeycloakRealm to enforce realm name uniqueness and immutability at admission time.
This prevents conflicts where multiple KeycloakRealm resources could reference the same realm name in Keycloak.

Key changes:
- Add ValidatingWebhook implementation with cluster-wide realm name uniqueness validation
- Add CEL validation rule to make RealmName field immutable
- Add webhook server configuration with cert-manager integration
- Add ENABLE_WEBHOOKS env variable to optionally disable webhooks
- Update Helm chart with enableWebhooks flag and webhook-related templates

**BREAKING CHANGE**: Webhook functionality now requires cert-manager to be installed in the cluster by default.
Users can disable webhooks by setting \`enableWebhooks: false\` in Helm values.

Fixes #259 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Integration tests

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.