### PR TITLE
feat(keycloak): migrate Keycloak and ClusterKeycloak controllers to keycloakv2 client

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,8 @@
       "Skill(generate-mocks:*)",
       "Skill(cr-field)",
       "Skill(cr-field:*)",
-      "Bash(make mocks)"
+      "Bash(make mocks)",
+      "Bash(TEST_KEYCLOAK_URL=http://localhost:8086 make test)"
     ]
   }
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -322,7 +322,7 @@ func main() {
 	}
 
 	if ns == "" {
-		if err = clusterkeycloak.NewReconcile(mgr.GetClient(), mgr.GetScheme(), h, operatorNamespace).
+		if err = clusterkeycloak.NewReconcile(mgr.GetClient(), mgr.GetScheme(), h).
 			SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create clusterkeycloak controller")
 			os.Exit(1)

--- a/internal/controller/clusterkeycloak/clusterkeycloak_controller.go
+++ b/internal/controller/clusterkeycloak/clusterkeycloak_controller.go
@@ -14,35 +14,31 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1alpha1"
-	"github.com/epam/edp-keycloak-operator/internal/controller/helper"
-	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak"
+	keycloakAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
+	keycloakv2 "github.com/epam/edp-keycloak-operator/pkg/client/keycloakv2"
 )
 
 type keycloakClientProvider interface {
-	CreateKeycloakClientFomAuthData(ctx context.Context, authData *helper.KeycloakAuthData) (keycloak.Client, error)
+	CreateKeycloakClientV2FromClusterKeycloak(ctx context.Context, clusterKeycloak *keycloakAlpha.ClusterKeycloak) (*keycloakv2.KeycloakClient, error)
 }
 
 func NewReconcile(
 	k8sClient client.Client,
 	scheme *runtime.Scheme,
 	controllerHelper keycloakClientProvider,
-	operatorNamespace string,
 ) *Reconciler {
 	return &Reconciler{
-		client:            k8sClient,
-		scheme:            scheme,
-		helper:            controllerHelper,
-		operatorNamespace: operatorNamespace,
+		client: k8sClient,
+		scheme: scheme,
+		helper: controllerHelper,
 	}
 }
 
 // Reconciler reconciles a Keycloak object.
 type Reconciler struct {
-	client            client.Client
-	scheme            *runtime.Scheme
-	helper            keycloakClientProvider
-	operatorNamespace string
+	client client.Client
+	scheme *runtime.Scheme
+	helper keycloakClientProvider
 }
 
 const (
@@ -60,7 +56,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Reconciling ClusterKeycloak")
 
-	clusterKeycloak := &keycloakApi.ClusterKeycloak{}
+	clusterKeycloak := &keycloakAlpha.ClusterKeycloak{}
 	if err := r.client.Get(ctx, req.NamespacedName, clusterKeycloak); err != nil {
 		if errors.IsNotFound(err) {
 			log.Info("Instance not found")
@@ -96,7 +92,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	err := ctrl.NewControllerManagedBy(mgr).
-		For(&keycloakApi.ClusterKeycloak{}, builder.WithPredicates(pred)).
+		For(&keycloakAlpha.ClusterKeycloak{}, builder.WithPredicates(pred)).
 		Complete(r)
 
 	if err != nil {
@@ -106,7 +102,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return nil
 }
 
-func (r *Reconciler) updateConnectionStatusToKeycloak(ctx context.Context, instance *keycloakApi.ClusterKeycloak) error {
+func (r *Reconciler) updateConnectionStatusToKeycloak(ctx context.Context, instance *keycloakAlpha.ClusterKeycloak) error {
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Start updating connection status to ClusterKeycloak")
 
@@ -137,13 +133,8 @@ func (r *Reconciler) updateConnectionStatusToKeycloak(ctx context.Context, insta
 	return nil
 }
 
-func (r *Reconciler) createClient(ctx context.Context, instance *keycloakApi.ClusterKeycloak) error {
-	auth, err := helper.MakeKeycloakAuthDataFromClusterKeycloak(ctx, instance, r.operatorNamespace, r.client)
-	if err != nil {
-		return fmt.Errorf("failed to make Keycloak auth data: %w", err)
-	}
-
-	_, err = r.helper.CreateKeycloakClientFomAuthData(ctx, auth)
+func (r *Reconciler) createClient(ctx context.Context, instance *keycloakAlpha.ClusterKeycloak) error {
+	_, err := r.helper.CreateKeycloakClientV2FromClusterKeycloak(ctx, instance)
 	if err != nil {
 		return fmt.Errorf("failed to create Keycloak client: %w", err)
 	}

--- a/internal/controller/clusterkeycloak/suite_test.go
+++ b/internal/controller/clusterkeycloak/suite_test.go
@@ -80,7 +80,7 @@ var _ = BeforeSuite(func() {
 
 	h := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default")
 
-	err = NewReconcile(k8sManager.GetClient(), k8sManager.GetScheme(), h, "default").
+	err = NewReconcile(k8sManager.GetClient(), k8sManager.GetScheme(), h).
 		SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/clusterkeycloakrealm/suite_test.go
+++ b/internal/controller/clusterkeycloakrealm/suite_test.go
@@ -95,7 +95,7 @@ var _ = BeforeSuite(func() {
 
 	h := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), ns)
 
-	err = clusterkeycloak.NewReconcile(k8sManager.GetClient(), k8sManager.GetScheme(), h, ns).
+	err = clusterkeycloak.NewReconcile(k8sManager.GetClient(), k8sManager.GetScheme(), h).
 		SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/helper/controller_helper.go
+++ b/internal/controller/helper/controller_helper.go
@@ -70,6 +70,8 @@ type ControllerHelper interface {
 	CreateKeycloakClient(ctx context.Context, url, user, password, adminType, caCert string, insecureSkipVerify bool) (keycloak.Client, error)
 	CreateKeycloakClientFomAuthData(ctx context.Context, authData *KeycloakAuthData) (keycloak.Client, error)
 	InvalidateKeycloakClientTokenSecret(ctx context.Context, namespace, rootKeycloakName string) error
+	CreateKeycloakClientV2FromKeycloak(ctx context.Context, kc *keycloakApi.Keycloak) (*keycloakclientv2.KeycloakClient, error)
+	CreateKeycloakClientV2FromClusterKeycloak(ctx context.Context, clusterKeycloak *keycloakAlpha.ClusterKeycloak) (*keycloakclientv2.KeycloakClient, error)
 	CreateKeycloakClientV2FromRealmRef(ctx context.Context, object ObjectWithRealmRef) (*keycloakclientv2.KeycloakClient, error)
 	CreateKeycloakClientV2FromRealm(ctx context.Context, realm *keycloakApi.KeycloakRealm) (*keycloakclientv2.KeycloakClient, error)
 	CreateKeycloakClientV2FromClusterRealm(ctx context.Context, realm *keycloakAlpha.ClusterKeycloakRealm) (*keycloakclientv2.KeycloakClient, error)

--- a/internal/controller/helper/controller_helper_auth.go
+++ b/internal/controller/helper/controller_helper_auth.go
@@ -79,6 +79,24 @@ func (h *Helper) CreateKeycloakClientV2FromRealm(ctx context.Context, realm *key
 	return h.createKeycloakClientV2FromAuthData(ctx, authData)
 }
 
+func (h *Helper) CreateKeycloakClientV2FromKeycloak(ctx context.Context, kc *keycloakApi.Keycloak) (*keycloakclientv2.KeycloakClient, error) {
+	authData, err := MakeKeycloakAuthDataFromKeycloak(ctx, kc, h.client)
+	if err != nil {
+		return nil, err
+	}
+
+	return h.createKeycloakClientV2FromAuthData(ctx, authData)
+}
+
+func (h *Helper) CreateKeycloakClientV2FromClusterKeycloak(ctx context.Context, kc *keycloakAlpha.ClusterKeycloak) (*keycloakclientv2.KeycloakClient, error) {
+	authData, err := MakeKeycloakAuthDataFromClusterKeycloak(ctx, kc, h.operatorNamespace, h.client)
+	if err != nil {
+		return nil, err
+	}
+
+	return h.createKeycloakClientV2FromAuthData(ctx, authData)
+}
+
 func (h *Helper) CreateKeycloakClientV2FromRealmRef(ctx context.Context, object ObjectWithRealmRef) (*keycloakclientv2.KeycloakClient, error) {
 	authData, err := h.getKeycloakAuthDataFromRealmRef(ctx, object)
 	if err != nil {

--- a/internal/controller/helper/controller_helper_auth_test.go
+++ b/internal/controller/helper/controller_helper_auth_test.go
@@ -1718,3 +1718,330 @@ func TestHelper_CreateKeycloakClientV2FromClusterRealm(t *testing.T) {
 		})
 	}
 }
+
+func TestHelper_CreateKeycloakClientV2FromKeycloak(t *testing.T) {
+	s := runtime.NewScheme()
+	require.NoError(t, keycloakApi.AddToScheme(s))
+	require.NoError(t, corev1.AddToScheme(s))
+
+	mockServer := fakehttp.NewServerBuilder().
+		AddKeycloakAuthResponders().
+		BuildAndStart()
+
+	t.Cleanup(func() {
+		mockServer.Close()
+	})
+
+	tests := []struct {
+		name      string
+		kc        *keycloakApi.Keycloak
+		objects   []client.Object
+		wantErr   require.ErrorAssertionFunc
+		checkFunc func(t *testing.T, cl *keycloakclientv2.KeycloakClient)
+	}{
+		{
+			name: "successfully create v2 client from keycloak",
+			kc: &keycloakApi.Keycloak{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-keycloak",
+					Namespace: "default",
+				},
+				Spec: keycloakApi.KeycloakSpec{
+					Url:    mockServer.GetURL(),
+					Secret: "keycloak-secret",
+				},
+			},
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "keycloak-secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"username": []byte("admin"),
+						"password": []byte("admin123"),
+					},
+				},
+			},
+			wantErr: require.NoError,
+			checkFunc: func(t *testing.T, cl *keycloakclientv2.KeycloakClient) {
+				require.NotNil(t, cl)
+			},
+		},
+		{
+			name: "successfully create v2 client with insecure skip verify",
+			kc: &keycloakApi.Keycloak{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-keycloak",
+					Namespace: "default",
+				},
+				Spec: keycloakApi.KeycloakSpec{
+					Url:                mockServer.GetURL(),
+					Secret:             "keycloak-secret",
+					InsecureSkipVerify: true,
+				},
+			},
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "keycloak-secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"username": []byte("admin"),
+						"password": []byte("admin123"),
+					},
+				},
+			},
+			wantErr: require.NoError,
+			checkFunc: func(t *testing.T, cl *keycloakclientv2.KeycloakClient) {
+				require.NotNil(t, cl)
+			},
+		},
+		{
+			name: "credentials secret not found",
+			kc: &keycloakApi.Keycloak{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-keycloak",
+					Namespace: "default",
+				},
+				Spec: keycloakApi.KeycloakSpec{
+					Url:    mockServer.GetURL(),
+					Secret: "non-existent-secret",
+				},
+			},
+			objects: []client.Object{},
+			wantErr: func(t require.TestingT, err error, i ...any) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "unable to get credentials")
+			},
+			checkFunc: func(t *testing.T, cl *keycloakclientv2.KeycloakClient) {
+				require.Nil(t, cl)
+			},
+		},
+		{
+			name: "ca cert secret not found returns error",
+			kc: &keycloakApi.Keycloak{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-keycloak",
+					Namespace: "default",
+				},
+				Spec: keycloakApi.KeycloakSpec{
+					Url:    mockServer.GetURL(),
+					Secret: "keycloak-secret",
+					CACert: &common.SourceRef{
+						SecretKeyRef: &common.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "non-existent-ca-secret",
+							},
+							Key: "ca.crt",
+						},
+					},
+				},
+			},
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "keycloak-secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"username": []byte("admin"),
+						"password": []byte("admin123"),
+					},
+				},
+			},
+			wantErr: func(t require.TestingT, err error, i ...any) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "unable to get ca cert")
+			},
+			checkFunc: func(t *testing.T, cl *keycloakclientv2.KeycloakClient) {
+				require.Nil(t, cl)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(tt.objects...).
+				Build()
+
+			h := &Helper{
+				client: k8sClient,
+			}
+
+			ctx := ctrl.LoggerInto(context.Background(), logr.Discard())
+			cl, err := h.CreateKeycloakClientV2FromKeycloak(ctx, tt.kc)
+
+			tt.wantErr(t, err)
+
+			if tt.checkFunc != nil {
+				tt.checkFunc(t, cl)
+			}
+		})
+	}
+}
+
+func TestHelper_CreateKeycloakClientV2FromClusterKeycloak(t *testing.T) {
+	s := runtime.NewScheme()
+	require.NoError(t, keycloakAlpha.AddToScheme(s))
+	require.NoError(t, corev1.AddToScheme(s))
+
+	mockServer := fakehttp.NewServerBuilder().
+		AddKeycloakAuthResponders().
+		BuildAndStart()
+
+	t.Cleanup(func() {
+		mockServer.Close()
+	})
+
+	tests := []struct {
+		name      string
+		kc        *keycloakAlpha.ClusterKeycloak
+		objects   []client.Object
+		wantErr   require.ErrorAssertionFunc
+		checkFunc func(t *testing.T, cl *keycloakclientv2.KeycloakClient)
+	}{
+		{
+			name: "successfully create v2 client from cluster keycloak",
+			kc: &keycloakAlpha.ClusterKeycloak{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-keycloak",
+				},
+				Spec: keycloakAlpha.ClusterKeycloakSpec{
+					Url:    mockServer.GetURL(),
+					Secret: "keycloak-secret",
+				},
+			},
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "keycloak-secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"username": []byte("admin"),
+						"password": []byte("admin123"),
+					},
+				},
+			},
+			wantErr: require.NoError,
+			checkFunc: func(t *testing.T, cl *keycloakclientv2.KeycloakClient) {
+				require.NotNil(t, cl)
+			},
+		},
+		{
+			name: "successfully create v2 client with insecure skip verify",
+			kc: &keycloakAlpha.ClusterKeycloak{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-keycloak",
+				},
+				Spec: keycloakAlpha.ClusterKeycloakSpec{
+					Url:                mockServer.GetURL(),
+					Secret:             "keycloak-secret",
+					InsecureSkipVerify: true,
+				},
+			},
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "keycloak-secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"username": []byte("admin"),
+						"password": []byte("admin123"),
+					},
+				},
+			},
+			wantErr: require.NoError,
+			checkFunc: func(t *testing.T, cl *keycloakclientv2.KeycloakClient) {
+				require.NotNil(t, cl)
+			},
+		},
+		{
+			name: "credentials secret not found",
+			kc: &keycloakAlpha.ClusterKeycloak{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-keycloak",
+				},
+				Spec: keycloakAlpha.ClusterKeycloakSpec{
+					Url:    mockServer.GetURL(),
+					Secret: "non-existent-secret",
+				},
+			},
+			objects: []client.Object{},
+			wantErr: func(t require.TestingT, err error, i ...any) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "unable to get credentials")
+			},
+			checkFunc: func(t *testing.T, cl *keycloakclientv2.KeycloakClient) {
+				require.Nil(t, cl)
+			},
+		},
+		{
+			name: "ca cert secret not found returns error",
+			kc: &keycloakAlpha.ClusterKeycloak{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-keycloak",
+				},
+				Spec: keycloakAlpha.ClusterKeycloakSpec{
+					Url:    mockServer.GetURL(),
+					Secret: "keycloak-secret",
+					CACert: &common.SourceRef{
+						SecretKeyRef: &common.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "non-existent-ca-secret",
+							},
+							Key: "ca.crt",
+						},
+					},
+				},
+			},
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "keycloak-secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"username": []byte("admin"),
+						"password": []byte("admin123"),
+					},
+				},
+			},
+			wantErr: func(t require.TestingT, err error, i ...any) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "unable to get ca cert")
+			},
+			checkFunc: func(t *testing.T, cl *keycloakclientv2.KeycloakClient) {
+				require.Nil(t, cl)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(tt.objects...).
+				Build()
+
+			h := &Helper{
+				client:            k8sClient,
+				operatorNamespace: "default",
+			}
+
+			ctx := ctrl.LoggerInto(context.Background(), logr.Discard())
+			cl, err := h.CreateKeycloakClientV2FromClusterKeycloak(ctx, tt.kc)
+
+			tt.wantErr(t, err)
+
+			if tt.checkFunc != nil {
+				tt.checkFunc(t, cl)
+			}
+		})
+	}
+}

--- a/internal/controller/helper/mocks/controller_helper_generated.mock.go
+++ b/internal/controller/helper/mocks/controller_helper_generated.mock.go
@@ -415,6 +415,74 @@ func (_c *MockControllerHelper_CreateKeycloakClientFromRealmRef_Call) RunAndRetu
 	return _c
 }
 
+// CreateKeycloakClientV2FromClusterKeycloak provides a mock function for the type MockControllerHelper
+func (_mock *MockControllerHelper) CreateKeycloakClientV2FromClusterKeycloak(ctx context.Context, clusterKeycloak *v1alpha1.ClusterKeycloak) (*keycloakv2.KeycloakClient, error) {
+	ret := _mock.Called(ctx, clusterKeycloak)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateKeycloakClientV2FromClusterKeycloak")
+	}
+
+	var r0 *keycloakv2.KeycloakClient
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *v1alpha1.ClusterKeycloak) (*keycloakv2.KeycloakClient, error)); ok {
+		return returnFunc(ctx, clusterKeycloak)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *v1alpha1.ClusterKeycloak) *keycloakv2.KeycloakClient); ok {
+		r0 = returnFunc(ctx, clusterKeycloak)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*keycloakv2.KeycloakClient)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *v1alpha1.ClusterKeycloak) error); ok {
+		r1 = returnFunc(ctx, clusterKeycloak)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockControllerHelper_CreateKeycloakClientV2FromClusterKeycloak_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateKeycloakClientV2FromClusterKeycloak'
+type MockControllerHelper_CreateKeycloakClientV2FromClusterKeycloak_Call struct {
+	*mock.Call
+}
+
+// CreateKeycloakClientV2FromClusterKeycloak is a helper method to define mock.On call
+//   - ctx context.Context
+//   - clusterKeycloak *v1alpha1.ClusterKeycloak
+func (_e *MockControllerHelper_Expecter) CreateKeycloakClientV2FromClusterKeycloak(ctx interface{}, clusterKeycloak interface{}) *MockControllerHelper_CreateKeycloakClientV2FromClusterKeycloak_Call {
+	return &MockControllerHelper_CreateKeycloakClientV2FromClusterKeycloak_Call{Call: _e.mock.On("CreateKeycloakClientV2FromClusterKeycloak", ctx, clusterKeycloak)}
+}
+
+func (_c *MockControllerHelper_CreateKeycloakClientV2FromClusterKeycloak_Call) Run(run func(ctx context.Context, clusterKeycloak *v1alpha1.ClusterKeycloak)) *MockControllerHelper_CreateKeycloakClientV2FromClusterKeycloak_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1alpha1.ClusterKeycloak
+		if args[1] != nil {
+			arg1 = args[1].(*v1alpha1.ClusterKeycloak)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockControllerHelper_CreateKeycloakClientV2FromClusterKeycloak_Call) Return(keycloakClient *keycloakv2.KeycloakClient, err error) *MockControllerHelper_CreateKeycloakClientV2FromClusterKeycloak_Call {
+	_c.Call.Return(keycloakClient, err)
+	return _c
+}
+
+func (_c *MockControllerHelper_CreateKeycloakClientV2FromClusterKeycloak_Call) RunAndReturn(run func(ctx context.Context, clusterKeycloak *v1alpha1.ClusterKeycloak) (*keycloakv2.KeycloakClient, error)) *MockControllerHelper_CreateKeycloakClientV2FromClusterKeycloak_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateKeycloakClientV2FromClusterRealm provides a mock function for the type MockControllerHelper
 func (_mock *MockControllerHelper) CreateKeycloakClientV2FromClusterRealm(ctx context.Context, realm *v1alpha1.ClusterKeycloakRealm) (*keycloakv2.KeycloakClient, error) {
 	ret := _mock.Called(ctx, realm)
@@ -479,6 +547,74 @@ func (_c *MockControllerHelper_CreateKeycloakClientV2FromClusterRealm_Call) Retu
 }
 
 func (_c *MockControllerHelper_CreateKeycloakClientV2FromClusterRealm_Call) RunAndReturn(run func(ctx context.Context, realm *v1alpha1.ClusterKeycloakRealm) (*keycloakv2.KeycloakClient, error)) *MockControllerHelper_CreateKeycloakClientV2FromClusterRealm_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateKeycloakClientV2FromKeycloak provides a mock function for the type MockControllerHelper
+func (_mock *MockControllerHelper) CreateKeycloakClientV2FromKeycloak(ctx context.Context, kc *v1.Keycloak) (*keycloakv2.KeycloakClient, error) {
+	ret := _mock.Called(ctx, kc)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateKeycloakClientV2FromKeycloak")
+	}
+
+	var r0 *keycloakv2.KeycloakClient
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *v1.Keycloak) (*keycloakv2.KeycloakClient, error)); ok {
+		return returnFunc(ctx, kc)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *v1.Keycloak) *keycloakv2.KeycloakClient); ok {
+		r0 = returnFunc(ctx, kc)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*keycloakv2.KeycloakClient)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *v1.Keycloak) error); ok {
+		r1 = returnFunc(ctx, kc)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockControllerHelper_CreateKeycloakClientV2FromKeycloak_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateKeycloakClientV2FromKeycloak'
+type MockControllerHelper_CreateKeycloakClientV2FromKeycloak_Call struct {
+	*mock.Call
+}
+
+// CreateKeycloakClientV2FromKeycloak is a helper method to define mock.On call
+//   - ctx context.Context
+//   - kc *v1.Keycloak
+func (_e *MockControllerHelper_Expecter) CreateKeycloakClientV2FromKeycloak(ctx interface{}, kc interface{}) *MockControllerHelper_CreateKeycloakClientV2FromKeycloak_Call {
+	return &MockControllerHelper_CreateKeycloakClientV2FromKeycloak_Call{Call: _e.mock.On("CreateKeycloakClientV2FromKeycloak", ctx, kc)}
+}
+
+func (_c *MockControllerHelper_CreateKeycloakClientV2FromKeycloak_Call) Run(run func(ctx context.Context, kc *v1.Keycloak)) *MockControllerHelper_CreateKeycloakClientV2FromKeycloak_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1.Keycloak
+		if args[1] != nil {
+			arg1 = args[1].(*v1.Keycloak)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockControllerHelper_CreateKeycloakClientV2FromKeycloak_Call) Return(keycloakClient *keycloakv2.KeycloakClient, err error) *MockControllerHelper_CreateKeycloakClientV2FromKeycloak_Call {
+	_c.Call.Return(keycloakClient, err)
+	return _c
+}
+
+func (_c *MockControllerHelper_CreateKeycloakClientV2FromKeycloak_Call) RunAndReturn(run func(ctx context.Context, kc *v1.Keycloak) (*keycloakv2.KeycloakClient, error)) *MockControllerHelper_CreateKeycloakClientV2FromKeycloak_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/controller/keycloak/keycloak_controller.go
+++ b/internal/controller/keycloak/keycloak_controller.go
@@ -15,12 +15,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
-	"github.com/epam/edp-keycloak-operator/internal/controller/helper"
-	"github.com/epam/edp-keycloak-operator/pkg/client/keycloak"
+	keycloakv2 "github.com/epam/edp-keycloak-operator/pkg/client/keycloakv2"
 )
 
 type Helper interface {
-	CreateKeycloakClientFomAuthData(ctx context.Context, authData *helper.KeycloakAuthData) (keycloak.Client, error)
+	CreateKeycloakClientV2FromKeycloak(ctx context.Context, keycloak *keycloakApi.Keycloak) (*keycloakv2.KeycloakClient, error)
 }
 
 func NewReconcileKeycloak(k8sClient client.Client, scheme *runtime.Scheme, controllerHelper Helper) *ReconcileKeycloak {
@@ -127,12 +126,7 @@ func (r *ReconcileKeycloak) updateConnectionStatusToKeycloak(ctx context.Context
 }
 
 func (r *ReconcileKeycloak) createClient(ctx context.Context, instance *keycloakApi.Keycloak) error {
-	auth, err := helper.MakeKeycloakAuthDataFromKeycloak(ctx, instance, r.client)
-	if err != nil {
-		return fmt.Errorf("failed to make Keycloak auth data: %w", err)
-	}
-
-	_, err = r.helper.CreateKeycloakClientFomAuthData(ctx, auth)
+	_, err := r.helper.CreateKeycloakClientV2FromKeycloak(ctx, instance)
 	if err != nil {
 		return fmt.Errorf("failed to create Keycloak client: %w", err)
 	}


### PR DESCRIPTION
# Pull Request Template

## Description
Replace legacy gocloak v12 client usage in the Keycloak and ClusterKeycloak controllers with the new oapi-codegen generated keycloakv2 client. Add CreateKeycloakClientV2FromKeycloak and CreateKeycloakClientV2FromClusterKeycloak helper methods, removing the need for callers to build KeycloakAuthData manually. Drop the operatorNamespace field from the ClusterKeycloak reconciler as it is now encapsulated in the helper. Update mocks and tests.

Closes #303