### PR TITLE
fix: Proceed to next group in list if SubGroups is an empty slice

### DIFF
--- a/pkg/client/keycloak/adapter/gocloak_adapter_groups.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_groups.go
@@ -106,7 +106,9 @@ func getGroupByName(groups []gocloak.Group, groupName string) *gocloak.Group {
 		}
 
 		if g.SubGroups != nil {
-			return getGroupByName(*g.SubGroups, groupName)
+			if group := getGroupByName(*g.SubGroups, groupName); group != nil {
+				return group
+			}
 		}
 	}
 

--- a/pkg/client/keycloak/adapter/gocloak_adapter_groups_test.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_groups_test.go
@@ -196,10 +196,20 @@ func TestGetGroupByName(t *testing.T) {
 			name: "find group by name",
 			groups: []gocloak.Group{
 				{Name: gocloak.StringP("group1")},
-				{Name: gocloak.StringP("group2")},
+				{
+					Name: gocloak.StringP("group2"),
+					SubGroups: &[]gocloak.Group{
+						{Name: gocloak.StringP("child1")},
+					},
+				},
 			},
 			groupName: "group2",
-			want:      &gocloak.Group{Name: gocloak.StringP("group2")},
+			want: &gocloak.Group{
+				Name: gocloak.StringP("group2"),
+				SubGroups: &[]gocloak.Group{
+					{Name: gocloak.StringP("child1")},
+				},
+			},
 		},
 		{
 			name: "find group in subgroups",


### PR DESCRIPTION
# Pull Request Template

## Description

During the `getGroupByName` function  `g.SubGroups` can not be nil and return an empty slice, which the recursive `getGroupByName` function call will return early instead of proceeding to the next group in the original `groups` list. This occurs when there are two groups returned via the `GetGroups` API call, and one of them has a child group and another one does not.

Fixes #268

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

Create a parent group and a child group from the issue

```
apiVersion: v1.edp.epam.com/v1
kind: KeycloakRealmGroup
metadata:
  name: system
  namespace: infra-system
spec:
  name: system
  realmRef:
    kind: KeycloakRealm
    name: infra
---
apiVersion: v1.edp.epam.com/v1
kind: KeycloakRealmGroup
metadata:
  name: system-no-children
  namespace: infra-system
spec:
  name: system_no_children
  realmRef:
    kind: KeycloakRealm
    name: infra
---
apiVersion: v1.edp.epam.com/v1
kind: KeycloakRealmGroup
metadata:
  name: child
  namespace: infra-system
spec:
  name: child
  realmRef:
    kind: KeycloakRealm
    name: infra
  parentGroup:
    name: system
```

Ensure there are no errors creating the CRs.

## Checklist:
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Pull Request contains one commit. I squash my commits.