### PR TITLE
feat(organization): make alias field immutable

### DIFF
--- a/api/v1alpha1/organization_types.go
+++ b/api/v1alpha1/organization_types.go
@@ -15,6 +15,8 @@ type KeycloakOrganizationSpec struct {
 
 	// Alias is the unique alias for the organization.
 	// The alias should be unique across Organizations.
+	// Alias is immutable after creation.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="alias is immutable"
 	// +required
 	Alias string `json:"alias"`
 

--- a/config/crd/bases/v1.edp.epam.com_keycloakorganizations.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakorganizations.yaml
@@ -60,7 +60,11 @@ spec:
                 description: |-
                   Alias is the unique alias for the organization.
                   The alias should be unique across Organizations.
+                  Alias is immutable after creation.
                 type: string
+                x-kubernetes-validations:
+                - message: alias is immutable
+                  rule: self == oldSelf
               attributes:
                 additionalProperties:
                   items:

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakorganizations.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakorganizations.yaml
@@ -60,7 +60,11 @@ spec:
                 description: |-
                   Alias is the unique alias for the organization.
                   The alias should be unique across Organizations.
+                  Alias is immutable after creation.
                 type: string
+                x-kubernetes-validations:
+                - message: alias is immutable
+                  rule: self == oldSelf
               attributes:
                 additionalProperties:
                   items:

--- a/docs/api.md
+++ b/docs/api.md
@@ -1920,7 +1920,10 @@ KeycloakOrganizationSpec defines the desired state of Organization.
         <td>string</td>
         <td>
           Alias is the unique alias for the organization.
-The alias should be unique across Organizations.<br/>
+The alias should be unique across Organizations.
+Alias is immutable after creation.<br/>
+          <br/>
+            <i>Validations</i>:<li>self == oldSelf: alias is immutable</li>
         </td>
         <td>true</td>
       </tr><tr>


### PR DESCRIPTION
# Pull Request Template

## Description
Keycloak uses the alias as a stable identifier for the organization. Allowing it to be changed post-creation causes the operator to create a duplicate organization or fail to reconcile, leaving the old one orphaned in Keycloak.

Closes #311