### PR TITLE
feat: Add Type field to KeycloakClientScope for default/optional/none scopes

### DIFF
--- a/api/v1/keycloakclientscope_types.go
+++ b/api/v1/keycloakclientscope_types.go
@@ -6,6 +6,12 @@ import (
 	"github.com/epam/edp-keycloak-operator/api/common"
 )
 
+const (
+	KeycloakClientScopeTypeDefault  = "default"
+	KeycloakClientScopeTypeOptional = "optional"
+	KeycloakClientScopeTypeNone     = "none"
+)
+
 // KeycloakClientScopeSpec defines the desired state of KeycloakClientScope.
 type KeycloakClientScopeSpec struct {
 	// Name of keycloak client scope.
@@ -28,8 +34,18 @@ type KeycloakClientScopeSpec struct {
 	Attributes map[string]string `json:"attributes,omitempty"`
 
 	// Default is a flag to set client scope as default.
+	// Deprecated: Use Type: default instead.
 	// +optional
 	Default bool `json:"default,omitempty"`
+
+	// Type of the client scope.
+	// If set to "default", the client scope is assigned to all clients by default.
+	// If set to "optional", the client scope can be assigned to clients on demand.
+	// If set to "none", the client scope is not assigned to any clients by default.
+	// +kubebuilder:validation:Enum=default;optional;none
+	// +kubebuilder:default=none
+	// +optional
+	Type string `json:"type"`
 
 	// ProtocolMappers is a list of protocol mappers assigned to client scope.
 	// +nullable
@@ -81,6 +97,28 @@ func (in *KeycloakClientScope) SetStatus(value string) {
 
 func (in *KeycloakClientScope) GetRealmRef() common.RealmRef {
 	return in.Spec.RealmRef
+}
+
+// GetType returns the type of the client scope.
+// For backward compatibility, if Default is set to true, it returns "default".
+func (in *KeycloakClientScope) GetType() string {
+	if in.Spec.Default {
+		return KeycloakClientScopeTypeDefault
+	}
+
+	return in.Spec.Type
+}
+
+func (in *KeycloakClientScope) IsTypeDefault() bool {
+	return in.GetType() == KeycloakClientScopeTypeDefault
+}
+
+func (in *KeycloakClientScope) IsTypeOptional() bool {
+	return in.GetType() == KeycloakClientScopeTypeOptional
+}
+
+func (in *KeycloakClientScope) IsTypeNone() bool {
+	return in.GetType() == KeycloakClientScopeTypeNone
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/v1.edp.epam.com_keycloakclientscopes.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakclientscopes.yaml
@@ -52,7 +52,9 @@ spec:
                 nullable: true
                 type: object
               default:
-                description: Default is a flag to set client scope as default.
+                description: |-
+                  Default is a flag to set client scope as default.
+                  Deprecated: Use Type: default instead.
                 type: boolean
               description:
                 description: Description is a description of client scope.
@@ -103,6 +105,18 @@ spec:
                 required:
                 - name
                 type: object
+              type:
+                default: none
+                description: |-
+                  Type of the client scope.
+                  If set to "default", the client scope is assigned to all clients by default.
+                  If set to "optional", the client scope can be assigned to clients on demand.
+                  If set to "none", the client scope is not assigned to any clients by default.
+                enum:
+                - default
+                - optional
+                - none
+                type: string
             required:
             - name
             - protocol

--- a/config/samples/v1_v1_keycloakclientscope.yaml
+++ b/config/samples/v1_v1_keycloakclientscope.yaml
@@ -8,6 +8,7 @@ spec:
     name: keycloakrealm-sample
     kind: KeycloakRealm
   description: "Group Membership"
+  type: Default
   protocol: openid-connect
   protocolMappers:
     - name: groups

--- a/deploy-templates/_crd_examples/keycloakclientscope.yaml
+++ b/deploy-templates/_crd_examples/keycloakclientscope.yaml
@@ -8,6 +8,7 @@ spec:
     name: keycloakrealm-sample
     kind: KeycloakRealm
   description: "Group Membership"
+  type: default
   protocol: openid-connect
   protocolMappers:
     - name: groups

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakclientscopes.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakclientscopes.yaml
@@ -52,7 +52,9 @@ spec:
                 nullable: true
                 type: object
               default:
-                description: Default is a flag to set client scope as default.
+                description: |-
+                  Default is a flag to set client scope as default.
+                  Deprecated: Use Type: default instead.
                 type: boolean
               description:
                 description: Description is a description of client scope.
@@ -103,6 +105,18 @@ spec:
                 required:
                 - name
                 type: object
+              type:
+                default: none
+                description: |-
+                  Type of the client scope.
+                  If set to "default", the client scope is assigned to all clients by default.
+                  If set to "optional", the client scope can be assigned to clients on demand.
+                  If set to "none", the client scope is not assigned to any clients by default.
+                enum:
+                - default
+                - optional
+                - none
+                type: string
             required:
             - name
             - protocol

--- a/docs/api.md
+++ b/docs/api.md
@@ -3799,7 +3799,8 @@ KeycloakClientScopeSpec defines the desired state of KeycloakClientScope.
         <td><b>default</b></td>
         <td>boolean</td>
         <td>
-          Default is a flag to set client scope as default.<br/>
+          Default is a flag to set client scope as default.
+Deprecated: Use Type: default instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -3814,6 +3815,19 @@ KeycloakClientScopeSpec defines the desired state of KeycloakClientScope.
         <td>[]object</td>
         <td>
           ProtocolMappers is a list of protocol mappers assigned to client scope.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Type of the client scope.
+If set to "default", the client scope is assigned to all clients by default.
+If set to "optional", the client scope can be assigned to clients on demand.
+If set to "none", the client scope is not assigned to any clients by default.<br/>
+          <br/>
+            <i>Enum</i>: default, optional, none<br/>
+            <i>Default</i>: none<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/internal/controller/keycloakclientscope/keycloakclientscope_controller.go
+++ b/internal/controller/keycloakclientscope/keycloakclientscope_controller.go
@@ -187,7 +187,7 @@ func (r *Reconcile) updateKeycloakClientScopeStatus(
 }
 
 func syncClientScope(ctx context.Context, instance *keycloakApi.KeycloakClientScope, realmName string, cl keycloak.Client) (string, error) {
-	clientScope, err := cl.GetClientScope(instance.Spec.Name, realmName)
+	clientScope, err := cl.GetClientScope(ctx, instance.Spec.Name, realmName)
 	if err != nil && !adapter.IsErrNotFound(err) {
 		return "", fmt.Errorf("unable to get client scope: %w", err)
 	}
@@ -198,7 +198,7 @@ func syncClientScope(ctx context.Context, instance *keycloakApi.KeycloakClientSc
 		Protocol:        instance.Spec.Protocol,
 		ProtocolMappers: convertProtocolMappers(instance.Spec.ProtocolMappers),
 		Description:     instance.Spec.Description,
-		Default:         instance.Spec.Default,
+		Type:            instance.GetType(),
 	}
 
 	if err == nil {

--- a/internal/controller/keycloakclientscope/keycloakclientscope_controller_integration_test.go
+++ b/internal/controller/keycloakclientscope/keycloakclientscope_controller_integration_test.go
@@ -31,7 +31,7 @@ var _ = Describe("KeycloakClientScope controller", Ordered, func() {
 				Protocol:    "openid-connect",
 				Description: "Group Membership",
 				Attributes:  map[string]string{"include.in.token.scope": "true"},
-				Default:     false,
+				Type:        keycloakApi.KeycloakClientScopeTypeOptional,
 				ProtocolMappers: []keycloakApi.ProtocolMapper{{
 					Name:           "groups",
 					Protocol:       "openid-connect",
@@ -52,7 +52,22 @@ var _ = Describe("KeycloakClientScope controller", Ordered, func() {
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: scope.Name, Namespace: ns}, createdScope)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(createdScope.Status.Value).Should(Equal(common.StatusOK))
-		}).WithTimeout(time.Second * 20).WithPolling(time.Second).Should(Succeed())
+		}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
+
+		By("Verifying the client scope type via API")
+		Eventually(func(g Gomega) {
+			adapter := keycloakAdapterManager.GetAdapter()
+
+			// Verify scope is in optional list
+			hasOptional, err := adapter.HasOptionalClientScope(ctx, KeycloakRealmCR, "groups")
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(hasOptional).Should(BeTrue(), "scope should be in optional scopes list")
+
+			// Verify scope is NOT in default list
+			hasDefault, err := adapter.HasDefaultClientScope(ctx, KeycloakRealmCR, "groups")
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(hasDefault).Should(BeFalse(), "scope should NOT be in default scopes list")
+		}, timeout, interval).Should(Succeed())
 	})
 	It("Should update KeycloakClientScope", func() {
 		By("Getting KeycloakClientScope")
@@ -68,7 +83,7 @@ var _ = Describe("KeycloakClientScope controller", Ordered, func() {
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: createdScope.Name, Namespace: ns}, updatedScope)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(updatedScope.Status.Value).Should(Equal(common.StatusOK))
-		}, time.Second*5, time.Second).Should(Succeed())
+		}, time.Second*5, interval).Should(Succeed())
 	})
 	It("Should delete KeycloakClientScope", func() {
 		By("Getting KeycloakClientScope")
@@ -82,7 +97,7 @@ var _ = Describe("KeycloakClientScope controller", Ordered, func() {
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: createdScope.Name, Namespace: ns}, deletedScope)
 
 			g.Expect(k8sErrors.IsNotFound(err)).Should(BeTrue())
-		}, time.Second*30, time.Second).Should(Succeed())
+		}, timeout, interval).Should(Succeed())
 	})
 	It("Should fail to create KeycloakClientScope with invalid name", func() {
 		By("Creating a KeycloakClientScope")
@@ -98,19 +113,251 @@ var _ = Describe("KeycloakClientScope controller", Ordered, func() {
 				},
 				Name:     "invalid name with spaces",
 				Protocol: "openid-connect",
+				Type:     keycloakApi.KeycloakClientScopeTypeOptional,
 			},
 		}
 		Expect(k8sClient.Create(ctx, scope)).Should(Succeed())
 
-		By("Waiting for KeycloakClientScope reconciliation")
-		time.Sleep(time.Second * 3)
-
 		By("Checking KeycloakClientScope status")
+		Eventually(func(g Gomega) {
+			createdScope := &keycloakApi.KeycloakClientScope{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: scope.Name, Namespace: ns}, createdScope)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(createdScope.Status.Value).Should(ContainSubstring("unable to sync client scope"))
+		}, timeout, interval).Should(Succeed())
+
+		By("Verifying the error status persists")
 		Consistently(func(g Gomega) {
 			createdScope := &keycloakApi.KeycloakClientScope{}
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: scope.Name, Namespace: ns}, createdScope)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(createdScope.Status.Value).Should(ContainSubstring("unable to sync client scope"))
-		}).WithTimeout(time.Second * 3).WithPolling(time.Second).Should(Succeed())
+		}).WithTimeout(time.Second * 3).WithPolling(interval).Should(Succeed())
+	})
+
+	It("Should create KeycloakClientScope with type default", func() {
+		By("Creating a KeycloakClientScope with type default")
+		scope := &keycloakApi.KeycloakClientScope{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-client-scope-default",
+				Namespace: ns,
+			},
+			Spec: keycloakApi.KeycloakClientScopeSpec{
+				Name: "test-default-scope",
+				RealmRef: common.RealmRef{
+					Kind: keycloakApi.KeycloakRealmKind,
+					Name: KeycloakRealmCR,
+				},
+				Protocol:    "openid-connect",
+				Description: "Test default scope",
+				Type:        keycloakApi.KeycloakClientScopeTypeDefault,
+			},
+		}
+		Expect(k8sClient.Create(ctx, scope)).Should(Succeed())
+		Eventually(func(g Gomega) {
+			createdScope := &keycloakApi.KeycloakClientScope{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: scope.Name, Namespace: ns}, createdScope)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(createdScope.Status.Value).Should(Equal(common.StatusOK))
+		}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
+
+		By("Verifying the client scope is in default list via API")
+		Eventually(func(g Gomega) {
+			adapter := keycloakAdapterManager.GetAdapter()
+
+			// Verify scope is in default list
+			hasDefault, err := adapter.HasDefaultClientScope(ctx, KeycloakRealmCR, "test-default-scope")
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(hasDefault).Should(BeTrue(), "scope should be in default scopes list")
+
+			// Verify scope is NOT in optional list
+			hasOptional, err := adapter.HasOptionalClientScope(ctx, KeycloakRealmCR, "test-default-scope")
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(hasOptional).Should(BeFalse(), "scope should NOT be in optional scopes list")
+		}, timeout, interval).Should(Succeed())
+
+		By("Deleting the KeycloakClientScope")
+		Expect(k8sClient.Delete(ctx, scope)).Should(Succeed())
+		Eventually(func(g Gomega) {
+			deletedScope := &keycloakApi.KeycloakClientScope{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: scope.Name, Namespace: ns}, deletedScope)
+			g.Expect(k8sErrors.IsNotFound(err)).Should(BeTrue())
+		}, timeout, interval).Should(Succeed())
+	})
+
+	It("Should create KeycloakClientScope with type none", func() {
+		By("Creating a KeycloakClientScope with type none")
+		scope := &keycloakApi.KeycloakClientScope{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-client-scope-none",
+				Namespace: ns,
+			},
+			Spec: keycloakApi.KeycloakClientScopeSpec{
+				Name: "test-none-scope",
+				RealmRef: common.RealmRef{
+					Kind: keycloakApi.KeycloakRealmKind,
+					Name: KeycloakRealmCR,
+				},
+				Protocol:    "openid-connect",
+				Description: "Test none scope",
+				Type:        keycloakApi.KeycloakClientScopeTypeNone,
+			},
+		}
+		Expect(k8sClient.Create(ctx, scope)).Should(Succeed())
+		Eventually(func(g Gomega) {
+			createdScope := &keycloakApi.KeycloakClientScope{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: scope.Name, Namespace: ns}, createdScope)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(createdScope.Status.Value).Should(Equal(common.StatusOK))
+		}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
+
+		By("Verifying the client scope is in neither default nor optional list via API")
+		Eventually(func(g Gomega) {
+			adapter := keycloakAdapterManager.GetAdapter()
+
+			// Verify scope is NOT in default list
+			hasDefault, err := adapter.HasDefaultClientScope(ctx, KeycloakRealmCR, "test-none-scope")
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(hasDefault).Should(BeFalse(), "scope should NOT be in default scopes list")
+
+			// Verify scope is NOT in optional list
+			hasOptional, err := adapter.HasOptionalClientScope(ctx, KeycloakRealmCR, "test-none-scope")
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(hasOptional).Should(BeFalse(), "scope should NOT be in optional scopes list")
+		}, timeout, interval).Should(Succeed())
+
+		By("Deleting the KeycloakClientScope")
+		Expect(k8sClient.Delete(ctx, scope)).Should(Succeed())
+		Eventually(func(g Gomega) {
+			deletedScope := &keycloakApi.KeycloakClientScope{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: scope.Name, Namespace: ns}, deletedScope)
+			g.Expect(k8sErrors.IsNotFound(err)).Should(BeTrue())
+		}, timeout, interval).Should(Succeed())
+	})
+
+	It("Should update KeycloakClientScope type from optional to default", func() {
+		By("Creating a KeycloakClientScope with type optional")
+		scope := &keycloakApi.KeycloakClientScope{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-client-scope-update-opt-to-def",
+				Namespace: ns,
+			},
+			Spec: keycloakApi.KeycloakClientScopeSpec{
+				Name: "test-update-opt-def",
+				RealmRef: common.RealmRef{
+					Kind: keycloakApi.KeycloakRealmKind,
+					Name: KeycloakRealmCR,
+				},
+				Protocol:    "openid-connect",
+				Description: "Test update optional to default",
+				Type:        keycloakApi.KeycloakClientScopeTypeOptional,
+			},
+		}
+		Expect(k8sClient.Create(ctx, scope)).Should(Succeed())
+		Eventually(func(g Gomega) {
+			createdScope := &keycloakApi.KeycloakClientScope{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: scope.Name, Namespace: ns}, createdScope)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(createdScope.Status.Value).Should(Equal(common.StatusOK))
+		}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
+
+		By("Updating KeycloakClientScope type to default")
+		updatableScope := &keycloakApi.KeycloakClientScope{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: scope.Name, Namespace: ns}, updatableScope)).Should(Succeed())
+		updatableScope.Spec.Type = keycloakApi.KeycloakClientScopeTypeDefault
+		Expect(k8sClient.Update(ctx, updatableScope)).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			updatedScope := &keycloakApi.KeycloakClientScope{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: scope.Name, Namespace: ns}, updatedScope)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(updatedScope.Status.Value).Should(Equal(common.StatusOK))
+		}, timeout, interval).Should(Succeed())
+
+		By("Verifying the client scope is now in default list via API")
+		Eventually(func(g Gomega) {
+			adapter := keycloakAdapterManager.GetAdapter()
+
+			// Verify scope is in default list
+			hasDefault, err := adapter.HasDefaultClientScope(ctx, KeycloakRealmCR, "test-update-opt-def")
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(hasDefault).Should(BeTrue(), "scope should be in default scopes list")
+
+			// Verify scope is NOT in optional list
+			hasOptional, err := adapter.HasOptionalClientScope(ctx, KeycloakRealmCR, "test-update-opt-def")
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(hasOptional).Should(BeFalse(), "scope should NOT be in optional scopes list")
+		}, timeout, interval).Should(Succeed())
+
+		By("Deleting the KeycloakClientScope")
+		Expect(k8sClient.Delete(ctx, scope)).Should(Succeed())
+		Eventually(func(g Gomega) {
+			deletedScope := &keycloakApi.KeycloakClientScope{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: scope.Name, Namespace: ns}, deletedScope)
+			g.Expect(k8sErrors.IsNotFound(err)).Should(BeTrue())
+		}, timeout, interval).Should(Succeed())
+	})
+
+	It("Should update KeycloakClientScope type from default to none", func() {
+		By("Creating a KeycloakClientScope with type default")
+		scope := &keycloakApi.KeycloakClientScope{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-client-scope-update-def-to-none",
+				Namespace: ns,
+			},
+			Spec: keycloakApi.KeycloakClientScopeSpec{
+				Name: "test-update-def-none",
+				RealmRef: common.RealmRef{
+					Kind: keycloakApi.KeycloakRealmKind,
+					Name: KeycloakRealmCR,
+				},
+				Protocol:    "openid-connect",
+				Description: "Test update default to none",
+				Type:        keycloakApi.KeycloakClientScopeTypeDefault,
+			},
+		}
+		Expect(k8sClient.Create(ctx, scope)).Should(Succeed())
+		Eventually(func(g Gomega) {
+			createdScope := &keycloakApi.KeycloakClientScope{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: scope.Name, Namespace: ns}, createdScope)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(createdScope.Status.Value).Should(Equal(common.StatusOK))
+		}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
+
+		By("Updating KeycloakClientScope type to none")
+		updatableScope := &keycloakApi.KeycloakClientScope{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: scope.Name, Namespace: ns}, updatableScope)).Should(Succeed())
+		updatableScope.Spec.Type = keycloakApi.KeycloakClientScopeTypeNone
+		Expect(k8sClient.Update(ctx, updatableScope)).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			updatedScope := &keycloakApi.KeycloakClientScope{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: scope.Name, Namespace: ns}, updatedScope)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(updatedScope.Status.Value).Should(Equal(common.StatusOK))
+		}, timeout, interval).Should(Succeed())
+
+		By("Verifying the client scope is in neither default nor optional list via API")
+		Eventually(func(g Gomega) {
+			adapter := keycloakAdapterManager.GetAdapter()
+
+			// Verify scope is NOT in default list
+			hasDefault, err := adapter.HasDefaultClientScope(ctx, KeycloakRealmCR, "test-update-def-none")
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(hasDefault).Should(BeFalse(), "scope should NOT be in default scopes list")
+
+			// Verify scope is NOT in optional list
+			hasOptional, err := adapter.HasOptionalClientScope(ctx, KeycloakRealmCR, "test-update-def-none")
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(hasOptional).Should(BeFalse(), "scope should NOT be in optional scopes list")
+		}, timeout, interval).Should(Succeed())
+
+		By("Deleting the KeycloakClientScope")
+		Expect(k8sClient.Delete(ctx, scope)).Should(Succeed())
+		Eventually(func(g Gomega) {
+			deletedScope := &keycloakApi.KeycloakClientScope{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: scope.Name, Namespace: ns}, deletedScope)
+			g.Expect(k8sErrors.IsNotFound(err)).Should(BeTrue())
+		}, timeout, interval).Should(Succeed())
 	})
 })

--- a/internal/controller/keycloakclientscope/suite_test.go
+++ b/internal/controller/keycloakclientscope/suite_test.go
@@ -31,11 +31,12 @@ import (
 )
 
 var (
-	cfg       *rest.Config
-	k8sClient client.Client
-	testEnv   *envtest.Environment
-	ctx       context.Context
-	cancel    context.CancelFunc
+	cfg                    *rest.Config
+	k8sClient              client.Client
+	testEnv                *envtest.Environment
+	ctx                    context.Context
+	cancel                 context.CancelFunc
+	keycloakAdapterManager *testutils.KeycloakAdapterManager
 )
 
 const (
@@ -172,6 +173,9 @@ var _ = BeforeSuite(func() {
 
 		return createdKeycloakRealm.Status.Available
 	}, timeout, interval).Should(BeTrue())
+
+	keycloakAdapterManager = testutils.NewKeycloakAdapterManager(os.Getenv("TEST_KEYCLOAK_URL"), logf.Log)
+	keycloakAdapterManager.Initialize(ctx)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/client/keycloak/adapter/gocloak_adapter.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter.go
@@ -54,6 +54,9 @@ const (
 	putDefaultClientScope           = "/admin/realms/{realm}/default-default-client-scopes/{clientScopeID}"
 	deleteDefaultClientScope        = "/admin/realms/{realm}/default-default-client-scopes/{clientScopeID}"
 	getDefaultClientScopes          = "/admin/realms/{realm}/default-default-client-scopes"
+	putOptionalClientScope          = "/admin/realms/{realm}/default-optional-client-scopes/{clientScopeID}"
+	deleteOptionalClientScope       = "/admin/realms/{realm}/default-optional-client-scopes/{clientScopeID}"
+	getOptionalClientScopes         = "/admin/realms/{realm}/default-optional-client-scopes"
 	realmEventConfigPut             = "/admin/realms/{realm}/events/config"
 	realmComponent                  = "/admin/realms/{realm}/components"
 	realmComponentEntity            = "/admin/realms/{realm}/components/{id}"
@@ -148,7 +151,8 @@ func MakeFromToken(conf GoCloakConfig, tokenData []byte, log logr.Logger) (*GoCl
 		return nil, fmt.Errorf("unable to decode JWT payload json: %w", err)
 	}
 
-	if tokenPayloadDecoded.Exp < time.Now().Unix() {
+	now := time.Now().Unix()
+	if tokenPayloadDecoded.Exp < now {
 		return nil, TokenExpiredError("token is expired")
 	}
 

--- a/pkg/client/keycloak/keycloak_client.go
+++ b/pkg/client/keycloak/keycloak_client.go
@@ -179,11 +179,14 @@ type KCloakClients interface {
 
 type KCloakClientScope interface {
 	PutClientScopeMapper(realmName, scopeID string, protocolMapper *adapter.ProtocolMapper) error
-	GetClientScope(scopeName, realmName string) (*adapter.ClientScope, error)
+	GetClientScope(ctx context.Context, scopeName, realmName string) (*adapter.ClientScope, error)
 	GetClientScopesByNames(ctx context.Context, realmName string, scopeNames []string) ([]adapter.ClientScope, error)
 	UpdateClientScope(ctx context.Context, realmName, scopeID string, scope *adapter.ClientScope) error
 	DeleteClientScope(ctx context.Context, realmName, scopeID string) error
 	GetDefaultClientScopesForRealm(ctx context.Context, realm string) ([]adapter.ClientScope, error)
+	GetOptionalClientScopesForRealm(ctx context.Context, realm string) ([]adapter.ClientScope, error)
+	HasDefaultClientScope(ctx context.Context, realmName, scopeName string) (bool, error)
+	HasOptionalClientScope(ctx context.Context, realmName, scopeName string) (bool, error)
 	CreateClientScope(ctx context.Context, realmName string, scope *adapter.ClientScope) (string, error)
 	GetClientScopeMappers(ctx context.Context, realmName, scopeID string) ([]adapter.ProtocolMapper, error)
 	GetClientScopes(ctx context.Context, realm string) (map[string]gocloak.ClientScope, error)

--- a/pkg/client/keycloak/mocks/client_generated.mock.go
+++ b/pkg/client/keycloak/mocks/client_generated.mock.go
@@ -2831,8 +2831,8 @@ func (_c *MockClient_GetClientManagementPermissions_Call) RunAndReturn(run func(
 }
 
 // GetClientScope provides a mock function for the type MockClient
-func (_mock *MockClient) GetClientScope(scopeName string, realmName string) (*adapter.ClientScope, error) {
-	ret := _mock.Called(scopeName, realmName)
+func (_mock *MockClient) GetClientScope(ctx context.Context, scopeName string, realmName string) (*adapter.ClientScope, error) {
+	ret := _mock.Called(ctx, scopeName, realmName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetClientScope")
@@ -2840,18 +2840,18 @@ func (_mock *MockClient) GetClientScope(scopeName string, realmName string) (*ad
 
 	var r0 *adapter.ClientScope
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) (*adapter.ClientScope, error)); ok {
-		return returnFunc(scopeName, realmName)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*adapter.ClientScope, error)); ok {
+		return returnFunc(ctx, scopeName, realmName)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) *adapter.ClientScope); ok {
-		r0 = returnFunc(scopeName, realmName)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *adapter.ClientScope); ok {
+		r0 = returnFunc(ctx, scopeName, realmName)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*adapter.ClientScope)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = returnFunc(scopeName, realmName)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, scopeName, realmName)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2864,25 +2864,31 @@ type MockClient_GetClientScope_Call struct {
 }
 
 // GetClientScope is a helper method to define mock.On call
+//   - ctx context.Context
 //   - scopeName string
 //   - realmName string
-func (_e *MockClient_Expecter) GetClientScope(scopeName interface{}, realmName interface{}) *MockClient_GetClientScope_Call {
-	return &MockClient_GetClientScope_Call{Call: _e.mock.On("GetClientScope", scopeName, realmName)}
+func (_e *MockClient_Expecter) GetClientScope(ctx interface{}, scopeName interface{}, realmName interface{}) *MockClient_GetClientScope_Call {
+	return &MockClient_GetClientScope_Call{Call: _e.mock.On("GetClientScope", ctx, scopeName, realmName)}
 }
 
-func (_c *MockClient_GetClientScope_Call) Run(run func(scopeName string, realmName string)) *MockClient_GetClientScope_Call {
+func (_c *MockClient_GetClientScope_Call) Run(run func(ctx context.Context, scopeName string, realmName string)) *MockClient_GetClientScope_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -2893,7 +2899,7 @@ func (_c *MockClient_GetClientScope_Call) Return(clientScope *adapter.ClientScop
 	return _c
 }
 
-func (_c *MockClient_GetClientScope_Call) RunAndReturn(run func(scopeName string, realmName string) (*adapter.ClientScope, error)) *MockClient_GetClientScope_Call {
+func (_c *MockClient_GetClientScope_Call) RunAndReturn(run func(ctx context.Context, scopeName string, realmName string) (*adapter.ClientScope, error)) *MockClient_GetClientScope_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3664,6 +3670,74 @@ func (_c *MockClient_GetOpenIdConfig_Call) Return(s string, err error) *MockClie
 }
 
 func (_c *MockClient_GetOpenIdConfig_Call) RunAndReturn(run func(realm *dto.Realm) (string, error)) *MockClient_GetOpenIdConfig_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetOptionalClientScopesForRealm provides a mock function for the type MockClient
+func (_mock *MockClient) GetOptionalClientScopesForRealm(ctx context.Context, realm string) ([]adapter.ClientScope, error) {
+	ret := _mock.Called(ctx, realm)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOptionalClientScopesForRealm")
+	}
+
+	var r0 []adapter.ClientScope
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]adapter.ClientScope, error)); ok {
+		return returnFunc(ctx, realm)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []adapter.ClientScope); ok {
+		r0 = returnFunc(ctx, realm)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]adapter.ClientScope)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, realm)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_GetOptionalClientScopesForRealm_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOptionalClientScopesForRealm'
+type MockClient_GetOptionalClientScopesForRealm_Call struct {
+	*mock.Call
+}
+
+// GetOptionalClientScopesForRealm is a helper method to define mock.On call
+//   - ctx context.Context
+//   - realm string
+func (_e *MockClient_Expecter) GetOptionalClientScopesForRealm(ctx interface{}, realm interface{}) *MockClient_GetOptionalClientScopesForRealm_Call {
+	return &MockClient_GetOptionalClientScopesForRealm_Call{Call: _e.mock.On("GetOptionalClientScopesForRealm", ctx, realm)}
+}
+
+func (_c *MockClient_GetOptionalClientScopesForRealm_Call) Run(run func(ctx context.Context, realm string)) *MockClient_GetOptionalClientScopesForRealm_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_GetOptionalClientScopesForRealm_Call) Return(clientScopes []adapter.ClientScope, err error) *MockClient_GetOptionalClientScopesForRealm_Call {
+	_c.Call.Return(clientScopes, err)
+	return _c
+}
+
+func (_c *MockClient_GetOptionalClientScopesForRealm_Call) RunAndReturn(run func(ctx context.Context, realm string) ([]adapter.ClientScope, error)) *MockClient_GetOptionalClientScopesForRealm_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -4670,6 +4744,150 @@ func (_c *MockClient_GetUsersProfile_Call) Return(v *keycloak_go_client.UserProf
 }
 
 func (_c *MockClient_GetUsersProfile_Call) RunAndReturn(run func(ctx context.Context, realm string) (*keycloak_go_client.UserProfileConfig, error)) *MockClient_GetUsersProfile_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// HasDefaultClientScope provides a mock function for the type MockClient
+func (_mock *MockClient) HasDefaultClientScope(ctx context.Context, realmName string, scopeName string) (bool, error) {
+	ret := _mock.Called(ctx, realmName, scopeName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasDefaultClientScope")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (bool, error)); ok {
+		return returnFunc(ctx, realmName, scopeName)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) bool); ok {
+		r0 = returnFunc(ctx, realmName, scopeName)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, realmName, scopeName)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_HasDefaultClientScope_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasDefaultClientScope'
+type MockClient_HasDefaultClientScope_Call struct {
+	*mock.Call
+}
+
+// HasDefaultClientScope is a helper method to define mock.On call
+//   - ctx context.Context
+//   - realmName string
+//   - scopeName string
+func (_e *MockClient_Expecter) HasDefaultClientScope(ctx interface{}, realmName interface{}, scopeName interface{}) *MockClient_HasDefaultClientScope_Call {
+	return &MockClient_HasDefaultClientScope_Call{Call: _e.mock.On("HasDefaultClientScope", ctx, realmName, scopeName)}
+}
+
+func (_c *MockClient_HasDefaultClientScope_Call) Run(run func(ctx context.Context, realmName string, scopeName string)) *MockClient_HasDefaultClientScope_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_HasDefaultClientScope_Call) Return(b bool, err error) *MockClient_HasDefaultClientScope_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockClient_HasDefaultClientScope_Call) RunAndReturn(run func(ctx context.Context, realmName string, scopeName string) (bool, error)) *MockClient_HasDefaultClientScope_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// HasOptionalClientScope provides a mock function for the type MockClient
+func (_mock *MockClient) HasOptionalClientScope(ctx context.Context, realmName string, scopeName string) (bool, error) {
+	ret := _mock.Called(ctx, realmName, scopeName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasOptionalClientScope")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (bool, error)); ok {
+		return returnFunc(ctx, realmName, scopeName)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) bool); ok {
+		r0 = returnFunc(ctx, realmName, scopeName)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, realmName, scopeName)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_HasOptionalClientScope_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasOptionalClientScope'
+type MockClient_HasOptionalClientScope_Call struct {
+	*mock.Call
+}
+
+// HasOptionalClientScope is a helper method to define mock.On call
+//   - ctx context.Context
+//   - realmName string
+//   - scopeName string
+func (_e *MockClient_Expecter) HasOptionalClientScope(ctx interface{}, realmName interface{}, scopeName interface{}) *MockClient_HasOptionalClientScope_Call {
+	return &MockClient_HasOptionalClientScope_Call{Call: _e.mock.On("HasOptionalClientScope", ctx, realmName, scopeName)}
+}
+
+func (_c *MockClient_HasOptionalClientScope_Call) Run(run func(ctx context.Context, realmName string, scopeName string)) *MockClient_HasOptionalClientScope_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_HasOptionalClientScope_Call) Return(b bool, err error) *MockClient_HasOptionalClientScope_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockClient_HasOptionalClientScope_Call) RunAndReturn(run func(ctx context.Context, realmName string, scopeName string) (bool, error)) *MockClient_HasOptionalClientScope_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5714,75 +5932,6 @@ func (_c *MockClient_SyncRealmRole_Call) Return(err error) *MockClient_SyncRealm
 }
 
 func (_c *MockClient_SyncRealmRole_Call) RunAndReturn(run func(ctx context.Context, realmName string, role *dto.PrimaryRealmRole) error) *MockClient_SyncRealmRole_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// SyncRealmUser provides a mock function for the type MockClient
-func (_mock *MockClient) SyncRealmUser(ctx context.Context, realmName string, user *adapter.KeycloakUser, addOnly bool) error {
-	ret := _mock.Called(ctx, realmName, user, addOnly)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SyncRealmUser")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *adapter.KeycloakUser, bool) error); ok {
-		r0 = returnFunc(ctx, realmName, user, addOnly)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockClient_SyncRealmUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SyncRealmUser'
-type MockClient_SyncRealmUser_Call struct {
-	*mock.Call
-}
-
-// SyncRealmUser is a helper method to define mock.On call
-//   - ctx context.Context
-//   - realmName string
-//   - user *adapter.KeycloakUser
-//   - addOnly bool
-func (_e *MockClient_Expecter) SyncRealmUser(ctx interface{}, realmName interface{}, user interface{}, addOnly interface{}) *MockClient_SyncRealmUser_Call {
-	return &MockClient_SyncRealmUser_Call{Call: _e.mock.On("SyncRealmUser", ctx, realmName, user, addOnly)}
-}
-
-func (_c *MockClient_SyncRealmUser_Call) Run(run func(ctx context.Context, realmName string, user *adapter.KeycloakUser, addOnly bool)) *MockClient_SyncRealmUser_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 *adapter.KeycloakUser
-		if args[2] != nil {
-			arg2 = args[2].(*adapter.KeycloakUser)
-		}
-		var arg3 bool
-		if args[3] != nil {
-			arg3 = args[3].(bool)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-		)
-	})
-	return _c
-}
-
-func (_c *MockClient_SyncRealmUser_Call) Return(err error) *MockClient_SyncRealmUser_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockClient_SyncRealmUser_Call) RunAndReturn(run func(ctx context.Context, realmName string, user *adapter.KeycloakUser, addOnly bool) error) *MockClient_SyncRealmUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/testutils/keycloak_adapter_manager.go
+++ b/pkg/testutils/keycloak_adapter_manager.go
@@ -1,0 +1,81 @@
+package testutils
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/Nerzal/gocloak/v12"
+	"github.com/go-logr/logr"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak/adapter"
+)
+
+// KeycloakAdapterManager manages a Keycloak adapter with token refresh.
+type KeycloakAdapterManager struct {
+	adapter      *adapter.GoCloakAdapter
+	config       adapter.GoCloakConfig
+	log          logr.Logger
+	adapterMutex sync.Mutex
+}
+
+// NewKeycloakAdapterManager creates a new Keycloak adapter manager.
+func NewKeycloakAdapterManager(keycloakURL string, log logr.Logger) *KeycloakAdapterManager {
+	return &KeycloakAdapterManager{
+		config: adapter.GoCloakConfig{
+			Url:      keycloakURL,
+			User:     "admin",
+			Password: "admin",
+		},
+		log: log,
+	}
+}
+
+// Initialize sets up the initial adapter and starts the token refresh goroutine.
+func (m *KeycloakAdapterManager) Initialize(ctx context.Context) {
+	m.refreshAdapter(ctx)
+
+	// Refresh adapter every 30 seconds to prevent token expiration
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		defer ginkgo.GinkgoRecover()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				m.refreshAdapter(ctx)
+			}
+		}
+	}()
+}
+
+// GetAdapter returns the current adapter in a thread-safe manner.
+func (m *KeycloakAdapterManager) GetAdapter() *adapter.GoCloakAdapter {
+	m.adapterMutex.Lock()
+	defer m.adapterMutex.Unlock()
+
+	return m.adapter
+}
+
+// refreshAdapter creates a new adapter with a fresh token.
+func (m *KeycloakAdapterManager) refreshAdapter(ctx context.Context) {
+	client := gocloak.NewClient(m.config.Url)
+	token, err := client.LoginAdmin(ctx, m.config.User, m.config.Password, "master")
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to login to keycloak")
+
+	tokenData, err := json.Marshal(token)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to marshal token")
+
+	newAdapter, err := adapter.MakeFromToken(m.config, tokenData, m.log)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create adapter")
+
+	m.adapterMutex.Lock()
+	m.adapter = newAdapter
+	m.adapterMutex.Unlock()
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,4 +3,4 @@ sonar.projectName=keycloak-operator
 sonar.projectVersion=1.0
 sonar.go.coverage.reportPaths=coverage.out
 sonar.test.inclusions=**/*_test.go
-sonar.exclusions=**/config/**,**/deploy-templates/**,**/factory.go,**/*_generated.*go,**/*_mock.go,**/mock_*.go,**/.github/**,**/api/**,**/tests/**,**/hack/**,**/bundle/**,**/main.go
+sonar.exclusions=**/config/**,**/deploy-templates/**,**/factory.go,**/*_generated.*go,**/*_mock.go,**/mock_*.go,**/.github/**,**/api/**,**/tests/**,**/hack/**,**/bundle/**,**/main.go,**/testutils/**


### PR DESCRIPTION
# Pull Request Template

## Description
Replace the boolean Default field with a more flexible Type field that supports three values: "default", "optional", and "none". This aligns with Keycloak's native client scope type system and provides better control over scope assignment. The Default field is now deprecated but remains functional for backward compatibility.

Fixes #220 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Unit tests
- Integration tests
- Manually

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.