### PR TITLE
feat: support hierarchical group paths in user groups

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,9 @@
     "go.testEnvVars": {
         "KUBEBUILDER_ASSETS": "${workspaceFolder}/bin/k8s/1.33.0-darwin-arm64",
         "TEST_KEYCLOAK_URL": "http://localhost:8086"
+    },
+    "chat.tools.terminal.autoApprove": {
+        "make": true,
+        "go": true
     }
 }

--- a/api/v1/keycloakrealmuser_types.go
+++ b/api/v1/keycloakrealmuser_types.go
@@ -51,8 +51,12 @@ type KeycloakRealmUserSpec struct {
 	ClientRoles []UserClientRole `json:"clientRoles,omitempty"`
 
 	// Groups is a list of groups assigned to user.
+	// Each entry is either a plain group name (e.g. "developers") or a slash-separated
+	// path (e.g. "/developers", "/parent/child"), where each segment represents a level
+	// in the group hierarchy.
 	// +nullable
 	// +optional
+	// +kubebuilder:example={"developers","/parent/child"}
 	Groups []string `json:"groups,omitempty"`
 
 	// Attributes is a map of user attributes.

--- a/config/crd/bases/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/config/crd/bases/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -152,6 +152,8 @@ spec:
                 description: PasswordPolicies is a list of password policies to apply
                   to the realm.
                 items:
+                  description: PasswordPolicy defines a single password policy rule
+                    for a realm.
                   properties:
                     type:
                       description: Type of password policy.
@@ -187,6 +189,7 @@ spec:
                     description: EnabledEventTypes is a list of event types to enable.
                     items:
                       type: string
+                    nullable: true
                     type: array
                   eventsEnabled:
                     description: EventsEnabled indicates whether to enable events.
@@ -199,6 +202,7 @@ spec:
                     description: EventsListeners is a list of event listeners to enable.
                     items:
                       type: string
+                    nullable: true
                     type: array
                 type: object
               realmName:

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
@@ -154,6 +154,8 @@ spec:
                 description: PasswordPolicies is a list of password policies to apply
                   to the realm.
                 items:
+                  description: PasswordPolicy defines a single password policy rule
+                    for a realm.
                   properties:
                     type:
                       description: Type of password policy.
@@ -189,6 +191,7 @@ spec:
                     description: EnabledEventTypes is a list of event types to enable.
                     items:
                       type: string
+                    nullable: true
                     type: array
                   eventsEnabled:
                     description: EventsEnabled indicates whether to enable events.
@@ -201,6 +204,7 @@ spec:
                     description: EventsListeners is a list of event listeners to enable.
                     items:
                       type: string
+                    nullable: true
                     type: array
                 type: object
               realmName:

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml
@@ -94,7 +94,14 @@ spec:
                 description: FirstName is a user first name.
                 type: string
               groups:
-                description: Groups is a list of groups assigned to user.
+                description: |-
+                  Groups is a list of groups assigned to user.
+                  Each entry is either a plain group name (e.g. "developers") or a slash-separated
+                  path (e.g. "/developers", "/parent/child"), where each segment represents a level
+                  in the group hierarchy.
+                example:
+                - developers
+                - /parent/child
                 items:
                   type: string
                 nullable: true

--- a/config/samples/v1_v1_keycloakrealmuser.yaml
+++ b/config/samples/v1_v1_keycloakrealmuser.yaml
@@ -22,6 +22,9 @@ spec:
   attributesV2:
     department: ["IT"]
     location: ["Winterfell"]
+  groups:
+    - developers
+    - /parent/child
 
 ---
 apiVersion: v1

--- a/deploy-templates/_crd_examples/keycloakrealmuser.yaml
+++ b/deploy-templates/_crd_examples/keycloakrealmuser.yaml
@@ -19,6 +19,9 @@ spec:
     temporary: true
   requiredUserActions:
     - UPDATE_PROFILE
+  groups:
+    - developers
+    - /parent/child
   attributesV2:
     department: ["IT"]
     location: ["Winterfell"]

--- a/deploy-templates/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -152,6 +152,8 @@ spec:
                 description: PasswordPolicies is a list of password policies to apply
                   to the realm.
                 items:
+                  description: PasswordPolicy defines a single password policy rule
+                    for a realm.
                   properties:
                     type:
                       description: Type of password policy.
@@ -187,6 +189,7 @@ spec:
                     description: EnabledEventTypes is a list of event types to enable.
                     items:
                       type: string
+                    nullable: true
                     type: array
                   eventsEnabled:
                     description: EventsEnabled indicates whether to enable events.
@@ -199,6 +202,7 @@ spec:
                     description: EventsListeners is a list of event listeners to enable.
                     items:
                       type: string
+                    nullable: true
                     type: array
                 type: object
               realmName:

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
@@ -154,6 +154,8 @@ spec:
                 description: PasswordPolicies is a list of password policies to apply
                   to the realm.
                 items:
+                  description: PasswordPolicy defines a single password policy rule
+                    for a realm.
                   properties:
                     type:
                       description: Type of password policy.
@@ -189,6 +191,7 @@ spec:
                     description: EnabledEventTypes is a list of event types to enable.
                     items:
                       type: string
+                    nullable: true
                     type: array
                   eventsEnabled:
                     description: EventsEnabled indicates whether to enable events.
@@ -201,6 +204,7 @@ spec:
                     description: EventsListeners is a list of event listeners to enable.
                     items:
                       type: string
+                    nullable: true
                     type: array
                 type: object
               realmName:

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml
@@ -94,7 +94,14 @@ spec:
                 description: FirstName is a user first name.
                 type: string
               groups:
-                description: Groups is a list of groups assigned to user.
+                description: |-
+                  Groups is a list of groups assigned to user.
+                  Each entry is either a plain group name (e.g. "developers") or a slash-separated
+                  path (e.g. "/developers", "/parent/child"), where each segment represents a level
+                  in the group hierarchy.
+                example:
+                - developers
+                - /parent/child
                 items:
                   type: string
                 nullable: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -367,7 +367,7 @@ Login settings for the realm.
 
 
 
-
+PasswordPolicy defines a single password policy rule for a realm.
 
 <table>
     <thead>
@@ -5901,7 +5901,7 @@ Login settings for the realm.
 
 
 
-
+PasswordPolicy defines a single password policy rule for a realm.
 
 <table>
     <thead>
@@ -7299,7 +7299,10 @@ Each attribute can have multiple values.<br/>
         <td><b>groups</b></td>
         <td>[]string</td>
         <td>
-          Groups is a list of groups assigned to user.<br/>
+          Groups is a list of groups assigned to user.
+Each entry is either a plain group name (e.g. "developers") or a slash-separated
+path (e.g. "/developers", "/parent/child"), where each segment represents a level
+in the group hierarchy.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/internal/controller/keycloakrealmuser/chain/chain.go
+++ b/internal/controller/keycloakrealmuser/chain/chain.go
@@ -10,6 +10,7 @@ import (
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak"
+	keycloakv2 "github.com/epam/edp-keycloak-operator/pkg/client/keycloakv2"
 )
 
 // UserContext holds data that is passed between chain handlers.
@@ -66,6 +67,7 @@ func (ch *Chain) Serve(
 
 func MakeChain(
 	k8sClient client.Client,
+	kClientV2 *keycloakv2.KeycloakClient,
 ) *Chain {
 	ch := &Chain{}
 
@@ -73,7 +75,7 @@ func MakeChain(
 		NewCreateOrUpdateUser(k8sClient),
 		NewSetUserPassword(k8sClient),
 		NewSyncUserRoles(),
-		NewSyncUserGroups(),
+		NewSyncUserGroups(kClientV2),
 		NewSyncUserIdentityProviders(),
 		NewCleanupResource(k8sClient),
 	)

--- a/internal/controller/keycloakrealmuser/chain/sync_user_groups.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_groups.go
@@ -3,38 +3,136 @@ package chain
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Nerzal/gocloak/v12"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak"
+	keycloakv2 "github.com/epam/edp-keycloak-operator/pkg/client/keycloakv2"
 )
 
-type SyncUserGroups struct{}
+type SyncUserGroups struct {
+	kClientV2 *keycloakv2.KeycloakClient
+}
 
-func NewSyncUserGroups() *SyncUserGroups {
-	return &SyncUserGroups{}
+func NewSyncUserGroups(kClientV2 *keycloakv2.KeycloakClient) *SyncUserGroups {
+	return &SyncUserGroups{kClientV2: kClientV2}
+}
+
+// resolvedGroup holds a Keycloak group identity resolved from a spec entry.
+type resolvedGroup struct {
+	id   string
+	name string
+	path string
+}
+
+// label returns a human-readable identifier for the group (path if available, otherwise name).
+func (g resolvedGroup) label() string {
+	if g.path != "" {
+		return g.path
+	}
+
+	return g.name
 }
 
 func (h *SyncUserGroups) Serve(
 	ctx context.Context,
 	user *keycloakApi.KeycloakRealmUser,
-	kClient keycloak.Client,
+	_ keycloak.Client,
 	realm *gocloak.RealmRepresentation,
 	userCtx *UserContext,
 ) error {
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Syncing user groups")
 
-	if err := kClient.SyncUserGroups(
-		ctx,
-		gocloak.PString(realm.Realm),
-		userCtx.UserID,
-		user.Spec.Groups,
-		user.IsReconciliationStrategyAddOnly(),
-	); err != nil {
-		return fmt.Errorf("unable to sync user groups: %w", err)
+	if len(user.Spec.Groups) == 0 && user.IsReconciliationStrategyAddOnly() {
+		log.Info("No groups specified (add-only), skipping")
+		return nil
+	}
+
+	realmName := ptr.Deref(realm.Realm, "")
+
+	currentGroups, _, err := h.kClientV2.Users.GetUserGroups(ctx, realmName, userCtx.UserID)
+	if err != nil {
+		return fmt.Errorf("unable to get user groups: %w", err)
+	}
+
+	desired := make([]resolvedGroup, 0, len(user.Spec.Groups))
+
+	for _, g := range user.Spec.Groups {
+		if strings.HasPrefix(g, "/") {
+			grp, _, err := h.kClientV2.Groups.GetGroupByPath(ctx, realmName, g)
+			if err != nil {
+				return fmt.Errorf("unable to get group by path %q: %w", g, err)
+			}
+
+			if grp == nil || grp.Id == nil {
+				return fmt.Errorf("group not found by path %q", g)
+			}
+
+			desired = append(desired, resolvedGroup{id: *grp.Id, path: g})
+		} else {
+			grp, _, err := h.kClientV2.Groups.FindGroupByName(ctx, realmName, g)
+			if err != nil {
+				return fmt.Errorf("unable to find group by name %q: %w", g, err)
+			}
+
+			if grp == nil || grp.Id == nil {
+				return fmt.Errorf("group not found by name %q", g)
+			}
+
+			desired = append(desired, resolvedGroup{id: *grp.Id, name: g})
+		}
+	}
+
+	// build lookup of current group IDs
+	currentByID := make(map[string]keycloakv2.GroupRepresentation, len(currentGroups))
+
+	for _, cg := range currentGroups {
+		if cg.Id != nil {
+			currentByID[*cg.Id] = cg
+		}
+	}
+
+	// add missing groups
+	for _, dg := range desired {
+		if _, exists := currentByID[dg.id]; !exists {
+			log.V(1).Info("Adding user to group", "group", dg.label(), "groupID", dg.id)
+
+			if _, err := h.kClientV2.Users.AddUserToGroup(ctx, realmName, userCtx.UserID, dg.id); err != nil {
+				return fmt.Errorf("unable to add user to group %q (id %s): %w", dg.label(), dg.id, err)
+			}
+		}
+	}
+
+	if user.IsReconciliationStrategyAddOnly() {
+		log.Info("User groups synced successfully (add-only)")
+		return nil
+	}
+
+	// build lookup of desired IDs for removal check
+	desiredIDs := make(map[string]struct{}, len(desired))
+	for _, dg := range desired {
+		desiredIDs[dg.id] = struct{}{}
+	}
+
+	// remove groups no longer desired
+	for id, cg := range currentByID {
+		if _, keep := desiredIDs[id]; !keep {
+			groupLabel := id
+			if cg.Name != nil {
+				groupLabel = *cg.Name
+			}
+
+			log.V(1).Info("Removing user from group", "group", groupLabel, "groupID", id)
+
+			if _, err := h.kClientV2.Users.RemoveUserFromGroup(ctx, realmName, userCtx.UserID, id); err != nil {
+				return fmt.Errorf("unable to remove user from group %q (id %s): %w", groupLabel, id, err)
+			}
+		}
 	}
 
 	log.Info("User groups synced successfully")

--- a/internal/controller/keycloakrealmuser/chain/sync_user_groups_test.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_groups_test.go
@@ -9,183 +9,336 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
-	keycloakmocks "github.com/epam/edp-keycloak-operator/pkg/client/keycloak/mocks"
+	keycloakv2 "github.com/epam/edp-keycloak-operator/pkg/client/keycloakv2"
+	v2mocks "github.com/epam/edp-keycloak-operator/pkg/client/keycloakv2/mocks"
 )
 
 func TestNewSyncUserGroups(t *testing.T) {
-	h := NewSyncUserGroups()
+	h := NewSyncUserGroups(&keycloakv2.KeycloakClient{})
 	require.NotNil(t, h)
 }
 
 func TestSyncUserGroups_Serve(t *testing.T) {
+	realm := &gocloak.RealmRepresentation{Realm: ptr.To("test-realm")}
+
 	tests := []struct {
 		name      string
 		user      *keycloakApi.KeycloakRealmUser
-		realm     *gocloak.RealmRepresentation
 		userCtx   *UserContext
-		mockSetup func(*keycloakmocks.MockClient)
+		mockSetup func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient)
 		wantErr   require.ErrorAssertionFunc
 	}{
 		{
-			name: "success - sync user groups with full reconciliation strategy",
+			name: "success - name-style group added when not yet assigned",
 			user: &keycloakApi.KeycloakRealmUser{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-user",
-					Namespace: "default",
-				},
-				Spec: keycloakApi.KeycloakRealmUserSpec{
-					Username: "testuser",
-					Groups:   []string{"group1", "group2"},
-				},
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"developers"}},
 			},
-			realm: &gocloak.RealmRepresentation{
-				Realm: gocloak.StringP("test-realm"),
-			},
-			userCtx: &UserContext{
-				UserID: "user-123",
-			},
-			mockSetup: func(m *keycloakmocks.MockClient) {
-				m.EXPECT().SyncUserGroups(
-					context.Background(),
-					"test-realm",
-					"user-123",
-					[]string{"group1", "group2"},
-					false,
-				).Return(nil)
+			userCtx: &UserContext{UserID: "user-1"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-1").
+					Return(nil, nil, nil)
+				g.EXPECT().FindGroupByName(context.Background(), "test-realm", "developers").
+					Return(&keycloakv2.GroupRepresentation{Id: ptr.To("grp-1"), Name: ptr.To("developers")}, nil, nil)
+				u.EXPECT().AddUserToGroup(context.Background(), "test-realm", "user-1", "grp-1").
+					Return(nil, nil)
 			},
 			wantErr: require.NoError,
 		},
 		{
-			name: "success - sync user groups with add-only reconciliation strategy",
+			name: "success - path-style group added when not yet assigned",
 			user: &keycloakApi.KeycloakRealmUser{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-user",
-					Namespace: "default",
-				},
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"/system/data_admin"}},
+			},
+			userCtx: &UserContext{UserID: "user-2"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-2").
+					Return(nil, nil, nil)
+				g.EXPECT().GetGroupByPath(context.Background(), "test-realm", "/system/data_admin").
+					Return(&keycloakv2.GroupRepresentation{
+						Id:   ptr.To("grp-nested"),
+						Path: ptr.To("/system/data_admin"),
+					}, nil, nil)
+				u.EXPECT().AddUserToGroup(context.Background(), "test-realm", "user-2", "grp-nested").
+					Return(nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "success - group already assigned, no add called",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"developers"}},
+			},
+			userCtx: &UserContext{UserID: "user-3"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-3").
+					Return([]keycloakv2.GroupRepresentation{
+						{Id: ptr.To("grp-1"), Name: ptr.To("developers")},
+					}, nil, nil)
+				g.EXPECT().FindGroupByName(context.Background(), "test-realm", "developers").
+					Return(&keycloakv2.GroupRepresentation{Id: ptr.To("grp-1"), Name: ptr.To("developers")}, nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "success - path-style: correct nested group selected over root with same name",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"/system/data_admin"}},
+			},
+			userCtx: &UserContext{UserID: "user-4"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-4").
+					Return([]keycloakv2.GroupRepresentation{
+						{Id: ptr.To("grp-root"), Name: ptr.To("data_admin"), Path: ptr.To("/data_admin")},
+					}, nil, nil)
+				g.EXPECT().GetGroupByPath(context.Background(), "test-realm", "/system/data_admin").
+					Return(&keycloakv2.GroupRepresentation{
+						Id:   ptr.To("grp-nested"),
+						Path: ptr.To("/system/data_admin"),
+					}, nil, nil)
+				u.EXPECT().AddUserToGroup(context.Background(), "test-realm", "user-4", "grp-nested").
+					Return(nil, nil)
+				u.EXPECT().RemoveUserFromGroup(context.Background(), "test-realm", "user-4", "grp-root").
+					Return(nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "success - add-only: extra group not removed",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
 				Spec: keycloakApi.KeycloakRealmUserSpec{
-					Username:               "testuser",
-					Groups:                 []string{"group1"},
+					Groups:                 []string{"developers"},
 					ReconciliationStrategy: keycloakApi.ReconciliationStrategyAddOnly,
 				},
 			},
-			realm: &gocloak.RealmRepresentation{
-				Realm: gocloak.StringP("test-realm"),
-			},
-			userCtx: &UserContext{
-				UserID: "user-456",
-			},
-			mockSetup: func(m *keycloakmocks.MockClient) {
-				m.EXPECT().SyncUserGroups(
-					context.Background(),
-					"test-realm",
-					"user-456",
-					[]string{"group1"},
-					true,
-				).Return(nil)
+			userCtx: &UserContext{UserID: "user-5"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-5").
+					Return([]keycloakv2.GroupRepresentation{
+						{Id: ptr.To("grp-1"), Name: ptr.To("developers")},
+						{Id: ptr.To("grp-extra"), Name: ptr.To("ops")},
+					}, nil, nil)
+				g.EXPECT().FindGroupByName(context.Background(), "test-realm", "developers").
+					Return(&keycloakv2.GroupRepresentation{Id: ptr.To("grp-1"), Name: ptr.To("developers")}, nil, nil)
 			},
 			wantErr: require.NoError,
 		},
 		{
-			name: "success - sync user with empty groups",
+			name: "success - add-only with empty groups skips API calls",
 			user: &keycloakApi.KeycloakRealmUser{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-user",
-					Namespace: "default",
-				},
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
 				Spec: keycloakApi.KeycloakRealmUserSpec{
-					Username: "testuser",
-					Groups:   []string{},
+					Groups:                 []string{},
+					ReconciliationStrategy: keycloakApi.ReconciliationStrategyAddOnly,
 				},
 			},
-			realm: &gocloak.RealmRepresentation{
-				Realm: gocloak.StringP("test-realm"),
-			},
-			userCtx: &UserContext{
-				UserID: "user-789",
-			},
-			mockSetup: func(m *keycloakmocks.MockClient) {
-				m.EXPECT().SyncUserGroups(
-					context.Background(),
-					"test-realm",
-					"user-789",
-					[]string{},
-					false,
-				).Return(nil)
-			},
-			wantErr: require.NoError,
+			userCtx:   &UserContext{UserID: "user-9"},
+			mockSetup: func(_ *v2mocks.MockUsersClient, _ *v2mocks.MockGroupsClient) {},
+			wantErr:   require.NoError,
 		},
 		{
-			name: "success - sync user with nil groups",
+			name: "error - FindGroupByName returns nil (group not found)",
 			user: &keycloakApi.KeycloakRealmUser{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-user",
-					Namespace: "default",
-				},
-				Spec: keycloakApi.KeycloakRealmUserSpec{
-					Username: "testuser",
-				},
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"missing-group"}},
 			},
-			realm: &gocloak.RealmRepresentation{
-				Realm: gocloak.StringP("test-realm"),
-			},
-			userCtx: &UserContext{
-				UserID: "user-nil-groups",
-			},
-			mockSetup: func(m *keycloakmocks.MockClient) {
-				m.EXPECT().SyncUserGroups(
-					context.Background(),
-					"test-realm",
-					"user-nil-groups",
-					[]string(nil),
-					false,
-				).Return(nil)
-			},
-			wantErr: require.NoError,
-		},
-		{
-			name: "error - SyncUserGroups fails",
-			user: &keycloakApi.KeycloakRealmUser{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-user",
-					Namespace: "default",
-				},
-				Spec: keycloakApi.KeycloakRealmUserSpec{
-					Username: "testuser",
-					Groups:   []string{"group1"},
-				},
-			},
-			realm: &gocloak.RealmRepresentation{
-				Realm: gocloak.StringP("test-realm"),
-			},
-			userCtx: &UserContext{
-				UserID: "user-error",
-			},
-			mockSetup: func(m *keycloakmocks.MockClient) {
-				m.EXPECT().SyncUserGroups(
-					context.Background(),
-					"test-realm",
-					"user-error",
-					[]string{"group1"},
-					false,
-				).Return(errors.New("keycloak api error"))
+			userCtx: &UserContext{UserID: "user-6"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-6").
+					Return(nil, nil, nil)
+				g.EXPECT().FindGroupByName(context.Background(), "test-realm", "missing-group").
+					Return(nil, nil, nil)
 			},
 			wantErr: func(t require.TestingT, err error, _ ...any) {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "unable to sync user groups: keycloak api error")
+				assert.Contains(t, err.Error(), "group not found by name")
 			},
+		},
+		{
+			name: "error - GetGroupByPath returns error",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"/bad/path"}},
+			},
+			userCtx: &UserContext{UserID: "user-7"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-7").
+					Return(nil, nil, nil)
+				g.EXPECT().GetGroupByPath(context.Background(), "test-realm", "/bad/path").
+					Return(nil, nil, errors.New("keycloak 404"))
+			},
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unable to get group by path")
+			},
+		},
+		{
+			name: "error - GetUserGroups fails",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"developers"}},
+			},
+			userCtx: &UserContext{UserID: "user-8"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-8").
+					Return(nil, nil, errors.New("connection refused"))
+			},
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unable to get user groups")
+			},
+		},
+		{
+			name: "error - AddUserToGroup fails",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"developers"}},
+			},
+			userCtx: &UserContext{UserID: "user-10"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-10").
+					Return(nil, nil, nil)
+				g.EXPECT().FindGroupByName(context.Background(), "test-realm", "developers").
+					Return(&keycloakv2.GroupRepresentation{Id: ptr.To("grp-1"), Name: ptr.To("developers")}, nil, nil)
+				u.EXPECT().AddUserToGroup(context.Background(), "test-realm", "user-10", "grp-1").
+					Return(nil, errors.New("keycloak error"))
+			},
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unable to add user to group")
+			},
+		},
+		{
+			name: "error - RemoveUserFromGroup fails",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"developers"}},
+			},
+			userCtx: &UserContext{UserID: "user-11"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-11").
+					Return([]keycloakv2.GroupRepresentation{
+						{Id: ptr.To("grp-1"), Name: ptr.To("developers")},
+						{Id: ptr.To("grp-extra"), Name: ptr.To("ops")},
+					}, nil, nil)
+				g.EXPECT().FindGroupByName(context.Background(), "test-realm", "developers").
+					Return(&keycloakv2.GroupRepresentation{Id: ptr.To("grp-1"), Name: ptr.To("developers")}, nil, nil)
+				u.EXPECT().RemoveUserFromGroup(context.Background(), "test-realm", "user-11", "grp-extra").
+					Return(nil, errors.New("keycloak error"))
+			},
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unable to remove user from group")
+			},
+		},
+		{
+			name: "error - GetGroupByPath returns nil (group not found by path)",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"/missing/path"}},
+			},
+			userCtx: &UserContext{UserID: "user-12"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-12").
+					Return(nil, nil, nil)
+				g.EXPECT().GetGroupByPath(context.Background(), "test-realm", "/missing/path").
+					Return(nil, nil, nil)
+			},
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "group not found by path")
+			},
+		},
+		{
+			name: "success - full strategy removes extra groups",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"developers"}},
+			},
+			userCtx: &UserContext{UserID: "user-13"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-13").
+					Return([]keycloakv2.GroupRepresentation{
+						{Id: ptr.To("grp-1"), Name: ptr.To("developers")},
+						{Id: ptr.To("grp-2"), Name: ptr.To("ops")},
+					}, nil, nil)
+				g.EXPECT().FindGroupByName(context.Background(), "test-realm", "developers").
+					Return(&keycloakv2.GroupRepresentation{Id: ptr.To("grp-1"), Name: ptr.To("developers")}, nil, nil)
+				u.EXPECT().RemoveUserFromGroup(context.Background(), "test-realm", "user-13", "grp-2").
+					Return(nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "success - empty groups with full strategy removes all",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{}},
+			},
+			userCtx: &UserContext{UserID: "user-14"},
+			mockSetup: func(u *v2mocks.MockUsersClient, _ *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-14").
+					Return([]keycloakv2.GroupRepresentation{
+						{Id: ptr.To("grp-1"), Name: ptr.To("developers")},
+						{Id: ptr.To("grp-2"), Name: ptr.To("ops")},
+					}, nil, nil)
+				u.EXPECT().RemoveUserFromGroup(context.Background(), "test-realm", "user-14", "grp-1").
+					Return(nil, nil)
+				u.EXPECT().RemoveUserFromGroup(context.Background(), "test-realm", "user-14", "grp-2").
+					Return(nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "success - multiple groups: mixed name-style and path-style",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"developers", "/system/admins"}},
+			},
+			userCtx: &UserContext{UserID: "user-15"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-15").
+					Return(nil, nil, nil)
+				g.EXPECT().FindGroupByName(context.Background(), "test-realm", "developers").
+					Return(&keycloakv2.GroupRepresentation{Id: ptr.To("grp-1"), Name: ptr.To("developers")}, nil, nil)
+				g.EXPECT().GetGroupByPath(context.Background(), "test-realm", "/system/admins").
+					Return(&keycloakv2.GroupRepresentation{
+						Id:   ptr.To("grp-2"),
+						Path: ptr.To("/system/admins"),
+					}, nil, nil)
+				u.EXPECT().AddUserToGroup(context.Background(), "test-realm", "user-15", "grp-1").
+					Return(nil, nil)
+				u.EXPECT().AddUserToGroup(context.Background(), "test-realm", "user-15", "grp-2").
+					Return(nil, nil)
+			},
+			wantErr: require.NoError,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockClient := keycloakmocks.NewMockClient(t)
-			tt.mockSetup(mockClient)
+			mockUsers := v2mocks.NewMockUsersClient(t)
+			mockGroups := v2mocks.NewMockGroupsClient(t)
+			tt.mockSetup(mockUsers, mockGroups)
 
-			h := NewSyncUserGroups()
-
-			err := h.Serve(context.Background(), tt.user, mockClient, tt.realm, tt.userCtx)
+			h := NewSyncUserGroups(&keycloakv2.KeycloakClient{
+				Users:  mockUsers,
+				Groups: mockGroups,
+			})
+			err := h.Serve(
+				context.Background(),
+				tt.user,
+				nil, /* legacy client unused */
+				realm,
+				tt.userCtx,
+			)
 
 			tt.wantErr(t, err)
 		})

--- a/pkg/client/keycloakv2/contracts.go
+++ b/pkg/client/keycloakv2/contracts.go
@@ -16,6 +16,9 @@ type UsersClient interface {
 	CreateUser(ctx context.Context, realm string, user UserRepresentation) (*Response, error)
 	GetUserRealmRoleMappings(ctx context.Context, realm, userID string) ([]RoleRepresentation, *Response, error)
 	AddUserRealmRoles(ctx context.Context, realm, userID string, roles []RoleRepresentation) (*Response, error)
+	GetUserGroups(ctx context.Context, realm, userID string) ([]GroupRepresentation, *Response, error)
+	AddUserToGroup(ctx context.Context, realm, userID, groupID string) (*Response, error)
+	RemoveUserFromGroup(ctx context.Context, realm, userID, groupID string) (*Response, error)
 }
 
 type RealmClient interface {
@@ -41,6 +44,7 @@ type GroupsClient interface {
 	) ([]GroupRepresentation, *Response, error)
 	CreateChildGroup(ctx context.Context, realm, parentGroupID string, group GroupRepresentation) (*Response, error)
 	FindGroupByName(ctx context.Context, realm, groupName string) (*GroupRepresentation, *Response, error)
+	GetGroupByPath(ctx context.Context, realm, path string) (*GroupRepresentation, *Response, error)
 	FindChildGroupByName(
 		ctx context.Context,
 		realm string,

--- a/pkg/client/keycloakv2/groups.go
+++ b/pkg/client/keycloakv2/groups.go
@@ -430,6 +430,27 @@ func (c *groupsClient) DeleteClientRoleMappings(
 	return response, nil
 }
 
+func (c *groupsClient) GetGroupByPath(
+	ctx context.Context, realm, path string,
+) (*GroupRepresentation, *Response, error) {
+	res, err := c.client.GetAdminRealmsRealmGroupByPathPathWithResponse(ctx, realm, path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if res == nil {
+		return nil, nil, ErrNilResponse
+	}
+
+	response := &Response{HTTPResponse: res.HTTPResponse, Body: res.Body}
+
+	if err := checkResponseError(res.HTTPResponse, res.Body); err != nil {
+		return nil, response, err
+	}
+
+	return res.JSON200, response, nil
+}
+
 // findGroupInList searches for a group by name in a list of groups.
 func findGroupInList(groups []GroupRepresentation, name string) *GroupRepresentation {
 	for i := range groups {

--- a/pkg/client/keycloakv2/mocks/groups_client_generated.mock.go
+++ b/pkg/client/keycloakv2/mocks/groups_client_generated.mock.go
@@ -1026,6 +1026,88 @@ func (_c *MockGroupsClient_GetGroup_Call) RunAndReturn(run func(ctx context.Cont
 	return _c
 }
 
+// GetGroupByPath provides a mock function for the type MockGroupsClient
+func (_mock *MockGroupsClient) GetGroupByPath(ctx context.Context, realm string, path string) (*keycloakv2.GroupRepresentation, *keycloakv2.Response, error) {
+	ret := _mock.Called(ctx, realm, path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGroupByPath")
+	}
+
+	var r0 *keycloakv2.GroupRepresentation
+	var r1 *keycloakv2.Response
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*keycloakv2.GroupRepresentation, *keycloakv2.Response, error)); ok {
+		return returnFunc(ctx, realm, path)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *keycloakv2.GroupRepresentation); ok {
+		r0 = returnFunc(ctx, realm, path)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*keycloakv2.GroupRepresentation)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *keycloakv2.Response); ok {
+		r1 = returnFunc(ctx, realm, path)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*keycloakv2.Response)
+		}
+	}
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string, string) error); ok {
+		r2 = returnFunc(ctx, realm, path)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockGroupsClient_GetGroupByPath_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGroupByPath'
+type MockGroupsClient_GetGroupByPath_Call struct {
+	*mock.Call
+}
+
+// GetGroupByPath is a helper method to define mock.On call
+//   - ctx context.Context
+//   - realm string
+//   - path string
+func (_e *MockGroupsClient_Expecter) GetGroupByPath(ctx interface{}, realm interface{}, path interface{}) *MockGroupsClient_GetGroupByPath_Call {
+	return &MockGroupsClient_GetGroupByPath_Call{Call: _e.mock.On("GetGroupByPath", ctx, realm, path)}
+}
+
+func (_c *MockGroupsClient_GetGroupByPath_Call) Run(run func(ctx context.Context, realm string, path string)) *MockGroupsClient_GetGroupByPath_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockGroupsClient_GetGroupByPath_Call) Return(v *keycloakv2.GroupRepresentation, response *keycloakv2.Response, err error) *MockGroupsClient_GetGroupByPath_Call {
+	_c.Call.Return(v, response, err)
+	return _c
+}
+
+func (_c *MockGroupsClient_GetGroupByPath_Call) RunAndReturn(run func(ctx context.Context, realm string, path string) (*keycloakv2.GroupRepresentation, *keycloakv2.Response, error)) *MockGroupsClient_GetGroupByPath_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetGroups provides a mock function for the type MockGroupsClient
 func (_mock *MockGroupsClient) GetGroups(ctx context.Context, realm string, params *keycloakv2.GetGroupsParams) ([]keycloakv2.GroupRepresentation, *keycloakv2.Response, error) {
 	ret := _mock.Called(ctx, realm, params)

--- a/pkg/client/keycloakv2/mocks/users_client_generated.mock.go
+++ b/pkg/client/keycloakv2/mocks/users_client_generated.mock.go
@@ -118,6 +118,86 @@ func (_c *MockUsersClient_AddUserRealmRoles_Call) RunAndReturn(run func(ctx cont
 	return _c
 }
 
+// AddUserToGroup provides a mock function for the type MockUsersClient
+func (_mock *MockUsersClient) AddUserToGroup(ctx context.Context, realm string, userID string, groupID string) (*keycloakv2.Response, error) {
+	ret := _mock.Called(ctx, realm, userID, groupID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddUserToGroup")
+	}
+
+	var r0 *keycloakv2.Response
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) (*keycloakv2.Response, error)); ok {
+		return returnFunc(ctx, realm, userID, groupID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) *keycloakv2.Response); ok {
+		r0 = returnFunc(ctx, realm, userID, groupID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*keycloakv2.Response)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = returnFunc(ctx, realm, userID, groupID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockUsersClient_AddUserToGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddUserToGroup'
+type MockUsersClient_AddUserToGroup_Call struct {
+	*mock.Call
+}
+
+// AddUserToGroup is a helper method to define mock.On call
+//   - ctx context.Context
+//   - realm string
+//   - userID string
+//   - groupID string
+func (_e *MockUsersClient_Expecter) AddUserToGroup(ctx interface{}, realm interface{}, userID interface{}, groupID interface{}) *MockUsersClient_AddUserToGroup_Call {
+	return &MockUsersClient_AddUserToGroup_Call{Call: _e.mock.On("AddUserToGroup", ctx, realm, userID, groupID)}
+}
+
+func (_c *MockUsersClient_AddUserToGroup_Call) Run(run func(ctx context.Context, realm string, userID string, groupID string)) *MockUsersClient_AddUserToGroup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockUsersClient_AddUserToGroup_Call) Return(response *keycloakv2.Response, err error) *MockUsersClient_AddUserToGroup_Call {
+	_c.Call.Return(response, err)
+	return _c
+}
+
+func (_c *MockUsersClient_AddUserToGroup_Call) RunAndReturn(run func(ctx context.Context, realm string, userID string, groupID string) (*keycloakv2.Response, error)) *MockUsersClient_AddUserToGroup_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateUser provides a mock function for the type MockUsersClient
 func (_mock *MockUsersClient) CreateUser(ctx context.Context, realm string, user keycloakv2.UserRepresentation) (*keycloakv2.Response, error) {
 	ret := _mock.Called(ctx, realm, user)
@@ -270,6 +350,88 @@ func (_c *MockUsersClient_FindUserByUsername_Call) Return(v *keycloakv2.UserRepr
 }
 
 func (_c *MockUsersClient_FindUserByUsername_Call) RunAndReturn(run func(ctx context.Context, realm string, username string) (*keycloakv2.UserRepresentation, *keycloakv2.Response, error)) *MockUsersClient_FindUserByUsername_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetUserGroups provides a mock function for the type MockUsersClient
+func (_mock *MockUsersClient) GetUserGroups(ctx context.Context, realm string, userID string) ([]keycloakv2.GroupRepresentation, *keycloakv2.Response, error) {
+	ret := _mock.Called(ctx, realm, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserGroups")
+	}
+
+	var r0 []keycloakv2.GroupRepresentation
+	var r1 *keycloakv2.Response
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]keycloakv2.GroupRepresentation, *keycloakv2.Response, error)); ok {
+		return returnFunc(ctx, realm, userID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []keycloakv2.GroupRepresentation); ok {
+		r0 = returnFunc(ctx, realm, userID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]keycloakv2.GroupRepresentation)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *keycloakv2.Response); ok {
+		r1 = returnFunc(ctx, realm, userID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*keycloakv2.Response)
+		}
+	}
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string, string) error); ok {
+		r2 = returnFunc(ctx, realm, userID)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockUsersClient_GetUserGroups_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserGroups'
+type MockUsersClient_GetUserGroups_Call struct {
+	*mock.Call
+}
+
+// GetUserGroups is a helper method to define mock.On call
+//   - ctx context.Context
+//   - realm string
+//   - userID string
+func (_e *MockUsersClient_Expecter) GetUserGroups(ctx interface{}, realm interface{}, userID interface{}) *MockUsersClient_GetUserGroups_Call {
+	return &MockUsersClient_GetUserGroups_Call{Call: _e.mock.On("GetUserGroups", ctx, realm, userID)}
+}
+
+func (_c *MockUsersClient_GetUserGroups_Call) Run(run func(ctx context.Context, realm string, userID string)) *MockUsersClient_GetUserGroups_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockUsersClient_GetUserGroups_Call) Return(vs []keycloakv2.GroupRepresentation, response *keycloakv2.Response, err error) *MockUsersClient_GetUserGroups_Call {
+	_c.Call.Return(vs, response, err)
+	return _c
+}
+
+func (_c *MockUsersClient_GetUserGroups_Call) RunAndReturn(run func(ctx context.Context, realm string, userID string) ([]keycloakv2.GroupRepresentation, *keycloakv2.Response, error)) *MockUsersClient_GetUserGroups_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -428,6 +590,86 @@ func (_c *MockUsersClient_GetUsersProfile_Call) Return(v *keycloakv2.UserProfile
 }
 
 func (_c *MockUsersClient_GetUsersProfile_Call) RunAndReturn(run func(ctx context.Context, realm string) (*keycloakv2.UserProfileConfig, *keycloakv2.Response, error)) *MockUsersClient_GetUsersProfile_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveUserFromGroup provides a mock function for the type MockUsersClient
+func (_mock *MockUsersClient) RemoveUserFromGroup(ctx context.Context, realm string, userID string, groupID string) (*keycloakv2.Response, error) {
+	ret := _mock.Called(ctx, realm, userID, groupID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveUserFromGroup")
+	}
+
+	var r0 *keycloakv2.Response
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) (*keycloakv2.Response, error)); ok {
+		return returnFunc(ctx, realm, userID, groupID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) *keycloakv2.Response); ok {
+		r0 = returnFunc(ctx, realm, userID, groupID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*keycloakv2.Response)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = returnFunc(ctx, realm, userID, groupID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockUsersClient_RemoveUserFromGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveUserFromGroup'
+type MockUsersClient_RemoveUserFromGroup_Call struct {
+	*mock.Call
+}
+
+// RemoveUserFromGroup is a helper method to define mock.On call
+//   - ctx context.Context
+//   - realm string
+//   - userID string
+//   - groupID string
+func (_e *MockUsersClient_Expecter) RemoveUserFromGroup(ctx interface{}, realm interface{}, userID interface{}, groupID interface{}) *MockUsersClient_RemoveUserFromGroup_Call {
+	return &MockUsersClient_RemoveUserFromGroup_Call{Call: _e.mock.On("RemoveUserFromGroup", ctx, realm, userID, groupID)}
+}
+
+func (_c *MockUsersClient_RemoveUserFromGroup_Call) Run(run func(ctx context.Context, realm string, userID string, groupID string)) *MockUsersClient_RemoveUserFromGroup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockUsersClient_RemoveUserFromGroup_Call) Return(response *keycloakv2.Response, err error) *MockUsersClient_RemoveUserFromGroup_Call {
+	_c.Call.Return(response, err)
+	return _c
+}
+
+func (_c *MockUsersClient_RemoveUserFromGroup_Call) RunAndReturn(run func(ctx context.Context, realm string, userID string, groupID string) (*keycloakv2.Response, error)) *MockUsersClient_RemoveUserFromGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/client/keycloakv2/users.go
+++ b/pkg/client/keycloakv2/users.go
@@ -168,3 +168,66 @@ func (c *usersClient) AddUserRealmRoles(
 
 	return response, nil
 }
+
+func (c *usersClient) GetUserGroups(
+	ctx context.Context, realm, userID string,
+) ([]GroupRepresentation, *Response, error) {
+	res, err := c.client.GetAdminRealmsRealmUsersUserIdGroupsWithResponse(ctx, realm, userID, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if res == nil {
+		return nil, nil, ErrNilResponse
+	}
+
+	response := &Response{HTTPResponse: res.HTTPResponse, Body: res.Body}
+
+	if err := checkResponseError(res.HTTPResponse, res.Body); err != nil {
+		return nil, response, err
+	}
+
+	if res.JSON200 == nil {
+		return nil, response, nil
+	}
+
+	return *res.JSON200, response, nil
+}
+
+func (c *usersClient) AddUserToGroup(ctx context.Context, realm, userID, groupID string) (*Response, error) {
+	res, err := c.client.PutAdminRealmsRealmUsersUserIdGroupsGroupIdWithResponse(ctx, realm, userID, groupID)
+	if err != nil {
+		return nil, err
+	}
+
+	if res == nil {
+		return nil, ErrNilResponse
+	}
+
+	response := &Response{HTTPResponse: res.HTTPResponse, Body: res.Body}
+
+	if err := checkResponseError(res.HTTPResponse, res.Body); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}
+
+func (c *usersClient) RemoveUserFromGroup(ctx context.Context, realm, userID, groupID string) (*Response, error) {
+	res, err := c.client.DeleteAdminRealmsRealmUsersUserIdGroupsGroupIdWithResponse(ctx, realm, userID, groupID)
+	if err != nil {
+		return nil, err
+	}
+
+	if res == nil {
+		return nil, ErrNilResponse
+	}
+
+	response := &Response{HTTPResponse: res.HTTPResponse, Body: res.Body}
+
+	if err := checkResponseError(res.HTTPResponse, res.Body); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}


### PR DESCRIPTION
# Pull Request Template

## Description
Groups field now accepts slash-separated paths (e.g. "/parent/child") in addition to plain group names, enabling nested group membership.