### PR TITLE
test(keycloakapi): centralize realm creation with retry helper

### DIFF
--- a/pkg/client/keycloakapi/auth_flows_test.go
+++ b/pkg/client/keycloakapi/auth_flows_test.go
@@ -29,17 +29,7 @@ func TestAuthFlowsClient_CRUD(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-af-crud-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	flowAlias := fmt.Sprintf("test-flow-%d", time.Now().UnixNano())
 	topLevel := true
@@ -132,17 +122,7 @@ func TestAuthFlowsClient_Executions(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-af-exec-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Create a custom flow to add executions to
 	flowAlias := fmt.Sprintf("test-flow-exec-%d", time.Now().UnixNano())
@@ -243,17 +223,7 @@ func TestAuthFlowsClient_ChildFlow(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-af-child-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Create parent flow
 	flowAlias := fmt.Sprintf("test-parent-flow-%d", time.Now().UnixNano())
@@ -315,17 +285,7 @@ func TestAuthFlowsClient_ExecutionConfig(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-af-cfg-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Create a flow
 	flowAlias := fmt.Sprintf("test-flow-cfg-%d", time.Now().UnixNano())
@@ -403,17 +363,7 @@ func TestAuthFlowsClient_GetAuthenticatorConfig(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-af-getcfg-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Create a flow and add a configurable execution.
 	flowAlias := fmt.Sprintf("test-flow-getcfg-%d", time.Now().UnixNano())
@@ -495,17 +445,7 @@ func TestAuthFlowsClient_GetAuthFlow(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-af-getflow-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Create a flow and then fetch it by ID.
 	flowAlias := fmt.Sprintf("test-get-flow-%d", time.Now().UnixNano())
@@ -550,17 +490,7 @@ func TestAuthFlowsClient_CopyAuthFlow(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-af-copy-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	newFlowAlias := fmt.Sprintf("copy-of-browser-%d", time.Now().UnixNano())
 
@@ -599,17 +529,7 @@ func TestAuthFlowsClient_UpdateAndDeleteAuthenticatorConfig(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-af-updcfg-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Create a flow with an execution that supports config (conditional-otp).
 	flowAlias := fmt.Sprintf("cfg-flow-%d", time.Now().UnixNano())
@@ -716,17 +636,7 @@ func TestAuthFlowsClient_RequiredActions(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-af-reqaction-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Get required actions — every realm has built-in required actions.
 	actions, resp, err := c.AuthFlows.GetRequiredActions(ctx, realmName)

--- a/pkg/client/keycloakapi/authorization_test.go
+++ b/pkg/client/keycloakapi/authorization_test.go
@@ -62,17 +62,7 @@ func TestAuthorizationClient_ScopeCRUD(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-authz-scope-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = kc.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = kc.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, kc, realmName)
 
 	clientUUID := createAuthzClient(t, kc, ctx, realmName)
 
@@ -139,17 +129,7 @@ func TestAuthorizationClient_ResourceCRUD(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-authz-res-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = kc.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = kc.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, kc, realmName)
 
 	clientUUID := createAuthzClient(t, kc, ctx, realmName)
 
@@ -239,17 +219,7 @@ func TestAuthorizationClient_PolicyCRUD(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-authz-policy-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = kc.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = kc.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, kc, realmName)
 
 	clientUUID := createAuthzClient(t, kc, ctx, realmName)
 
@@ -350,17 +320,7 @@ func TestAuthorizationClient_PolicyTypes(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-policy-types-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = kc.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = kc.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, kc, realmName)
 
 	clientUUID := createAuthzClient(t, kc, ctx, realmName)
 
@@ -676,17 +636,7 @@ func TestAuthorizationClient_PermissionCRUD(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-authz-perm-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = kc.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = kc.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, kc, realmName)
 
 	clientUUID := createAuthzClient(t, kc, ctx, realmName)
 
@@ -758,17 +708,7 @@ func TestAuthorizationClient_GetResource(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-authz-getres-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = kc.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = kc.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, kc, realmName)
 
 	clientUUID := createAuthzClient(t, kc, ctx, realmName)
 
@@ -803,17 +743,7 @@ func TestAuthorizationClient_GetAndUpdateScope(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-authz-getscope-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = kc.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = kc.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, kc, realmName)
 
 	clientUUID := createAuthzClient(t, kc, ctx, realmName)
 

--- a/pkg/client/keycloakapi/client_policies_test.go
+++ b/pkg/client/keycloakapi/client_policies_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/utils/ptr"
 
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	"github.com/epam/edp-keycloak-operator/pkg/testutils"
@@ -28,15 +27,7 @@ func newClientPoliciesTestRealm(t *testing.T, suffix string) (*keycloakapi.Keycl
 
 	realmName := fmt.Sprintf("test-realm-cp-%s-%d", suffix, time.Now().UnixNano())
 
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(context.Background(), keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: ptr.To(true),
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	return c, realmName
 }

--- a/pkg/client/keycloakapi/client_scopes_test.go
+++ b/pkg/client/keycloakapi/client_scopes_test.go
@@ -27,17 +27,7 @@ func TestClientScopesClient_CRUD(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-cs-crud-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	scopeName := "test-scope"
 	protocol := protocolOpenIDConnect
@@ -115,17 +105,7 @@ func TestClientScopesClient_RealmScopeType(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-cs-type-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	scopeName := "test-type-scope"
 	protocol := protocolOpenIDConnect
@@ -188,17 +168,7 @@ func TestClientScopesClient_ProtocolMappers(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-cs-mappers-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	scopeName := "test-mapper-scope"
 	protocol := protocolOpenIDConnect
@@ -273,17 +243,7 @@ func TestClientScopesClient_UpdateClientScopeProtocolMapper(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-cs-updmapper-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Create a client scope.
 	scopeName := fmt.Sprintf("test-scope-updmapper-%d", time.Now().UnixNano())

--- a/pkg/client/keycloakapi/clients_test.go
+++ b/pkg/client/keycloakapi/clients_test.go
@@ -32,22 +32,7 @@ func TestClientsClient_ClientCRUD(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-cli-crud-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm first
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	require.NotNil(t, resp.HTTPResponse)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	clientId := fmt.Sprintf("test-client-%d", time.Now().UnixNano())
 	clientName := "Test Client for CRUD"
@@ -174,20 +159,7 @@ func TestClientsClient_GetClient_NotFound(t *testing.T) {
 
 	// Generate unique realm name
 	realmName := fmt.Sprintf("test-realm-cli-get-nf-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Test getting a non-existent client
 	client, resp, err := c.Clients.GetClient(ctx, realmName, "nonexistent-client-uuid-12345")
@@ -213,23 +185,10 @@ func TestClientsClient_DeleteClient_NotFound(t *testing.T) {
 
 	// Generate unique realm name
 	realmName := fmt.Sprintf("test-realm-cli-del-nf-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Test deleting a non-existent client
-	resp, err = c.Clients.DeleteClient(ctx, realmName, "nonexistent-client-uuid-12345")
+	resp, err := c.Clients.DeleteClient(ctx, realmName, "nonexistent-client-uuid-12345")
 	require.Error(t, err)
 	require.True(t, keycloakapi.IsNotFound(err), "Should return 404 error for non-existent client")
 	require.NotNil(t, resp, "Response should be present even for error")
@@ -251,21 +210,7 @@ func TestClientsClient_CreateClient_Conflict(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-cli-conflict-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	clientId := "duplicate-client"
 	protocol := protocolOpenIDConnect
@@ -275,7 +220,7 @@ func TestClientsClient_CreateClient_Conflict(t *testing.T) {
 	}
 
 	// Create the client
-	resp, err = c.Clients.CreateClient(ctx, realmName, client)
+	resp, err := c.Clients.CreateClient(ctx, realmName, client)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -302,22 +247,7 @@ func TestClientsClient_ClientRoleCRUD(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-cli-role-crud-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm first
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	require.NotNil(t, resp.HTTPResponse)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Create test client
 	clientId := fmt.Sprintf("test-client-%d", time.Now().UnixNano())
@@ -327,7 +257,7 @@ func TestClientsClient_ClientRoleCRUD(t *testing.T) {
 		Protocol: &protocol,
 	}
 
-	resp, err = c.Clients.CreateClient(ctx, realmName, client)
+	resp, err := c.Clients.CreateClient(ctx, realmName, client)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.HTTPResponse)
@@ -448,20 +378,7 @@ func TestClientsClient_GetClientRole_NotFound(t *testing.T) {
 
 	// Generate unique realm name
 	realmName := fmt.Sprintf("test-realm-cli-role-get-nf-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Create test client
 	clientId := fmt.Sprintf("test-client-%d", time.Now().UnixNano())
@@ -471,7 +388,7 @@ func TestClientsClient_GetClientRole_NotFound(t *testing.T) {
 		Protocol: &protocol,
 	}
 
-	resp, err = c.Clients.CreateClient(ctx, realmName, client)
+	resp, err := c.Clients.CreateClient(ctx, realmName, client)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -503,20 +420,7 @@ func TestClientsClient_DeleteClientRole_NotFound(t *testing.T) {
 
 	// Generate unique realm name
 	realmName := fmt.Sprintf("test-realm-cli-role-del-nf-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Create test client
 	clientId := fmt.Sprintf("test-client-%d", time.Now().UnixNano())
@@ -526,7 +430,7 @@ func TestClientsClient_DeleteClientRole_NotFound(t *testing.T) {
 		Protocol: &protocol,
 	}
 
-	resp, err = c.Clients.CreateClient(ctx, realmName, client)
+	resp, err := c.Clients.CreateClient(ctx, realmName, client)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -556,17 +460,7 @@ func TestClientsClient_GetClientByClientID(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-cli-by-id-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	clientId := fmt.Sprintf("test-client-by-id-%d", time.Now().UnixNano())
 	protocol := protocolOpenIDConnect
@@ -605,17 +499,7 @@ func TestClientsClient_GetClientUUID(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-cli-uuid-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	clientId := fmt.Sprintf("test-client-uuid-%d", time.Now().UnixNano())
 	protocol := protocolOpenIDConnect
@@ -655,17 +539,7 @@ func TestClientsClient_UpdateAndScopeMethods(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-cli-update-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	clientId := fmt.Sprintf("test-client-update-%d", time.Now().UnixNano())
 	protocol := protocolOpenIDConnect
@@ -732,17 +606,7 @@ func TestClientsClient_ServiceAccount(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-svc-acc-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	clientId := fmt.Sprintf("test-svc-acc-%d", time.Now().UnixNano())
 	protocol := protocolOpenIDConnect
@@ -782,17 +646,7 @@ func TestClientsClient_ProtocolMapperCRUD(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-mapper-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	clientId := fmt.Sprintf("test-client-mapper-%d", time.Now().UnixNano())
 	protocol := protocolOpenIDConnect
@@ -892,17 +746,7 @@ func TestClientsClient_ManagementPermissions(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-mgmt-perm-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	clientId := fmt.Sprintf("test-client-mgmt-%d", time.Now().UnixNano())
 	protocol := protocolOpenIDConnect
@@ -956,17 +800,7 @@ func TestClientsClient_RoleComposites(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-role-comp-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	clientId := fmt.Sprintf("test-client-comp-%d", time.Now().UnixNano())
 	protocol := protocolOpenIDConnect
@@ -1045,17 +879,7 @@ func TestClientsClient_AddDefaultClientScope(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-cli-scope-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	clientId := fmt.Sprintf("test-client-scope-%d", time.Now().UnixNano())
 	protocol := protocolOpenIDConnect
@@ -1122,17 +946,7 @@ func TestClientsClient_AddOptionalClientScope(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-cli-optscope-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	clientId := fmt.Sprintf("test-client-optscope-%d", time.Now().UnixNano())
 	protocol := protocolOpenIDConnect
@@ -1212,21 +1026,7 @@ func TestClientsClient_CreateClientRole_Conflict(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-cli-role-conflict-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Create test client
 	clientId := fmt.Sprintf("test-client-%d", time.Now().UnixNano())
@@ -1236,7 +1036,7 @@ func TestClientsClient_CreateClientRole_Conflict(t *testing.T) {
 		Protocol: &protocol,
 	}
 
-	resp, err = c.Clients.CreateClient(ctx, realmName, client)
+	resp, err := c.Clients.CreateClient(ctx, realmName, client)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -1276,17 +1076,7 @@ func TestClientsClient_UpdateClientRole(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-cli-role-update-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	clientId := fmt.Sprintf("test-client-role-update-%d", time.Now().UnixNano())
 	protocol := protocolOpenIDConnect
@@ -1336,17 +1126,9 @@ func TestClientsClient_GetClientSecret(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-client-secret-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
 
 	// Create a confidential client.
 	clientID := fmt.Sprintf("secret-client-%d", time.Now().UnixNano())
@@ -1386,17 +1168,9 @@ func TestClientsClient_RegenerateClientSecret(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-client-regen-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
 
 	clientID := fmt.Sprintf("regen-client-%d", time.Now().UnixNano())
 	protocol := protocolOpenIDConnect
@@ -1441,17 +1215,9 @@ func TestClientsClient_GetClientSessions(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-client-sessions-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
 
 	clientID := fmt.Sprintf("sessions-client-%d", time.Now().UnixNano())
 	protocol := protocolOpenIDConnect
@@ -1486,17 +1252,9 @@ func TestClientsClient_GetClientInstallationProvider(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-client-install-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
 
 	clientID := fmt.Sprintf("install-client-%d", time.Now().UnixNano())
 	protocol := protocolOpenIDConnect

--- a/pkg/client/keycloakapi/events_test.go
+++ b/pkg/client/keycloakapi/events_test.go
@@ -30,15 +30,7 @@ func newEventsTestRealm(t *testing.T) (*keycloakapi.KeycloakClient, string) {
 
 	realmName := fmt.Sprintf("test-realm-events-%d", time.Now().UnixNano())
 
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(context.Background(), keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: ptr.To(true),
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Enable events so that queries work.
 	_, err = c.Realms.SetRealmEventConfig(context.Background(), realmName, keycloakapi.RealmEventsConfigRepresentation{

--- a/pkg/client/keycloakapi/groups_test.go
+++ b/pkg/client/keycloakapi/groups_test.go
@@ -31,22 +31,7 @@ func TestGroupsClient_CRUD(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-grp-crud-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm first
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	require.NotNil(t, resp.HTTPResponse)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// 1. Create a top-level group
 	groupName := "test-group"
@@ -54,7 +39,7 @@ func TestGroupsClient_CRUD(t *testing.T) {
 		Name: &groupName,
 	}
 
-	resp, err = c.Groups.CreateGroup(ctx, realmName, group)
+	resp, err := c.Groups.CreateGroup(ctx, realmName, group)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.HTTPResponse)
@@ -142,21 +127,7 @@ func TestGroupsClient_ChildGroups(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-grp-child-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm first
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	var parentGroupID *string
 
@@ -347,21 +318,7 @@ func TestGroupsClient_GetGroups_WithParams(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-grp-params-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm first
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Create multiple groups for testing
 	groupNames := []string{"alpha-group", "beta-group", "gamma-group"}
@@ -440,21 +397,7 @@ func TestGroupsClient_RealmRoleMappings(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-grp-realm-roles-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	var groupID *string
 
@@ -586,21 +529,7 @@ func TestGroupsClient_ClientRoleMappings(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-grp-client-roles-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	var groupID *string
 
@@ -767,21 +696,7 @@ func TestGroupsClient_FindGroupByName(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-find-grp-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Test: Find non-existent group
 	t.Run("Find Non-Existent Group", func(t *testing.T) {
@@ -865,21 +780,7 @@ func TestGroupsClient_FindChildGroupByName(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-find-child-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	var parentGroupID string
 
@@ -980,21 +881,7 @@ func TestGroupsClient_FindGroupByName_MultiLevel(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-multilevel-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Create a hierarchy: root-group -> level1-group -> level2-group -> level3-group
 	var rootGroupID, level1GroupID, level2GroupID, level3GroupID string
@@ -1161,21 +1048,7 @@ func TestGroupsClient_GetGroupByPath(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-grp-path-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Build hierarchy: top-group -> mid-group -> bottom-group
 	var topGroupID, midGroupID, bottomGroupID string
@@ -1300,17 +1173,7 @@ func TestGroupsClient_CountGroups(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-grp-count-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// Create a group so count > 0.
 	groupName := fmt.Sprintf("count-group-%d", time.Now().UnixNano())
@@ -1345,17 +1208,9 @@ func TestGroupsClient_GetGroupMembers(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-grp-members-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
 
 	// Create a group.
 	groupName := fmt.Sprintf("members-group-%d", time.Now().UnixNano())
@@ -1403,17 +1258,9 @@ func TestGroupsClient_GroupManagementPermissions(t *testing.T) {
 
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-grp-perms-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
 
 	groupName := fmt.Sprintf("perms-group-%d", time.Now().UnixNano())
 

--- a/pkg/client/keycloakapi/identity_providers_test.go
+++ b/pkg/client/keycloakapi/identity_providers_test.go
@@ -31,17 +31,7 @@ func newIdentityProvidersTestRealm(t *testing.T) (*keycloakapi.KeycloakClient, s
 	require.NoError(t, err)
 
 	realmName := fmt.Sprintf("test-realm-idp-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(context.Background(), keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	return c, realmName
 }

--- a/pkg/client/keycloakapi/organizations_test.go
+++ b/pkg/client/keycloakapi/organizations_test.go
@@ -29,18 +29,20 @@ func newOrganizationsTestRealm(t *testing.T) (*keycloakapi.KeycloakClient, strin
 	require.NoError(t, err)
 
 	realmName := fmt.Sprintf("test-realm-org-%d", time.Now().UnixNano())
-	enabled := true
 
 	t.Cleanup(func() {
 		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
 	})
 
-	_, err = c.Realms.CreateRealm(context.Background(), keycloakapi.RealmRepresentation{
-		Realm:                &realmName,
-		Enabled:              &enabled,
-		OrganizationsEnabled: ptr.To(true),
-	})
-	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		_, err = c.Realms.CreateRealm(context.Background(), keycloakapi.RealmRepresentation{
+			Realm:                &realmName,
+			Enabled:              ptr.To(true),
+			OrganizationsEnabled: ptr.To(true),
+		})
+
+		return err == nil
+	}, 10*time.Second, time.Second, "creating realm %s", realmName)
 
 	return c, realmName
 }
@@ -170,17 +172,22 @@ func TestOrganizationsClient_GetOrganizationByAlias(t *testing.T) {
 	orgID := ptr.Deref(org.Id, "")
 	require.NotEmpty(t, orgID)
 
-	// Rename the organization (name changes, alias stays the same)
+	// Rename the organization (name changes, alias stays the same).
+	// Keycloak transiently returns "unknown_error" under parallel test load, so retry.
 	updatedName := "Alias Test Organization Renamed"
-	_, err = c.Organizations.UpdateOrganization(ctx, realmName, orgID, keycloakapi.OrganizationRepresentation{
-		Id:    &orgID,
-		Name:  &updatedName,
-		Alias: &alias,
-		Domains: &[]keycloakapi.OrganizationDomainRepresentation{
-			{Name: ptr.To("alias-test.com")},
-		},
-	})
-	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		_, err = c.Organizations.UpdateOrganization(ctx, realmName, orgID, keycloakapi.OrganizationRepresentation{
+			Id:    &orgID,
+			Name:  &updatedName,
+			Alias: &alias,
+			Domains: &[]keycloakapi.OrganizationDomainRepresentation{
+				{Name: ptr.To("alias-test.com")},
+			},
+		})
+
+		return err == nil
+	}, 10*time.Second, time.Second, "renaming organization %s", orgID)
 
 	// GetOrganizationByAlias still finds the org by the original alias despite name change
 	renamedOrg, _, err := c.Organizations.GetOrganizationByAlias(ctx, realmName, alias)

--- a/pkg/client/keycloakapi/realm_components_test.go
+++ b/pkg/client/keycloakapi/realm_components_test.go
@@ -28,17 +28,7 @@ func TestRealmComponentsClient_CRUD(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-rc-crud-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	componentName := "test-client-reg-policy"
 	providerID := "scope"

--- a/pkg/client/keycloakapi/realm_test.go
+++ b/pkg/client/keycloakapi/realm_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/utils/ptr"
 
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	"github.com/epam/edp-keycloak-operator/pkg/testutils"
@@ -179,21 +178,10 @@ func TestRealmClient_SetRealmBrowserFlow(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-browser-flow-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	resp, err := c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// "browser" is the default flow that always exists in every Keycloak realm
-	resp, err = c.Realms.SetRealmBrowserFlow(ctx, realmName, "browser")
+	resp, err := c.Realms.SetRealmBrowserFlow(ctx, realmName, "browser")
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.HTTPResponse)
@@ -239,18 +227,7 @@ func TestRealmClient_SetRealmEventConfig(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-event-config-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	resp, err := c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	eventsEnabled := true
 	adminEventsEnabled := true
@@ -268,7 +245,7 @@ func TestRealmClient_SetRealmEventConfig(t *testing.T) {
 		EnabledEventTypes:         &eventTypes,
 	}
 
-	resp, err = c.Realms.SetRealmEventConfig(ctx, realmName, cfg)
+	resp, err := c.Realms.SetRealmEventConfig(ctx, realmName, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.HTTPResponse)
@@ -289,17 +266,7 @@ func TestRealmClient_GetAuthenticationFlows(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-auth-flows-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	flows, resp, err := c.Realms.GetAuthenticationFlows(ctx, realmName)
 	require.NoError(t, err)
@@ -408,15 +375,7 @@ func TestRealmClient_GetRealmKeys(t *testing.T) {
 
 	realmName := fmt.Sprintf("test-realm-keys-%d", time.Now().UnixNano())
 
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: ptr.To(true),
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	keys, resp, err := c.Realms.GetRealmKeys(ctx, realmName)
 	require.NoError(t, err)
@@ -442,15 +401,7 @@ func TestRealmClient_GetRealmLocalization(t *testing.T) {
 
 	realmName := fmt.Sprintf("test-realm-localization-%d", time.Now().UnixNano())
 
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: ptr.To(true),
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// A fresh realm may have no localization entries for "en" — that is valid.
 	localization, resp, err := c.Realms.GetRealmLocalization(ctx, realmName, "en")
@@ -476,15 +427,7 @@ func TestRealmClient_PostRealmLocalization(t *testing.T) {
 
 	realmName := fmt.Sprintf("test-realm-localization-post-%d", time.Now().UnixNano())
 
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: ptr.To(true),
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	_, err = c.Realms.PostRealmLocalization(ctx, realmName, "en", map[string]string{
 		"customTestKey": "customTestValue",

--- a/pkg/client/keycloakapi/roles_test.go
+++ b/pkg/client/keycloakapi/roles_test.go
@@ -27,22 +27,7 @@ func TestRolesClient_CRUD(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-role-crud-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm first
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	require.NotNil(t, resp.HTTPResponse)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	roleName := "test-role"
 	roleDescription := "Test role for CRUD operations"
@@ -53,7 +38,7 @@ func TestRolesClient_CRUD(t *testing.T) {
 		Description: &roleDescription,
 	}
 
-	resp, err = c.Roles.CreateRealmRole(ctx, realmName, role)
+	resp, err := c.Roles.CreateRealmRole(ctx, realmName, role)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.HTTPResponse)
@@ -188,21 +173,7 @@ func TestRolesClient_CreateRealmRole_Conflict(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-role-conflict-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	roleName := "duplicate-role"
 	role := keycloakapi.RoleRepresentation{
@@ -210,7 +181,7 @@ func TestRolesClient_CreateRealmRole_Conflict(t *testing.T) {
 	}
 
 	// Create the role
-	resp, err = c.Roles.CreateRealmRole(ctx, realmName, role)
+	resp, err := c.Roles.CreateRealmRole(ctx, realmName, role)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -236,18 +207,7 @@ func TestRolesClient_UpdateAndComposites(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-role-composites-%d", time.Now().UnixNano())
-	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	resp, err := c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	})
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	mainRoleName := "main-role"
 	subRole1Name := "sub-role-1"

--- a/pkg/client/keycloakapi/sessions_test.go
+++ b/pkg/client/keycloakapi/sessions_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/utils/ptr"
 
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	"github.com/epam/edp-keycloak-operator/pkg/testutils"
@@ -28,15 +27,7 @@ func TestSessionsClient_GetRealmSessionStats(t *testing.T) {
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-sessions-%d", time.Now().UnixNano())
 
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: ptr.To(true),
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	stats, resp, err := c.Sessions.GetRealmSessionStats(ctx, realmName)
 	require.NoError(t, err)
@@ -60,15 +51,7 @@ func TestSessionsClient_LogoutAllSessions(t *testing.T) {
 	ctx := context.Background()
 	realmName := fmt.Sprintf("test-realm-logout-all-%d", time.Now().UnixNano())
 
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: ptr.To(true),
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	resp, err := c.Sessions.LogoutAllSessions(ctx, realmName)
 	require.NoError(t, err)

--- a/pkg/client/keycloakapi/users_test.go
+++ b/pkg/client/keycloakapi/users_test.go
@@ -30,22 +30,7 @@ func TestUsersClient_UserProfile_CRUD(t *testing.T) {
 
 	// Generate unique realm name to avoid conflicts
 	realmName := fmt.Sprintf("test-realm-user-profile-%d", time.Now().UnixNano())
-	enabled := true
-
-	// Ensure cleanup happens even if test fails
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	// Create test realm first
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	require.NotNil(t, resp.HTTPResponse)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	// 1. Get default user profile configuration
 	originalProfile, resp, err := c.Users.GetUsersProfile(ctx, realmName)
@@ -154,19 +139,9 @@ func TestUsersClient_FindUserByUsername(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-find-user-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
 
 	username := "test-find-user"
 	email := "test-find-user@example.com"
@@ -177,7 +152,7 @@ func TestUsersClient_FindUserByUsername(t *testing.T) {
 	}
 
 	// Create a user
-	resp, err = c.Users.CreateUser(ctx, realmName, user)
+	resp, err := c.Users.CreateUser(ctx, realmName, user)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -236,19 +211,9 @@ func TestUsersClient_CreateUser(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-create-user-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	resp, err := c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
 
 	username := "new-test-user"
 	email := "new-test-user@example.com"
@@ -258,7 +223,7 @@ func TestUsersClient_CreateUser(t *testing.T) {
 		Enabled:  &enabled,
 	}
 
-	resp, err = c.Users.CreateUser(ctx, realmName, user)
+	resp, err := c.Users.CreateUser(ctx, realmName, user)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.HTTPResponse)
@@ -285,18 +250,9 @@ func TestUsersClient_CreateUser_Conflict(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-create-user-conflict-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	realm := keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: &enabled,
-	}
-	_, err = c.Realms.CreateRealm(ctx, realm)
-	require.NoError(t, err)
 
 	username := "duplicate-user"
 	user := keycloakapi.UserRepresentation{
@@ -330,14 +286,9 @@ func TestUsersClient_GetUserRealmRoleMappings(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-user-role-mappings-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{Realm: &realmName, Enabled: &enabled})
-	require.NoError(t, err)
 
 	// Create a role
 	roleName := "mapping-test-role"
@@ -452,14 +403,9 @@ func TestUsersClient_GetUserGroups(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-user-groups-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{Realm: &realmName, Enabled: &enabled})
-	require.NoError(t, err)
 
 	// Create a user
 	username := "user-groups-test"
@@ -531,14 +477,9 @@ func TestUsersClient_AddUserToGroup(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-add-user-group-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{Realm: &realmName, Enabled: &enabled})
-	require.NoError(t, err)
 
 	// Create a user
 	username := "add-group-user"
@@ -633,14 +574,9 @@ func TestUsersClient_RemoveUserFromGroup(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-remove-user-group-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{Realm: &realmName, Enabled: &enabled})
-	require.NoError(t, err)
 
 	// Create a user
 	username := "remove-group-user"
@@ -719,14 +655,9 @@ func TestUsersClient_UpdateAndDeleteUser(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-upd-del-user-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{Realm: &realmName, Enabled: &enabled})
-	require.NoError(t, err)
 
 	username := "update-delete-user"
 	_, err = c.Users.CreateUser(ctx, realmName, keycloakapi.UserRepresentation{Username: &username, Enabled: &enabled})
@@ -801,14 +732,9 @@ func TestUsersClient_SetUserPassword(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-set-pwd-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{Realm: &realmName, Enabled: &enabled})
-	require.NoError(t, err)
 
 	username := "password-user"
 	_, err = c.Users.CreateUser(ctx, realmName, keycloakapi.UserRepresentation{Username: &username, Enabled: &enabled})
@@ -846,14 +772,9 @@ func TestUsersClient_UserClientRoleMappings(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-user-cli-roles-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{Realm: &realmName, Enabled: &enabled})
-	require.NoError(t, err)
 
 	// Create client
 	clientID := fmt.Sprintf("test-client-%d", time.Now().UnixNano())
@@ -944,14 +865,9 @@ func TestUsersClient_UserFederatedIdentities(t *testing.T) {
 	ctx := context.Background()
 
 	realmName := fmt.Sprintf("test-realm-fed-id-%d", time.Now().UnixNano())
+	testutils.CreateRealmWithRetry(t, c, realmName)
+
 	enabled := true
-
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{Realm: &realmName, Enabled: &enabled})
-	require.NoError(t, err)
 
 	// Create an identity provider
 	alias := fmt.Sprintf("test-idp-%d", time.Now().UnixNano())
@@ -1301,15 +1217,7 @@ func newUsersTestRealm(t *testing.T) (*keycloakapi.KeycloakClient, string) {
 
 	realmName := fmt.Sprintf("test-realm-users-%d", time.Now().UnixNano())
 
-	t.Cleanup(func() {
-		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
-	})
-
-	_, err = c.Realms.CreateRealm(context.Background(), keycloakapi.RealmRepresentation{
-		Realm:   &realmName,
-		Enabled: ptr.To(true),
-	})
-	require.NoError(t, err)
+	testutils.CreateRealmWithRetry(t, c, realmName)
 
 	return c, realmName
 }

--- a/pkg/testutils/keycloak_integration.go
+++ b/pkg/testutils/keycloak_integration.go
@@ -1,8 +1,14 @@
 package testutils
 
 import (
+	"context"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 )
 
 // GetKeycloakURLOrSkip returns the TEST_KEYCLOAK_URL environment variable value.
@@ -17,4 +23,26 @@ func GetKeycloakURLOrSkip(t *testing.T) string {
 	}
 
 	return url
+}
+
+// CreateRealmWithRetry creates a fresh enabled realm and registers t.Cleanup
+// to delete it. Keycloak transiently returns "unknown_error" under parallel
+// test load, so realm creation is retried for up to 10s.
+func CreateRealmWithRetry(t *testing.T, c *keycloakapi.KeycloakClient, realmName string) {
+	t.Helper()
+
+	enabled := true
+
+	require.Eventually(t, func() bool {
+		_, err := c.Realms.CreateRealm(context.Background(), keycloakapi.RealmRepresentation{
+			Realm:   &realmName,
+			Enabled: &enabled,
+		})
+
+		return err == nil
+	}, 10*time.Second, time.Second, "creating realm %s", realmName)
+
+	t.Cleanup(func() {
+		_, _ = c.Realms.DeleteRealm(context.Background(), realmName)
+	})
 }


### PR DESCRIPTION
## Summary

- Adds `testutils.CreateRealmWithRetry` helper that wraps `Realms.CreateRealm` in `require.Eventually` (10s timeout, 1s interval) and registers `t.Cleanup` to delete the realm.
- Migrates ~76 callsites across 14 `*_test.go` files in `pkg/client/keycloakapi` to use the helper, deleting ~800 lines of duplicated setup/teardown.
- Fixes flake where Keycloak transiently returns `unknown_error` under parallel test load (e.g. `TestIdentityProvidersClient_GetIdentityProviders` on internal CI). Same precedent already used for `GetScope` in `authorization_test.go`.

## Notes

- `TestRealmClient_CRUD` is intentionally **not** migrated — it tests `CreateRealm` itself.
- `newOrganizationsTestRealm` keeps an inline `require.Eventually` because it needs the extra `OrganizationsEnabled` field.

## Test plan

- [x] `go build ./...`
- [x] `make lint-fix` — 0 issues
- [x] `make test` (unit tests) — all pass
- [x] `TEST_KEYCLOAK_URL=http://localhost:8086 make test` — all pass
- [x] `TEST_KEYCLOAK_URL=http://localhost:8086 go test -count=3 ./pkg/client/keycloakapi/` — passes under repeated load (65s)
- [ ] Internal CI run