### PR TITLE
feat: Add HideOnLogin support for KeycloakRealmIdentityProvider

### DIFF
--- a/api/v1/keycloakrealmidentityprovider_types.go
+++ b/api/v1/keycloakrealmidentityprovider_types.go
@@ -74,6 +74,11 @@ type KeycloakRealmIdentityProviderSpec struct {
 	// +nullable
 	// +optional
 	Permission *AdminFineGrainedPermission `json:"permission,omitempty"`
+
+	// HideOnLogin is a flag to hide the idp from the login page.
+	// If hidden, login with this provider is possible only if requested explicitly, for example using the 'kc_idp_hint' parameter.
+	// +optional
+	HideOnLogin bool `json:"hideOnLogin,omitempty"`
 }
 
 type IdentityProviderMapper struct {

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealmidentityproviders.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealmidentityproviders.yaml
@@ -83,6 +83,11 @@ spec:
                 description: FirstBrokerLoginFlowAlias is a first broker login flow
                   alias.
                 type: string
+              hideOnLogin:
+                description: |-
+                  HideOnLogin is a flag to hide the idp from the login page.
+                  If hidden, login with this provider is possible only if requested explicitly, for example using the 'kc_idp_hint' parameter.
+                type: boolean
               linkOnly:
                 description: LinkOnly is a flag to link only.
                 type: boolean

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealmidentityproviders.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealmidentityproviders.yaml
@@ -83,6 +83,11 @@ spec:
                 description: FirstBrokerLoginFlowAlias is a first broker login flow
                   alias.
                 type: string
+              hideOnLogin:
+                description: |-
+                  HideOnLogin is a flag to hide the idp from the login page.
+                  If hidden, login with this provider is possible only if requested explicitly, for example using the 'kc_idp_hint' parameter.
+                type: boolean
               linkOnly:
                 description: LinkOnly is a flag to link only.
                 type: boolean

--- a/docs/api.md
+++ b/docs/api.md
@@ -5265,6 +5265,14 @@ Important: FGAP:V1 Keycloak feature remains in preview and may be deprecated and
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>hideOnLogin</b></td>
+        <td>boolean</td>
+        <td>
+          HideOnLogin is a flag to hide the idp from the login page.
+If hidden, login with this provider is possible only if requested explicitly, for example using the 'kc_idp_hint' parameter.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>linkOnly</b></td>
         <td>boolean</td>
         <td>

--- a/internal/controller/keycloakrealmidentityprovider/chain/put_idp.go
+++ b/internal/controller/keycloakrealmidentityprovider/chain/put_idp.go
@@ -71,6 +71,7 @@ func specToIdentityProviderRepresentation(spec *keycloakApi.KeycloakRealmIdentit
 		LinkOnly:                  &spec.LinkOnly,
 		StoreToken:                &spec.StoreToken,
 		TrustEmail:                &spec.TrustEmail,
+		HideOnLogin:               &spec.HideOnLogin,
 		Config:                    &config,
 	}
 }

--- a/pkg/client/keycloak/adapter/identity_provider.go
+++ b/pkg/client/keycloak/adapter/identity_provider.go
@@ -20,6 +20,7 @@ type IdentityProvider struct {
 	LinkOnly                  bool              `json:"linkOnly"`
 	StoreToken                bool              `json:"storeToken"`
 	TrustEmail                bool              `json:"trustEmail"`
+	HideOnLogin               bool              `json:"hideOnLogin"`
 }
 
 type IdentityProviderMapper struct {


### PR DESCRIPTION
# Add HideOnLogin support for KeycloakRealmIdentityProvider

## Description
Add a new `hideOnLogin` field to KeycloakRealmIdentityProviderSpec that controls whether the identity provider is shown on the login page. When hidden, the provider can still be used via explicit hints such as the `kc_idp_hint` query parameter.

Updates the CRD schema, deploy templates, API docs, adapter struct, and the IDP chain builder to propagate the new field to Keycloak.

Fixes #324 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
with `make test` and manually by building the operator and deploy the sample manifests both with hideOnLogin: true and false and verified in the keycloak console.

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):

## Additional context
Replaced my initial PR from the old gocloak v12 client with the new keycloakv2 client.