### PR TITLE
refactor: add golangci-lint gofmt rewrite rule to enforce the use of `any`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -53,3 +53,8 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+  settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: 'interface{}'
+          replacement: 'any'

--- a/internal/controller/clusterkeycloakrealm/chain/auth_flow_test.go
+++ b/internal/controller/clusterkeycloakrealm/chain/auth_flow_test.go
@@ -68,7 +68,7 @@ func TestAuthFlow_ServeRequest(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "setting realm browser flow")
 			},

--- a/internal/controller/clusterkeycloakrealm/chain/put_realm_test.go
+++ b/internal/controller/clusterkeycloakrealm/chain/put_realm_test.go
@@ -77,7 +77,7 @@ func TestPutRealm_ServeRequest(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to check realm existence")
 			},
@@ -98,7 +98,7 @@ func TestPutRealm_ServeRequest(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to create realm")
 			},

--- a/internal/controller/helper/controller_helper_auth_test.go
+++ b/internal/controller/helper/controller_helper_auth_test.go
@@ -321,7 +321,7 @@ func TestMakeKeycloakAuthDataFromKeycloak(t *testing.T) {
 			k8sClient: func(t *testing.T) client.Client {
 				return fake.NewClientBuilder().Build()
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unable to get secret")
 			},
@@ -346,7 +346,7 @@ func TestMakeKeycloakAuthDataFromKeycloak(t *testing.T) {
 			k8sClient: func(t *testing.T) client.Client {
 				return fake.NewClientBuilder().Build()
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unable to get configmap")
 			},
@@ -496,7 +496,7 @@ func TestHelper_createKeycloakClientFromLoginPassword(t *testing.T) {
 					tokenSecretLock: &sync.Mutex{},
 				}
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unable to get credentials")
 			},
@@ -530,7 +530,7 @@ func TestHelper_createKeycloakClientFromLoginPassword(t *testing.T) {
 					tokenSecretLock: &sync.Mutex{},
 				}
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unable to init authData client adapter")
 			},
@@ -567,7 +567,7 @@ func TestHelper_createKeycloakClientFromLoginPassword(t *testing.T) {
 					tokenSecretLock: &sync.Mutex{},
 				}
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unable to export authData client token")
 			},
@@ -689,7 +689,7 @@ func TestHelper_createKeycloakClientFromLoginPassword(t *testing.T) {
 					tokenSecretLock: &sync.Mutex{},
 				}
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unable to save authData token to secret")
 			},
@@ -1043,7 +1043,7 @@ func TestHelper_CreateKeycloakClientV2FromRealm(t *testing.T) {
 				},
 			},
 			objects: []client.Object{},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unable to get keycloak")
 			},
@@ -1081,7 +1081,7 @@ func TestHelper_CreateKeycloakClientV2FromRealm(t *testing.T) {
 					},
 				},
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.ErrorIs(t, err, ErrKeycloakIsNotAvailable)
 			},
@@ -1119,7 +1119,7 @@ func TestHelper_CreateKeycloakClientV2FromRealm(t *testing.T) {
 					},
 				},
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unable to get credentials")
 			},
@@ -1143,7 +1143,7 @@ func TestHelper_CreateKeycloakClientV2FromRealm(t *testing.T) {
 				},
 			},
 			objects: []client.Object{},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unable to get keycloak")
 			},
@@ -1541,7 +1541,7 @@ func TestHelper_CreateKeycloakClientV2FromClusterRealm(t *testing.T) {
 				},
 			},
 			objects: []client.Object{},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unable to get cluster keycloak")
 			},
@@ -1574,7 +1574,7 @@ func TestHelper_CreateKeycloakClientV2FromClusterRealm(t *testing.T) {
 					},
 				},
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.ErrorIs(t, err, ErrKeycloakIsNotAvailable)
 			},
@@ -1607,7 +1607,7 @@ func TestHelper_CreateKeycloakClientV2FromClusterRealm(t *testing.T) {
 					},
 				},
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unable to get credentials")
 			},

--- a/internal/controller/helper/controller_helper_test.go
+++ b/internal/controller/helper/controller_helper_test.go
@@ -484,7 +484,7 @@ func TestHelper_GetRealmNameFromRef(t *testing.T) {
 					},
 				},
 			},
-			wantErr: func(t require.TestingT, err error, _ ...interface{}) {
+			wantErr: func(t require.TestingT, err error, _ ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unknown realm kind: UnknownKind")
 			},

--- a/internal/controller/keycloakclient/chain/process_permissions_test.go
+++ b/internal/controller/keycloakclient/chain/process_permissions_test.go
@@ -281,7 +281,7 @@ func TestProcessPermissions_Serve(t *testing.T) {
 
 				return client
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to delete permission")
 			},
@@ -340,7 +340,7 @@ func TestProcessPermissions_Serve(t *testing.T) {
 
 				return client
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to update permission")
 			},
@@ -394,7 +394,7 @@ func TestProcessPermissions_Serve(t *testing.T) {
 
 				return client
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to create permission")
 			},
@@ -439,7 +439,7 @@ func TestProcessPermissions_Serve(t *testing.T) {
 
 				return client
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to get policies")
 			},
@@ -477,7 +477,7 @@ func TestProcessPermissions_Serve(t *testing.T) {
 
 				return client
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to get resources")
 			},
@@ -508,7 +508,7 @@ func TestProcessPermissions_Serve(t *testing.T) {
 
 				return client
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to get permissions")
 			},
@@ -537,7 +537,7 @@ func TestProcessPermissions_Serve(t *testing.T) {
 
 				return client
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to get client id")
 			},

--- a/internal/controller/keycloakclient/chain/process_policy_test.go
+++ b/internal/controller/keycloakclient/chain/process_policy_test.go
@@ -342,7 +342,7 @@ func TestProcessPolicy_Serve(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to delete policy")
 			},
@@ -388,7 +388,7 @@ func TestProcessPolicy_Serve(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to update policy")
 			},
@@ -430,7 +430,7 @@ func TestProcessPolicy_Serve(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to create policy")
 			},
@@ -464,7 +464,7 @@ func TestProcessPolicy_Serve(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to convert policy")
 			},
@@ -498,7 +498,7 @@ func TestProcessPolicy_Serve(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to get policies")
 			},
@@ -530,7 +530,7 @@ func TestProcessPolicy_Serve(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to get client id")
 			},

--- a/internal/controller/keycloakclient/chain/process_resources_test.go
+++ b/internal/controller/keycloakclient/chain/process_resources_test.go
@@ -256,7 +256,7 @@ func TestProcessResources_Serve(t *testing.T) {
 
 				return client
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to delete resource")
 			},
@@ -299,7 +299,7 @@ func TestProcessResources_Serve(t *testing.T) {
 
 				return client
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to update resource")
 			},
@@ -337,7 +337,7 @@ func TestProcessResources_Serve(t *testing.T) {
 
 				return client
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to create resource")
 			},
@@ -369,7 +369,7 @@ func TestProcessResources_Serve(t *testing.T) {
 
 				return client
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to get scopes")
 			},
@@ -397,7 +397,7 @@ func TestProcessResources_Serve(t *testing.T) {
 
 				return client
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to get resources")
 			},
@@ -423,7 +423,7 @@ func TestProcessResources_Serve(t *testing.T) {
 
 				return client
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to get client id")
 			},

--- a/internal/controller/keycloakclient/chain/put_protocol_mappers_test.go
+++ b/internal/controller/keycloakclient/chain/put_protocol_mappers_test.go
@@ -318,7 +318,7 @@ func TestPutProtocolMappers_Serve(t *testing.T) {
 					return m
 				},
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unable to put protocol mappers")
 				require.Contains(t, err.Error(), "unable to sync protocol mapper")
@@ -352,8 +352,8 @@ func TestPutProtocolMappers_Serve(t *testing.T) {
 }
 
 // mockMatchProtocolMappers is a helper function to match protocol mappers slice in mock calls
-func mockMatchProtocolMappers(expectedCount int) interface{} {
-	return mock.MatchedBy(func(mappers interface{}) bool {
+func mockMatchProtocolMappers(expectedCount int) any {
+	return mock.MatchedBy(func(mappers any) bool {
 		if mappers == nil {
 			return expectedCount == 0
 		}

--- a/internal/controller/keycloakrealm/chain/configure_email_test.go
+++ b/internal/controller/keycloakrealm/chain/configure_email_test.go
@@ -151,7 +151,7 @@ func TestConfigureEmail_ServeRequest(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unable to get password")
 			},
@@ -186,7 +186,7 @@ func TestConfigureEmail_ServeRequest(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "realm not found")
 			},

--- a/internal/controller/keycloakrealm/chain/user_profile.go
+++ b/internal/controller/keycloakrealm/chain/user_profile.go
@@ -166,7 +166,7 @@ func userProfileConfigGroupSpecToModel(v common.UserProfileGroup) keycloakv2.Use
 		Name:               &v.Name,
 	}
 
-	annotations := make(map[string]interface{}, len(v.Annotations))
+	annotations := make(map[string]any, len(v.Annotations))
 	for ak, av := range v.Annotations {
 		annotations[ak] = av
 	}
@@ -191,7 +191,7 @@ func userProfileConfigAttributeSpecToModel(v *common.UserProfileAttribute) keycl
 		attr.Group = &v.Group
 	}
 
-	annotations := make(map[string]interface{}, len(v.Annotations))
+	annotations := make(map[string]any, len(v.Annotations))
 	for ak, av := range v.Annotations {
 		annotations[ak] = av
 	}
@@ -233,11 +233,11 @@ func userProfileConfigAttributeSpecToModel(v *common.UserProfileAttribute) keycl
 	return attr
 }
 
-func userProfileConfigValidationSpecToModel(validations map[string]map[string]common.UserProfileAttributeValidation) map[string]map[string]interface{} {
-	model := make(map[string]map[string]interface{}, len(validations))
+func userProfileConfigValidationSpecToModel(validations map[string]map[string]common.UserProfileAttributeValidation) map[string]map[string]any {
+	model := make(map[string]map[string]any, len(validations))
 
 	for validatorName, validatorVal := range validations {
-		val := make(map[string]interface{}, len(validatorVal))
+		val := make(map[string]any, len(validatorVal))
 
 		for k, v := range validatorVal {
 			if v.StringVal != "" {

--- a/internal/controller/keycloakrealm/chain/user_profile_test.go
+++ b/internal/controller/keycloakrealm/chain/user_profile_test.go
@@ -98,10 +98,10 @@ func TestUserProfileConfigSpecToModel(t *testing.T) {
 						Selector: &keycloakv2.UserProfileAttributeSelector{
 							Scopes: &[]string{"scope"},
 						},
-						Annotations: &map[string]interface{}{
+						Annotations: &map[string]any{
 							"inputType": "text",
 						},
-						Validations: &map[string]map[string]interface{}{
+						Validations: &map[string]map[string]any{
 							"email": {
 								"max-local-length": 64,
 							},
@@ -118,7 +118,7 @@ func TestUserProfileConfigSpecToModel(t *testing.T) {
 				},
 				Groups: &[]keycloakv2.UserProfileGroup{
 					{
-						Annotations:        &map[string]interface{}{"group": "test"},
+						Annotations:        &map[string]any{"group": "test"},
 						DisplayDescription: ptr.To("Group description"),
 						DisplayHeader:      ptr.To("Group header"),
 						Name:               ptr.To("Group"),

--- a/internal/controller/keycloakrealmuser/chain/create_or_update_user_test.go
+++ b/internal/controller/keycloakrealmuser/chain/create_or_update_user_test.go
@@ -209,7 +209,7 @@ func TestCreateOrUpdateUser_Serve(t *testing.T) {
 					false,
 				).Return("", errors.New("keycloak api error"))
 			},
-			wantErr: func(t require.TestingT, err error, _ ...interface{}) {
+			wantErr: func(t require.TestingT, err error, _ ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to create or update user: keycloak api error")
 			},

--- a/internal/controller/keycloakrealmuser/chain/set_user_password_test.go
+++ b/internal/controller/keycloakrealmuser/chain/set_user_password_test.go
@@ -352,7 +352,7 @@ func TestSetUserPassword_Serve(t *testing.T) {
 				Realm: gocloak.StringP("test-realm"),
 			},
 			mockSetup: func(m *keycloakmocks.MockClient) {},
-			wantErr: func(t require.TestingT, err error, _ ...interface{}) {
+			wantErr: func(t require.TestingT, err error, _ ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to get secret")
 			},
@@ -390,7 +390,7 @@ func TestSetUserPassword_Serve(t *testing.T) {
 				},
 			},
 			mockSetup: func(m *keycloakmocks.MockClient) {},
-			wantErr: func(t require.TestingT, err error, _ ...interface{}) {
+			wantErr: func(t require.TestingT, err error, _ ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "key wrong-key not found in secret")
 			},
@@ -439,7 +439,7 @@ func TestSetUserPassword_Serve(t *testing.T) {
 					},
 				).Return(errors.New("keycloak error"))
 			},
-			wantErr: func(t require.TestingT, err error, _ ...interface{}) {
+			wantErr: func(t require.TestingT, err error, _ ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to set user password")
 			},

--- a/internal/controller/keycloakrealmuser/chain/sync_user_groups_test.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_groups_test.go
@@ -171,7 +171,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 					false,
 				).Return(errors.New("keycloak api error"))
 			},
-			wantErr: func(t require.TestingT, err error, _ ...interface{}) {
+			wantErr: func(t require.TestingT, err error, _ ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to sync user groups: keycloak api error")
 			},

--- a/internal/controller/keycloakrealmuser/chain/sync_user_identity_providers_test.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_identity_providers_test.go
@@ -164,7 +164,7 @@ func TestSyncUserIdentityProviders_Serve(t *testing.T) {
 					[]string{"idp1"},
 				).Return(errors.New("keycloak api error"))
 			},
-			wantErr: func(t require.TestingT, err error, _ ...interface{}) {
+			wantErr: func(t require.TestingT, err error, _ ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to sync user identity providers: keycloak api error")
 			},

--- a/internal/controller/keycloakrealmuser/chain/sync_user_roles_test.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_roles_test.go
@@ -219,7 +219,7 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 					false,
 				).Return(errors.New("keycloak api error"))
 			},
-			wantErr: func(t require.TestingT, err error, _ ...interface{}) {
+			wantErr: func(t require.TestingT, err error, _ ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to sync user roles: keycloak api error")
 			},

--- a/pkg/client/keycloak/adapter/gocloak_adapter_groups_test.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_groups_test.go
@@ -1015,7 +1015,7 @@ func TestGoCloakAdapter_DeleteGroup(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, _ ...interface{}) {
+			wantErr: func(t require.TestingT, err error, _ ...any) {
 				// This test should panic due to nil pointer dereference
 				// We'll handle this in the test runner
 			},

--- a/pkg/client/keycloak/adapter/gocloak_adapter_realms.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_realms.go
@@ -350,8 +350,8 @@ func (a GoCloakAdapter) SyncRealmIdentityProviderMappers(realmName string, mappe
 	return nil
 }
 
-func decodeIdentityProviderMapper(mp interface{}) (*dto.IdentityProviderMapper, bool) {
-	mapInterface, ok := mp.(map[string]interface{})
+func decodeIdentityProviderMapper(mp any) (*dto.IdentityProviderMapper, bool) {
+	mapInterface, ok := mp.(map[string]any)
 	if !ok {
 		return nil, false
 	}
@@ -385,7 +385,7 @@ func decodeIdentityProviderMapper(mp interface{}) (*dto.IdentityProviderMapper, 
 	}
 
 	if configRaw, ok := mapInterface["config"]; ok {
-		if configInterface, ok := configRaw.(map[string]interface{}); ok {
+		if configInterface, ok := configRaw.(map[string]any); ok {
 			for k, v := range configInterface {
 				if value, ok := v.(string); ok {
 					mapper.Config[k] = value

--- a/pkg/client/keycloak/adapter/gocloak_adapter_realms_test.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_realms_test.go
@@ -292,8 +292,8 @@ func TestGoCloakAdapter_SyncRealmIdentityProviderMappers(t *testing.T) {
 	realmName := "sso-realm-1"
 	idpAlias := "alias-1"
 
-	mappers := []interface{}{
-		map[string]interface{}{
+	mappers := []any{
+		map[string]any{
 			keycloakApiParamId: currentMapperID,
 			"name":             "mp1name",
 		},
@@ -416,7 +416,7 @@ func TestGoCloakAdapter_GetRealm(t *testing.T) {
 				return m
 			},
 			want: nil,
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "realm not found")
 			},
@@ -496,7 +496,7 @@ func setupOrganizationToggleServer(realmName string, currentOrgEnabled bool) *ht
 				"{realm}", realmName,
 			).Replace(realmEntity)
 			if r.URL.Path == expectedPath {
-				response := map[string]interface{}{
+				response := map[string]any{
 					"realm":                realmName,
 					"organizationsEnabled": currentOrgEnabled,
 				}
@@ -559,7 +559,7 @@ func TestGoCloakAdapter_SetRealmOrganizationsEnabled(t *testing.T) {
 						"{realm}", "test-realm",
 					).Replace(realmEntity)
 					if r.Method == http.MethodGet && r.URL.Path == expectedPath {
-						response := map[string]interface{}{
+						response := map[string]any{
 							"realm":                "test-realm",
 							"organizationsEnabled": true,
 						}
@@ -583,7 +583,7 @@ func TestGoCloakAdapter_SetRealmOrganizationsEnabled(t *testing.T) {
 						"{realm}", "test-realm",
 					).Replace(realmEntity)
 					if r.Method == http.MethodGet && r.URL.Path == expectedPath {
-						response := map[string]interface{}{
+						response := map[string]any{
 							"realm":                "test-realm",
 							"organizationsEnabled": false,
 						}
@@ -628,7 +628,7 @@ func TestGoCloakAdapter_SetRealmOrganizationsEnabled(t *testing.T) {
 							"{realm}", "test-realm",
 						).Replace(realmEntity)
 						if r.URL.Path == expectedPath {
-							response := map[string]interface{}{
+							response := map[string]any{
 								"realm":                "test-realm",
 								"organizationsEnabled": false,
 							}

--- a/pkg/client/keycloak/adapter/gocloak_adapter_roles_test.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_roles_test.go
@@ -198,7 +198,7 @@ func TestGoCloakAdapter_SyncRealmRole(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to delete composite roles")
 			},
@@ -246,7 +246,7 @@ func TestGoCloakAdapter_SyncRealmRole(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to add composite roles")
 			},
@@ -285,7 +285,7 @@ func TestGoCloakAdapter_SyncRealmRole(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to get associated role")
 			},
@@ -324,7 +324,7 @@ func TestGoCloakAdapter_SyncRealmRole(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to get associated client role")
 			},
@@ -357,7 +357,7 @@ func TestGoCloakAdapter_SyncRealmRole(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to get client")
 			},
@@ -387,7 +387,7 @@ func TestGoCloakAdapter_SyncRealmRole(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to get current composite roles")
 			},
@@ -460,7 +460,7 @@ func TestGoCloakAdapter_SyncRealmRole(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to update role")
 			},
@@ -486,7 +486,7 @@ func TestGoCloakAdapter_SyncRealmRole(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to create role")
 			},
@@ -504,7 +504,7 @@ func TestGoCloakAdapter_SyncRealmRole(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to get role")
 			},
@@ -553,7 +553,7 @@ func TestGoCloakAdapter_SyncRealmRole(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to make role default")
 			},

--- a/pkg/client/keycloak/adapter/gocloak_adapter_service_account_test.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_service_account_test.go
@@ -138,7 +138,7 @@ func TestGoCloakAdapter_SetServiceAccountAttributes(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to get client service account")
 				assert.Contains(t, err.Error(), "service account not found")
@@ -165,7 +165,7 @@ func TestGoCloakAdapter_SetServiceAccountAttributes(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to update service account user: clientID1")
 				assert.Contains(t, err.Error(), "update failed")
@@ -325,7 +325,7 @@ func TestGoCloakAdapter_SyncServiceAccountRoles(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to get service account")
 			},
@@ -352,7 +352,7 @@ func TestGoCloakAdapter_SyncServiceAccountRoles(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to get role mapping")
 			},
@@ -384,7 +384,7 @@ func TestGoCloakAdapter_SyncServiceAccountRoles(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to get realm role")
 			},
@@ -416,7 +416,7 @@ func TestGoCloakAdapter_SyncServiceAccountRoles(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to get clients")
 			},
@@ -453,7 +453,7 @@ func TestGoCloakAdapter_SyncServiceAccountRoles(t *testing.T) {
 
 				return m
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to get client role")
 			},

--- a/pkg/client/keycloak/adapter/gocloak_adapter_test.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_test.go
@@ -93,7 +93,7 @@ func (e *AdapterTestSuite) TestMakeFromServiceAccount() {
 			mockServer: fakehttp.NewServerBuilder().
 				AddStringResponderWithCode(http.StatusBadRequest, authPath+realmsEndpoint, "{}").
 				BuildAndStart(),
-			wantErr: func(t require.TestingT, err error, _ ...interface{}) {
+			wantErr: func(t require.TestingT, err error, _ ...any) {
 				require.Error(t, err)
 				require.EqualError(
 					t,
@@ -153,7 +153,7 @@ func (e *AdapterTestSuite) TestMake() {
 		{
 			name:       "should fail on unsupported protocol scheme",
 			mockServer: nil,
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unsupported protocol scheme")
 			},
@@ -163,7 +163,7 @@ func (e *AdapterTestSuite) TestMake() {
 			mockServer: fakehttp.NewServerBuilder().
 				AddStringResponderWithCode(http.StatusBadRequest, authPath+realmsEndpoint, "{}").
 				BuildAndStart(),
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "400")
 			},
@@ -579,7 +579,7 @@ func TestMakeFromToken(t *testing.T) {
 		name       string
 		token      string
 		mockServer fakehttp.Server
-		wantErr    func(require.TestingT, error, ...interface{})
+		wantErr    func(require.TestingT, error, ...any)
 	}{
 		{
 			name:  "should succeed",
@@ -587,7 +587,7 @@ func TestMakeFromToken(t *testing.T) {
 			mockServer: fakehttp.NewServerBuilder().
 				AddStringResponder("/admin/realms/", "{}").
 				BuildAndStart(),
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.NoError(t, err)
 
 				cl, ok := i[0].(*GoCloakAdapter)
@@ -608,7 +608,7 @@ func TestMakeFromToken(t *testing.T) {
 			mockServer: fakehttp.NewServerBuilder().
 				AddStringResponder("/auth/admin/realms/", "{}").
 				BuildAndStart(),
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.NoError(t, err)
 
 				cl, ok := i[0].(*GoCloakAdapter)
@@ -627,7 +627,7 @@ func TestMakeFromToken(t *testing.T) {
 			name:       "should fail on expired token",
 			token:      expiredToken,
 			mockServer: nil,
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.True(t, IsErrTokenExpired(err) || err.Error() == "token is expired")
 			},
@@ -636,7 +636,7 @@ func TestMakeFromToken(t *testing.T) {
 			name:       "should fail on wrong token structure",
 			token:      "foo.bar",
 			mockServer: nil,
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "wrong JWT token structure")
 			},
@@ -645,7 +645,7 @@ func TestMakeFromToken(t *testing.T) {
 			name:       "should fail on wrong token encoding",
 			token:      "foo.bar .baz",
 			mockServer: nil,
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "wrong JWT token base64 encoding")
 			},
@@ -654,7 +654,7 @@ func TestMakeFromToken(t *testing.T) {
 			name:       "should fail on decoding json payload",
 			token:      "foo.bar.baz",
 			mockServer: nil,
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "unable to decode JWT payload json")
 			},
@@ -846,7 +846,7 @@ func TestGoCloakAdapter_GetUsersByNames(t *testing.T) {
 				return mockClient
 			},
 			names: []string{"user1", "user2"},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "fatal")
 			},
@@ -937,7 +937,7 @@ func TestGoCloakAdapter_CreatePrimaryRealmRole(t *testing.T) {
 				return m
 			},
 			want: "",
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "failed to get role")
 			},

--- a/pkg/client/keycloak/adapter/gocloak_adapter_user.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_user.go
@@ -309,7 +309,7 @@ func (a GoCloakAdapter) SetUserPassword(realmName, userID string, password *Keyc
 			keycloakApiParamRealm: realmName,
 			keycloakApiParamId:    userID,
 		}).
-		SetBody(map[string]interface{}{
+		SetBody(map[string]any{
 			"temporary": password.Temporary,
 			"type":      "password",
 			"value":     password.Value,

--- a/pkg/client/keycloak/adapter/gocloak_adapter_user_test.go
+++ b/pkg/client/keycloak/adapter/gocloak_adapter_user_test.go
@@ -396,7 +396,7 @@ func TestGoCloakAdapter_CreateOrUpdateUser(t *testing.T) {
 				return m
 			},
 			wantID: "",
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "connection error")
 			},
@@ -419,7 +419,7 @@ func TestGoCloakAdapter_CreateOrUpdateUser(t *testing.T) {
 				return m
 			},
 			wantID: "",
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "user already exists")
 			},
@@ -445,7 +445,7 @@ func TestGoCloakAdapter_CreateOrUpdateUser(t *testing.T) {
 				return m
 			},
 			wantID: "",
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "update failed")
 			},

--- a/pkg/client/keycloak/adapter/serverinfo_test.go
+++ b/pkg/client/keycloak/adapter/serverinfo_test.go
@@ -155,7 +155,7 @@ func TestGoCloakAdapter_GetServerInfo_ErrorScenarios(t *testing.T) {
 			name:           "server returns 500 error",
 			serverResponse: `{"error":"internal server error"}`,
 			statusCode:     http.StatusInternalServerError,
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to get server info")
 				assert.Contains(t, err.Error(), "500")
@@ -165,7 +165,7 @@ func TestGoCloakAdapter_GetServerInfo_ErrorScenarios(t *testing.T) {
 			name:           "server returns 401 unauthorized",
 			serverResponse: `{"error":"unauthorized"}`,
 			statusCode:     http.StatusUnauthorized,
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to get server info")
 				assert.Contains(t, err.Error(), "401")
@@ -175,7 +175,7 @@ func TestGoCloakAdapter_GetServerInfo_ErrorScenarios(t *testing.T) {
 			name:           "server returns 403 forbidden",
 			serverResponse: `{"error":"forbidden"}`,
 			statusCode:     http.StatusForbidden,
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to get server info")
 				assert.Contains(t, err.Error(), "403")
@@ -185,7 +185,7 @@ func TestGoCloakAdapter_GetServerInfo_ErrorScenarios(t *testing.T) {
 			name:           "server returns invalid JSON",
 			serverResponse: `{"invalid": json}`,
 			statusCode:     http.StatusOK,
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to get server info")
 			},
@@ -194,7 +194,7 @@ func TestGoCloakAdapter_GetServerInfo_ErrorScenarios(t *testing.T) {
 			name:           "server returns empty response",
 			serverResponse: ``,
 			statusCode:     http.StatusOK,
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to get server info")
 			},
@@ -378,7 +378,7 @@ func TestGoCloakAdapter_FeatureFlagEnabled_ErrorScenarios(t *testing.T) {
 			statusCode:     http.StatusInternalServerError,
 			featureFlag:    "ADMIN_FINE_GRAINED_AUTHZ",
 			expected:       false,
-			expectedErr: func(t require.TestingT, err error, i ...interface{}) {
+			expectedErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to get server info")
 			},
@@ -389,7 +389,7 @@ func TestGoCloakAdapter_FeatureFlagEnabled_ErrorScenarios(t *testing.T) {
 			statusCode:     http.StatusUnauthorized,
 			featureFlag:    "ADMIN_FINE_GRAINED_AUTHZ",
 			expected:       false,
-			expectedErr: func(t require.TestingT, err error, i ...interface{}) {
+			expectedErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to get server info")
 			},
@@ -400,7 +400,7 @@ func TestGoCloakAdapter_FeatureFlagEnabled_ErrorScenarios(t *testing.T) {
 			statusCode:     http.StatusOK,
 			featureFlag:    "ADMIN_FINE_GRAINED_AUTHZ",
 			expected:       false,
-			expectedErr: func(t require.TestingT, err error, i ...interface{}) {
+			expectedErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to get server info")
 			},
@@ -411,7 +411,7 @@ func TestGoCloakAdapter_FeatureFlagEnabled_ErrorScenarios(t *testing.T) {
 			statusCode:     http.StatusOK,
 			featureFlag:    "ADMIN_FINE_GRAINED_AUTHZ",
 			expected:       false,
-			expectedErr: func(t require.TestingT, err error, i ...interface{}) {
+			expectedErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to get server info")
 			},

--- a/pkg/client/keycloak/mock/mock_logger.go
+++ b/pkg/client/keycloak/mock/mock_logger.go
@@ -8,7 +8,7 @@ func NewLogr() logr.Logger {
 
 type Logger struct {
 	errors       []error
-	infoMessages map[string][]interface{}
+	infoMessages map[string][]any
 }
 
 // Init implements logr.LogSink.
@@ -16,15 +16,15 @@ func (log *Logger) Init(logr.RuntimeInfo) {
 }
 
 // Info implements logr.InfoLogger.
-func (l *Logger) Info(level int, msg string, keysAndValues ...interface{}) {
+func (l *Logger) Info(level int, msg string, keysAndValues ...any) {
 	if l.infoMessages == nil {
-		l.infoMessages = make(map[string][]interface{})
+		l.infoMessages = make(map[string][]any)
 	}
 
 	l.infoMessages[msg] = keysAndValues
 }
 
-func (l *Logger) InfoMessages() map[string][]interface{} {
+func (l *Logger) InfoMessages() map[string][]any {
 	return l.infoMessages
 }
 
@@ -33,7 +33,7 @@ func (Logger) Enabled(level int) bool {
 	return true
 }
 
-func (l *Logger) Error(err error, msg string, keysAndValues ...interface{}) {
+func (l *Logger) Error(err error, msg string, keysAndValues ...any) {
 	l.errors = append(l.errors, err)
 }
 
@@ -51,6 +51,6 @@ func (log *Logger) WithName(_ string) logr.LogSink {
 }
 
 // WithValues implements logr.Logger.
-func (log *Logger) WithValues(_ ...interface{}) logr.LogSink {
+func (log *Logger) WithValues(_ ...any) logr.LogSink {
 	return log
 }

--- a/pkg/fakehttp/server.go
+++ b/pkg/fakehttp/server.go
@@ -66,7 +66,7 @@ func (b *ServerBuilder) AddKeycloakAuthRespondersForRealm(realm string) *ServerB
 	}
 
 	b.fakeServer.addJsonResponder(http.StatusOK, "/realms/"+realm+"/protocol/openid-connect/token", tokenResponse)
-	b.fakeServer.addJsonResponder(http.StatusOK, "/admin/realms/"+realm, map[string]interface{}{})
+	b.fakeServer.addJsonResponder(http.StatusOK, "/admin/realms/"+realm, map[string]any{})
 
 	return b
 }

--- a/pkg/fakehttp/server_test.go
+++ b/pkg/fakehttp/server_test.go
@@ -161,7 +161,7 @@ func TestDefaultFakeServer_Close(t *testing.T) {
 	tests := []struct {
 		name             string
 		createFakeServer func() *DefaultServer
-		wantPanic        func(t require.TestingT, f assert.PanicTestFunc, _ ...interface{})
+		wantPanic        func(t require.TestingT, f assert.PanicTestFunc, _ ...any)
 	}{
 		{
 			name: "should close",
@@ -197,7 +197,7 @@ func TestDefaultFakeServer_GetURL(t *testing.T) {
 	tests := []struct {
 		name             string
 		createFakeServer func() *DefaultServer
-		wantPanic        func(t require.TestingT, f assert.PanicTestFunc, _ ...interface{})
+		wantPanic        func(t require.TestingT, f assert.PanicTestFunc, _ ...any)
 	}{
 		{
 			name: "should return URL",
@@ -271,7 +271,7 @@ func TestServerBuilder_AddKeycloakAuthResponders(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, tokenResp.StatusCode)
 
-			var tokenBody map[string]interface{}
+			var tokenBody map[string]any
 			err = json.NewDecoder(tokenResp.Body).Decode(&tokenBody)
 			require.NoError(t, err)
 			assert.Equal(t, "test-access-token", tokenBody["access_token"])
@@ -284,7 +284,7 @@ func TestServerBuilder_AddKeycloakAuthResponders(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, adminResp.StatusCode)
 
-			var adminBody map[string]interface{}
+			var adminBody map[string]any
 			err = json.NewDecoder(adminResp.Body).Decode(&adminBody)
 			require.NoError(t, err)
 			assert.Empty(t, adminBody)

--- a/pkg/secretref/secretref_test.go
+++ b/pkg/secretref/secretref_test.go
@@ -89,7 +89,7 @@ func TestSecretRef_MapComponentConfigSecretsRefs(t *testing.T) {
 					},
 				).Build()
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "does not contain key")
 			},
@@ -110,7 +110,7 @@ func TestSecretRef_MapComponentConfigSecretsRefs(t *testing.T) {
 
 				return fake.NewClientBuilder().WithScheme(s).Build()
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to get secret")
 			},
@@ -131,7 +131,7 @@ func TestSecretRef_MapComponentConfigSecretsRefs(t *testing.T) {
 
 				return fake.NewClientBuilder().WithScheme(s).Build()
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "invalid config secret  reference")
 			},
@@ -228,7 +228,7 @@ func TestSecretRef_MapConfigSecretsRefs(t *testing.T) {
 					},
 				).Build()
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "does not contain key")
 			},
@@ -249,7 +249,7 @@ func TestSecretRef_MapConfigSecretsRefs(t *testing.T) {
 
 				return fake.NewClientBuilder().WithScheme(s).Build()
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to get secret")
 			},
@@ -270,7 +270,7 @@ func TestSecretRef_MapConfigSecretsRefs(t *testing.T) {
 
 				return fake.NewClientBuilder().WithScheme(s).Build()
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+			wantErr: func(t require.TestingT, err error, i ...any) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "invalid config secret  reference")
 			},


### PR DESCRIPTION
Replace all `interface{}` occurrences with the `any` builtin type alias across the codebase to align with modern Go style.