### PR TITLE
fix(keycloakrealmgroup): use status ID to detect group renames

### DIFF
--- a/internal/controller/keycloakrealmgroup/chain/chain.go
+++ b/internal/controller/keycloakrealmgroup/chain/chain.go
@@ -12,7 +12,8 @@ import (
 
 // GroupContext holds data that is passed between chain handlers.
 type GroupContext struct {
-	// GroupID is the Keycloak group ID, set by CreateOrUpdateGroup handler.
+	// GroupID is the Keycloak group ID. Pre-populated from status.ID by the reconciler
+	// (to support rename detection), then overwritten by CreateOrUpdateGroup handler.
 	GroupID string
 
 	// ParentGroupID is the parent group's Keycloak ID (empty if top-level).

--- a/internal/controller/keycloakrealmgroup/chain/create_or_update_group.go
+++ b/internal/controller/keycloakrealmgroup/chain/create_or_update_group.go
@@ -33,17 +33,35 @@ func (h *CreateOrUpdateGroup) Serve(
 		err           error
 	)
 
-	if groupCtx.ParentGroupID != "" {
-		existingGroup, _, err = kClient.Groups.FindChildGroupByName(ctx, realm, groupCtx.ParentGroupID, spec.Name)
-	} else {
-		existingGroup, _, err = kClient.Groups.FindGroupByName(ctx, realm, spec.Name)
+	// If we already have an ID from a previous reconciliation, fetch by ID first.
+	// This handles renames: spec.Name may have changed but the ID stays the same.
+	if groupCtx.GroupID != "" {
+		existingGroup, _, err = kClient.Groups.GetGroup(ctx, realm, groupCtx.GroupID)
+		if err != nil && !keycloakv2.IsNotFound(err) {
+			return fmt.Errorf("unable to get group by ID %q: %w", groupCtx.GroupID, err)
+		}
+
+		if keycloakv2.IsNotFound(err) {
+			log.Info("Group not found by ID, will search by name", "groupID", groupCtx.GroupID)
+
+			existingGroup = nil
+		}
 	}
 
-	if err != nil && !keycloakv2.IsNotFound(err) {
-		return fmt.Errorf("unable to search for group %q: %w", spec.Name, err)
+	// If we didn't find the group by ID, search by name.
+	if existingGroup == nil {
+		if groupCtx.ParentGroupID != "" {
+			existingGroup, _, err = kClient.Groups.FindChildGroupByName(ctx, realm, groupCtx.ParentGroupID, spec.Name)
+		} else {
+			existingGroup, _, err = kClient.Groups.FindGroupByName(ctx, realm, spec.Name)
+		}
+
+		if err != nil && !keycloakv2.IsNotFound(err) {
+			return fmt.Errorf("unable to search for group %q: %w", spec.Name, err)
+		}
 	}
 
-	if keycloakv2.IsNotFound(err) {
+	if existingGroup == nil {
 		groupRep := keycloakv2.GroupRepresentation{
 			Name:        &spec.Name,
 			Description: &spec.Description,
@@ -67,6 +85,7 @@ func (h *CreateOrUpdateGroup) Serve(
 		log.Info("Group created", "groupID", groupCtx.GroupID)
 	} else {
 		groupCtx.GroupID = *existingGroup.Id
+		existingGroup.Name = &spec.Name
 		existingGroup.Description = &spec.Description
 		existingGroup.Path = &spec.Path
 		existingGroup.Attributes = &spec.Attributes

--- a/internal/controller/keycloakrealmgroup/chain/create_or_update_group_test.go
+++ b/internal/controller/keycloakrealmgroup/chain/create_or_update_group_test.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	testGroupName      = "test-group"
+	testGroupPath      = "/test-group"
 	testChildGroupName = "child-group"
 	testUpdatedPath    = "/updated-path"
 )
@@ -29,7 +30,7 @@ func TestCreateOrUpdateGroup_Serve_CreateTopLevel(t *testing.T) {
 
 	group := &keycloakApi.KeycloakRealmGroup{}
 	group.Spec.Name = testGroupName
-	group.Spec.Path = "/test-group"
+	group.Spec.Path = testGroupPath
 	group.Spec.Attributes = map[string][]string{"key": {"val"}}
 
 	mockGroups.EXPECT().FindGroupByName(
@@ -41,7 +42,7 @@ func TestCreateOrUpdateGroup_Serve_CreateTopLevel(t *testing.T) {
 		keycloakv2.GroupRepresentation{
 			Name:        ptr.To(testGroupName),
 			Description: ptr.To(""),
-			Path:        ptr.To("/test-group"),
+			Path:        ptr.To(testGroupPath),
 			Attributes:  &map[string][]string{"key": {"val"}},
 		},
 	).Return(&keycloakv2.Response{
@@ -155,7 +156,7 @@ func TestCreateOrUpdateGroup_Serve_CreateGroupError(t *testing.T) {
 
 	group := &keycloakApi.KeycloakRealmGroup{}
 	group.Spec.Name = testGroupName
-	group.Spec.Path = "/test-group"
+	group.Spec.Path = testGroupPath
 	group.Spec.Attributes = map[string][]string{"key": {"val"}}
 
 	mockGroups.EXPECT().FindGroupByName(
@@ -167,7 +168,7 @@ func TestCreateOrUpdateGroup_Serve_CreateGroupError(t *testing.T) {
 		keycloakv2.GroupRepresentation{
 			Name:        ptr.To(testGroupName),
 			Description: ptr.To(""),
-			Path:        ptr.To("/test-group"),
+			Path:        ptr.To(testGroupPath),
 			Attributes:  &map[string][]string{"key": {"val"}},
 		},
 	).Return(nil, errors.New("create failed"))
@@ -264,4 +265,98 @@ func TestCreateOrUpdateGroup_Serve_FindChildGroupError(t *testing.T) {
 	h := NewCreateOrUpdateGroup()
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	assert.ErrorContains(t, err, "unable to search for group")
+}
+
+func TestCreateOrUpdateGroup_Serve_RenameByID(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakv2.KeycloakClient{Groups: mockGroups}
+	groupCtx := &GroupContext{RealmName: "test-realm", GroupID: "existing-id"}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.Name = "new-name"
+	group.Spec.Description = "Updated desc"
+	group.Spec.Path = "/new-name"
+	group.Spec.Attributes = map[string][]string{"key": {"val"}}
+
+	mockGroups.EXPECT().GetGroup(
+		context.Background(), "test-realm", "existing-id",
+	).Return(&keycloakv2.GroupRepresentation{
+		Id:   ptr.To("existing-id"),
+		Name: ptr.To("old-name"),
+		Path: ptr.To("/old-name"),
+	}, nil, nil)
+
+	mockGroups.EXPECT().UpdateGroup(
+		context.Background(), "test-realm", "existing-id",
+		keycloakv2.GroupRepresentation{
+			Id:          ptr.To("existing-id"),
+			Name:        ptr.To("new-name"),
+			Description: ptr.To("Updated desc"),
+			Path:        ptr.To("/new-name"),
+			Attributes:  &map[string][]string{"key": {"val"}},
+		},
+	).Return(nil, nil)
+
+	h := NewCreateOrUpdateGroup()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	require.NoError(t, err)
+	assert.Equal(t, "existing-id", groupCtx.GroupID)
+}
+
+func TestCreateOrUpdateGroup_Serve_ExistingIDNotFound_FallsBackToName(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakv2.KeycloakClient{Groups: mockGroups}
+	groupCtx := &GroupContext{RealmName: "test-realm", GroupID: "deleted-id"}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.Name = testGroupName
+	group.Spec.Path = testGroupPath
+	group.Spec.Attributes = map[string][]string{"key": {"val"}}
+
+	mockGroups.EXPECT().GetGroup(
+		context.Background(), "test-realm", "deleted-id",
+	).Return(nil, nil, keycloakv2.ErrNotFound)
+
+	mockGroups.EXPECT().FindGroupByName(
+		context.Background(), "test-realm", testGroupName,
+	).Return(nil, nil, keycloakv2.ErrNotFound)
+
+	mockGroups.EXPECT().CreateGroup(
+		context.Background(), "test-realm",
+		keycloakv2.GroupRepresentation{
+			Name:        ptr.To(testGroupName),
+			Description: ptr.To(""),
+			Path:        ptr.To(testGroupPath),
+			Attributes:  &map[string][]string{"key": {"val"}},
+		},
+	).Return(&keycloakv2.Response{
+		HTTPResponse: &http.Response{
+			Header: http.Header{"Location": []string{"http://localhost/admin/realms/test-realm/groups/new-id"}},
+		},
+	}, nil)
+
+	h := NewCreateOrUpdateGroup()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	require.NoError(t, err)
+	assert.Equal(t, "new-id", groupCtx.GroupID)
+}
+
+func TestCreateOrUpdateGroup_Serve_GetGroupByIDError(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakv2.KeycloakClient{Groups: mockGroups}
+	groupCtx := &GroupContext{RealmName: "test-realm", GroupID: "existing-id"}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.Name = testGroupName
+
+	mockGroups.EXPECT().GetGroup(
+		context.Background(), "test-realm", "existing-id",
+	).Return(nil, nil, errors.New("connection error"))
+
+	h := NewCreateOrUpdateGroup()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.ErrorContains(t, err, "unable to get group by ID")
 }

--- a/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller.go
+++ b/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller.go
@@ -168,6 +168,7 @@ func (r *ReconcileKeycloakRealmGroup) tryReconcile(ctx context.Context, keycloak
 	groupCtx := &chain.GroupContext{
 		RealmName:     realmName,
 		ParentGroupID: parentGroupID,
+		GroupID:       keycloakRealmGroup.Status.ID,
 	}
 
 	if err := chain.MakeChain().Serve(ctx, keycloakRealmGroup, kClientV2, groupCtx); err != nil {

--- a/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller_integration_test.go
+++ b/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller_integration_test.go
@@ -276,6 +276,30 @@ var _ = Describe("KeycloakRealmGroup controller", Ordered, func() {
 			g.Expect(*groupRep.RealmRoles).ShouldNot(ContainElement("test-group-role"))
 		}, time.Minute, time.Second*5).Should(Succeed())
 
+		By("Renaming the group via spec.Name")
+		updatableGroup = &keycloakApi.KeycloakRealmGroup{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: group.Name, Namespace: ns}, updatableGroup)).Should(Succeed())
+		oldID := updatableGroup.Status.ID
+		updatableGroup.Spec.Name = "group-all-params-renamed"
+		updatableGroup.Spec.Path = "/group-all-params-renamed"
+		Expect(k8sClient.Update(ctx, updatableGroup)).Should(Succeed())
+
+		By("Verifying the group was renamed in Keycloak, not recreated")
+		Eventually(func(g Gomega) {
+			// Fetch the group from Keycloak by its new name.
+			groupRep, _, err := keycloakApiClient.Groups.FindGroupByName(ctx, KeycloakRealmCR, "group-all-params-renamed")
+			g.Expect(err).ShouldNot(HaveOccurred())
+			// Same Keycloak ID — proves it was updated in place, not deleted and recreated.
+			g.Expect(*groupRep.Id).Should(Equal(oldID))
+
+			// Verify the K8s status also reflects the same ID.
+			renamedGroup := &keycloakApi.KeycloakRealmGroup{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: group.Name, Namespace: ns}, renamedGroup)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(renamedGroup.Status.Value).Should(Equal(common.StatusOK))
+			g.Expect(renamedGroup.Status.ID).Should(Equal(oldID))
+		}, time.Minute, time.Second*5).Should(Succeed())
+
 		By("Cleaning up")
 		Expect(k8sClient.Delete(ctx, group)).Should(Succeed())
 	})


### PR DESCRIPTION
# Pull Request Template

## Description

Updating a KeycloakRealmGroup's spec should update the group, not create a new one, but if `.spec.name` is updated, a new group is created.

Fixes #308 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

Unit tests against mocks, updated integration tests and manual testing with cozystack/cozystack#2206, where we use the Keycloak Operator.

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

## Additional context

See #308.