### PR TITLE
feat: add cluster domain for DNS name construction in kubernetes serv…

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -130,6 +130,7 @@ Development versions are also available from the [snapshot helm chart repository
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for pod assignment |
 | annotations | object | `{}` | Annotations to be added to the Deployment |
+| clusterDomain | string | `"cluster.local"` | Cluster domain for constructing service DNS names |
 | clusterReconciliationEnabled | bool | `false` | If clusterReconciliationEnabled is true, the operator reconciles all Keycloak instances in the cluster;  otherwise, it only reconciles instances in the same namespace by default, and cluster-scoped resources are ignored. |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Container Security Context Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | enableOwnerRef | bool | `true` | If set to true, the operator will set the owner reference for all resources that have Keycloak or KeycloakRealm as reference. This is legacy behavior and not recommended for use. In the future, this will be set to false by default. |

--- a/deploy-templates/templates/webhook/certmanager.yaml
+++ b/deploy-templates/templates/webhook/certmanager.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   dnsNames:
   - {{ .Values.name }}-webhook-service.{{ .Release.Namespace }}.svc
-  - {{ .Values.name }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  - {{ .Values.name }}-webhook-service.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
   issuerRef:
     kind: Issuer
     name: {{ .Values.name }}-selfsigned-issuer

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -2,6 +2,8 @@
 name: keycloak-operator
 # -- Annotations to be added to the Deployment
 annotations: {}
+# -- Cluster domain for constructing service DNS names
+clusterDomain: cluster.local
 # -- Labels to be added to the pod
 podLabels: {}
 # -- Node labels for pod assignment


### PR DESCRIPTION
# Pull Request

## Description
This feature add possibility to change cluster dns name due generating certificate for weebhook
(with 1 commit)

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- change value for .Values.clusterDomain and deploy via 
```sh
helm upgrade --install keycloak-operator 
```
- check that `kind: Certificate` has correct service name

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):

## Additional context
Add any other context or screenshots about the feature request here.