### PR TITLE
feat(helm): add configurable serviceAccountName to operator chart

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -147,4 +147,9 @@ Development versions are also available from the [snapshot helm chart repository
 | podLabels | object | `{}` | Labels to be added to the pod |
 | resources | object | `{"limits":{"memory":"192Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | Resource limits and requests for the pod |
 | securityContext | object | `{"runAsNonRoot":true}` | Deployment Security Context Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
+| serviceAccount | object | `{"annotations":{},"create":true,"labels":{},"name":"edp-keycloak-operator"}` | ServiceAccount configuration |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount (e.g. for AWS IAM role association) |
+| serviceAccount.create | bool | `true` | If true, a ServiceAccount will be created |
+| serviceAccount.labels | object | `{}` | Additional labels to add to the ServiceAccount |
+| serviceAccount.name | string | `"edp-keycloak-operator"` | The name of the ServiceAccount to use. Defaults to "edp-keycloak-operator" |
 | tolerations | list | `[]` | Node tolerations for server scheduling to nodes with taints |

--- a/deploy-templates/templates/clusterrolebinding.yaml
+++ b/deploy-templates/templates/clusterrolebinding.yaml
@@ -11,6 +11,6 @@ roleRef:
   name: edp-{{ .Release.Namespace }}-clusterrole
 subjects:
   - kind: ServiceAccount
-    name: edp-{{ .Values.name }}
+    name: {{ include "keycloak-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end}}

--- a/deploy-templates/templates/deployment.yaml
+++ b/deploy-templates/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
-      serviceAccountName: edp-{{ .Values.name }}
+      serviceAccountName: {{ include "keycloak-operator.serviceAccountName" . }}
       {{- if .Values.securityContext }}
       securityContext: {{ toYaml .Values.securityContext | nindent 8 }}
       {{- end }}

--- a/deploy-templates/templates/leader_election_rolebinding.yaml
+++ b/deploy-templates/templates/leader_election_rolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
   name: edp-{{ .Values.name }}-leader-election-role
 subjects:
   - kind: ServiceAccount
-    name: edp-{{ .Values.name }}
+    name: {{ include "keycloak-operator.serviceAccountName" . }}

--- a/deploy-templates/templates/operator_rolebinding.yaml
+++ b/deploy-templates/templates/operator_rolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
   name: edp-{{ .Values.name }}-role
 subjects:
   - kind: ServiceAccount
-    name: edp-{{ .Values.name }}
+    name: {{ include "keycloak-operator.serviceAccountName" . }}

--- a/deploy-templates/templates/serviceaccount.yaml
+++ b/deploy-templates/templates/serviceaccount.yaml
@@ -1,6 +1,15 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: edp-{{ .Values.name }}
+  name: {{ include "keycloak-operator.serviceAccountName" . }}
   labels:
     {{- include "keycloak-operator.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.serviceAccount.labels }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy-templates/templates/webhook/rbac.yaml
+++ b/deploy-templates/templates/webhook/rbac.yaml
@@ -28,6 +28,6 @@ roleRef:
   name: edp-{{ .Release.Namespace }}-webhook-clusterrole
 subjects:
   - kind: ServiceAccount
-    name: edp-{{ .Values.name }}
+    name: {{ include "keycloak-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -68,3 +68,14 @@ enableOwnerRef: true
 # -- If set to true, enables webhook resources (ValidatingWebhookConfiguration, Service, and Certificate).
 # Webhooks require cert-manager to be installed in the cluster.
 enableWebhooks: true
+
+# -- ServiceAccount configuration
+serviceAccount:
+  # -- If true, a ServiceAccount will be created
+  create: true
+  # -- The name of the ServiceAccount to use. Defaults to "edp-keycloak-operator"
+  name: "edp-keycloak-operator"
+  # -- Annotations to add to the ServiceAccount (e.g. for AWS IAM role association)
+  annotations: {}
+  # -- Additional labels to add to the ServiceAccount
+  labels: {}


### PR DESCRIPTION
## Description

Allows users to control whether the Helm chart creates the ServiceAccount and what name it uses. This is needed when the SA must be pre-created externally (e.g., to attach an AWS IAM role annotation before chart installation).

Changes:
- `serviceAccount.create` — skip SA creation when `false` (bring your own SA)
- `serviceAccount.name` — override the SA name (default: `edp-keycloak-operator`)
- `serviceAccount.annotations` — attach arbitrary annotations (e.g., `eks.amazonaws.com/role-arn`)
- `serviceAccount.labels` — attach additional labels
- All RoleBinding / ClusterRoleBinding subjects updated to use the helper so RBAC stays consistent with the configured name

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Notes

This is a cleaned-up, single-commit version of #322 (squashed merge commit removed, RBAC bindings fixed, annotations support added).

Co-authored-by: Rudger Gravestein <rgravestein+pv@lionsville.nl>