### PR TITLE
fix(keycloakapi): route admin requests through resty.Request to enable retries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,3 +82,7 @@ Edit `pkg/client/keycloakapi/openapi.yaml` then re-run `make generate-keycloak-g
 
 ## Further Reading
 - `docs/development.md` — local setup, debugging, VS Code config
+
+
+## Commit Messages
+- Do not append `Co-Authored-By: Claude <noreply@anthropic.com>` (or any Claude co-author trailer) to git commit messages.

--- a/pkg/client/keycloakapi/keycloak_client.go
+++ b/pkg/client/keycloakapi/keycloak_client.go
@@ -34,7 +34,7 @@ type KeycloakClient struct {
 	authUrl             string
 	realm               string
 	clientCredentials   *ClientCredentials
-	httpClient          *http.Client
+	restyClient         *resty.Client
 	initialLogin        bool
 	userAgent           string
 	additionalHeaders   map[string]string
@@ -94,6 +94,8 @@ type clientConfig struct {
 	tlsClientCert         string
 	tlsClientPrivateKey   string
 	logger                logr.Logger
+	retryWaitTime         time.Duration
+	retryMaxWaitTime      time.Duration
 }
 
 // ClientOption is a function that configures a KeycloakClient
@@ -169,6 +171,21 @@ func WithInitialLogin(initialLogin bool) ClientOption {
 func WithClientTimeout(timeout int) ClientOption {
 	return func(c *KeycloakClient, cfg *clientConfig) {
 		cfg.clientTimeout = timeout
+	}
+}
+
+// WithRetryWaitTime sets the initial wait time between retries (default: 1s).
+// Resty uses exponential back-off; the actual delay is capped by WithRetryMaxWaitTime.
+func WithRetryWaitTime(d time.Duration) ClientOption {
+	return func(c *KeycloakClient, cfg *clientConfig) {
+		cfg.retryWaitTime = d
+	}
+}
+
+// WithRetryMaxWaitTime sets the maximum wait time between retries (default: 10s).
+func WithRetryMaxWaitTime(d time.Duration) ClientOption {
+	return func(c *KeycloakClient, cfg *clientConfig) {
+		cfg.retryMaxWaitTime = d
 	}
 }
 
@@ -259,6 +276,8 @@ func NewKeycloakClient(ctx context.Context, baseURL, clientId string, opts ...Cl
 	config := &clientConfig{
 		clientTimeout:         60, // default timeout in seconds
 		tlsInsecureSkipVerify: false,
+		retryWaitTime:         time.Second,
+		retryMaxWaitTime:      10 * time.Second,
 	}
 
 	// Initialize client with defaults
@@ -315,18 +334,20 @@ func NewKeycloakClient(ctx context.Context, baseURL, clientId string, opts ...Cl
 		)
 	}
 
-	httpClient, err := newHttpClient(
+	restyClient, err := newRestyClient(
 		config.tlsInsecureSkipVerify,
 		config.clientTimeout,
 		config.caCert,
 		config.tlsClientCert,
 		config.tlsClientPrivateKey,
+		config.retryWaitTime,
+		config.retryMaxWaitTime,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create http client: %v", err)
 	}
 
-	keycloakClient.httpClient = httpClient
+	keycloakClient.restyClient = restyClient
 
 	if keycloakClient.clientCredentials.AccessToken == "" && keycloakClient.initialLogin {
 		err = keycloakClient.login(ctx)
@@ -390,46 +411,26 @@ func (keycloakClient *KeycloakClient) login(ctx context.Context) error {
 
 		logger.V(debugVerbosityLevel).Info("Login request", "content_length", len(accessTokenData.Encode()))
 
-		accessTokenRequest, err := http.NewRequestWithContext(
-			ctx,
-			http.MethodPost,
-			accessTokenUrl,
-			strings.NewReader(accessTokenData.Encode()),
-		)
-		if err != nil {
-			return err
-		}
-
-		for header, value := range keycloakClient.additionalHeaders {
-			accessTokenRequest.Header.Set(header, value)
-		}
-
-		accessTokenRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-		if keycloakClient.userAgent != "" {
-			accessTokenRequest.Header.Set("User-Agent", keycloakClient.userAgent)
-		}
-
-		accessTokenResponse, err := keycloakClient.httpClient.Do(accessTokenRequest)
-		if err != nil {
-			return err
-		}
-
-		if accessTokenResponse.StatusCode != http.StatusOK {
-			return fmt.Errorf("error sending POST request to %s: %s", accessTokenUrl, accessTokenResponse.Status)
-		}
-
-		defer func() {
-			_ = accessTokenResponse.Body.Close()
-		}()
-
-		body, _ := io.ReadAll(accessTokenResponse.Body)
-
 		var clientCredentials ClientCredentials
 
-		err = json.Unmarshal(body, &clientCredentials)
+		req := keycloakClient.restyClient.R().
+			SetContext(ctx).
+			SetFormDataFromValues(accessTokenData).
+			SetHeaders(keycloakClient.additionalHeaders).
+			SetHeader("Content-Type", "application/x-www-form-urlencoded").
+			SetResult(&clientCredentials)
+
+		if keycloakClient.userAgent != "" {
+			req.SetHeader("User-Agent", keycloakClient.userAgent)
+		}
+
+		resp, err := req.Post(accessTokenUrl)
 		if err != nil {
 			return err
+		}
+
+		if resp.IsError() {
+			return fmt.Errorf("error sending POST request to %s: %s", accessTokenUrl, resp.Status())
 		}
 
 		logger.V(debugVerbosityLevel).Info("Login response", "expires_in", clientCredentials.ExpiresIn)
@@ -463,40 +464,24 @@ func (keycloakClient *KeycloakClient) Refresh(ctx context.Context) error {
 
 	logger.V(debugVerbosityLevel).Info("Refresh request", "content_length", len(refreshTokenData.Encode()))
 
-	refreshTokenRequest, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
-		refreshTokenUrl,
-		strings.NewReader(refreshTokenData.Encode()),
-	)
-	if err != nil {
-		return err
-	}
-
-	for header, value := range keycloakClient.additionalHeaders {
-		refreshTokenRequest.Header.Set(header, value)
-	}
-
-	refreshTokenRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req := keycloakClient.restyClient.R().
+		SetContext(ctx).
+		SetFormDataFromValues(refreshTokenData).
+		SetHeaders(keycloakClient.additionalHeaders).
+		SetHeader("Content-Type", "application/x-www-form-urlencoded")
 
 	if keycloakClient.userAgent != "" {
-		refreshTokenRequest.Header.Set("User-Agent", keycloakClient.userAgent)
+		req.SetHeader("User-Agent", keycloakClient.userAgent)
 	}
 
-	refreshTokenResponse, err := keycloakClient.httpClient.Do(refreshTokenRequest)
+	resp, err := req.Post(refreshTokenUrl)
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		_ = refreshTokenResponse.Body.Close()
-	}()
-
-	body, _ := io.ReadAll(refreshTokenResponse.Body)
 
 	// Handle 401 "User or client no longer has role permissions for client key"
 	// until I better understand why that happens in the first place
-	if refreshTokenResponse.StatusCode == http.StatusBadRequest {
+	if resp.StatusCode() == http.StatusBadRequest {
 		logger.V(debugVerbosityLevel).Info("Unexpected 400, attempting to log in again")
 
 		return keycloakClient.login(ctx)
@@ -504,7 +489,7 @@ func (keycloakClient *KeycloakClient) Refresh(ctx context.Context) error {
 
 	var clientCredentials ClientCredentials
 
-	err = json.Unmarshal(body, &clientCredentials)
+	err = json.Unmarshal(resp.Body(), &clientCredentials)
 	if err != nil {
 		return err
 	}
@@ -642,7 +627,7 @@ func (d *keycloakDoer) Do(req *http.Request) (*http.Response, error) {
 
 	d.kc.addRequestHeaders(req)
 
-	resp, err := d.kc.httpClient.Do(req)
+	resp, err := d.executeViaResty(req)
 	if err != nil {
 		return nil, err
 	}
@@ -677,13 +662,55 @@ func (d *keycloakDoer) Do(req *http.Request) (*http.Response, error) {
 
 		d.kc.addRequestHeaders(req)
 
-		resp, err = d.kc.httpClient.Do(req)
+		resp, err = d.executeViaResty(req)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	return resp, nil
+}
+
+// executeViaResty forwards an *http.Request through the configured resty.Client
+// so that resty's retry middleware (SetRetryCount + RetryPolicy) is actually
+// invoked. Calling restyClient.GetClient().Do bypasses retries entirely.
+func (d *keycloakDoer) executeViaResty(req *http.Request) (*http.Response, error) {
+	var bodyBytes []byte
+
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("reading request body: %w", err)
+		}
+
+		_ = req.Body.Close()
+		bodyBytes = b
+	}
+
+	rr := d.kc.restyClient.R().
+		SetContext(req.Context()).
+		SetDoNotParseResponse(true)
+
+	for k, vs := range req.Header {
+		for _, v := range vs {
+			rr.SetHeader(k, v)
+		}
+	}
+
+	if bodyBytes != nil {
+		rr.SetBody(bodyBytes)
+	}
+
+	resp, err := rr.Execute(req.Method, req.URL.String())
+	if err != nil {
+		if resp != nil && resp.RawResponse != nil {
+			return resp.RawResponse, err
+		}
+
+		return nil, err
+	}
+
+	return resp.RawResponse, nil
 }
 
 func RetryPolicy(resp *resty.Response, err error) bool {
@@ -711,13 +738,15 @@ func RetryPolicy(resp *resty.Response, err error) bool {
 	return false
 }
 
-func newHttpClient(
+func newRestyClient(
 	tlsInsecureSkipVerify bool,
 	clientTimeout int,
 	caCert string,
 	tlsClientCert string,
 	tlsClientPrivateKey string,
-) (*http.Client, error) {
+	retryWaitTime time.Duration,
+	retryMaxWaitTime time.Duration,
+) (*resty.Client, error) {
 	cookieJar, err := cookiejar.New(&cookiejar.Options{
 		PublicSuffixList: publicsuffix.List,
 	})
@@ -751,13 +780,11 @@ func newHttpClient(
 		SetTimeout(time.Second * time.Duration(clientTimeout)).
 		SetCookieJar(cookieJar).
 		SetRetryCount(5).
-		SetRetryWaitTime(time.Second).
-		SetRetryMaxWaitTime(time.Second * 60).
+		SetRetryWaitTime(retryWaitTime).
+		SetRetryMaxWaitTime(retryMaxWaitTime).
 		AddRetryCondition(RetryPolicy)
 
-	httpClient := restyClient.GetClient()
-
-	return httpClient, nil
+	return restyClient, nil
 }
 
 func (keycloakClient *KeycloakClient) newSignedJWT(

--- a/pkg/client/keycloakapi/keycloak_client_test.go
+++ b/pkg/client/keycloakapi/keycloak_client_test.go
@@ -292,7 +292,7 @@ func TestNewKeycloakClient(t *testing.T) {
 				t.Error("realm should have default value")
 			}
 
-			assert.NotNil(t, client.httpClient)
+			assert.NotNil(t, client.restyClient)
 			assert.NotNil(t, client.Users)
 			assert.NotNil(t, client.Realms)
 		})
@@ -1321,7 +1321,7 @@ func TestRetryPolicy(t *testing.T) {
 	}
 }
 
-func TestNewHttpClient(t *testing.T) {
+func TestNewRestyClient(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -1333,16 +1333,16 @@ func TestNewHttpClient(t *testing.T) {
 		tlsClientPrivateKey   string
 		setupCerts            func(t *testing.T) (string, string)
 		wantErr               bool
-		validate              func(t *testing.T, client *http.Client)
+		validate              func(t *testing.T, client *resty.Client)
 	}{
 		{
 			name:                  "default configuration",
 			tlsInsecureSkipVerify: false,
 			clientTimeout:         60,
 			wantErr:               false,
-			validate: func(t *testing.T, client *http.Client) {
+			validate: func(t *testing.T, client *resty.Client) {
 				assert.NotNil(t, client)
-				assert.Equal(t, 60*time.Second, client.Timeout)
+				assert.Equal(t, 60*time.Second, client.GetClient().Timeout)
 			},
 		},
 		{
@@ -1350,8 +1350,8 @@ func TestNewHttpClient(t *testing.T) {
 			tlsInsecureSkipVerify: true,
 			clientTimeout:         30,
 			wantErr:               false,
-			validate: func(t *testing.T, client *http.Client) {
-				transport := client.Transport.(*http.Transport)
+			validate: func(t *testing.T, client *resty.Client) {
+				transport := client.GetClient().Transport.(*http.Transport)
 				assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
 			},
 		},
@@ -1363,8 +1363,8 @@ func TestNewHttpClient(t *testing.T) {
 				return caCert
 			}(),
 			wantErr: false,
-			validate: func(t *testing.T, client *http.Client) {
-				transport := client.Transport.(*http.Transport)
+			validate: func(t *testing.T, client *resty.Client) {
+				transport := client.GetClient().Transport.(*http.Transport)
 				assert.NotNil(t, transport.TLSClientConfig.RootCAs)
 			},
 		},
@@ -1378,8 +1378,8 @@ func TestNewHttpClient(t *testing.T) {
 				return clientCert, clientKey
 			},
 			wantErr: false,
-			validate: func(t *testing.T, client *http.Client) {
-				transport := client.Transport.(*http.Transport)
+			validate: func(t *testing.T, client *resty.Client) {
+				transport := client.GetClient().Transport.(*http.Transport)
 				assert.NotEmpty(t, transport.TLSClientConfig.Certificates)
 			},
 		},
@@ -1396,12 +1396,14 @@ func TestNewHttpClient(t *testing.T) {
 				clientCert, privateKey = tt.setupCerts(t)
 			}
 
-			client, err := newHttpClient(
+			client, err := newRestyClient(
 				tt.tlsInsecureSkipVerify,
 				tt.clientTimeout,
 				tt.caCert,
 				clientCert,
 				privateKey,
+				time.Second,
+				10*time.Second,
 			)
 
 			if tt.wantErr {
@@ -1708,6 +1710,8 @@ func TestClientOptions_AllOptions(t *testing.T) {
 		WithAdditionalHeaders(customHeaders),
 		WithRedHatSSO(true),
 		WithClientTimeout(30),
+		WithRetryWaitTime(2*time.Second),
+		WithRetryMaxWaitTime(20*time.Second),
 		WithTLSInsecureSkipVerify(true),
 		WithCACert(caCertPEM),
 		WithLogger(logr.Discard()),
@@ -1723,7 +1727,7 @@ func TestClientOptions_AllOptions(t *testing.T) {
 	assert.Equal(t, testUserAgent, client.userAgent)
 	assert.Equal(t, "test-value", client.additionalHeaders["X-Test-Header"])
 	assert.True(t, client.redHatSSO)
-	assert.Equal(t, 30*time.Second, client.httpClient.Timeout)
+	assert.Equal(t, 30*time.Second, client.restyClient.GetClient().Timeout)
 }
 
 func TestNewSignedJWT_Deprecated(t *testing.T) {
@@ -1785,7 +1789,7 @@ func TestClientOptions_WithTLSClientCert(t *testing.T) {
 	require.NotNil(t, client)
 
 	// Verify TLS config has certificates
-	transport := client.httpClient.Transport.(*http.Transport)
+	transport := client.restyClient.GetClient().Transport.(*http.Transport)
 	assert.NotEmpty(t, transport.TLSClientConfig.Certificates)
 }
 
@@ -2013,16 +2017,18 @@ func TestKeycloakClient_GetAuthenticationFormData_JWTFromFile_Error(t *testing.T
 	assert.Contains(t, err.Error(), "failed to read JWT token from file")
 }
 
-func TestNewHttpClient_InvalidCert(t *testing.T) {
+func TestNewRestyClient_InvalidCert(t *testing.T) {
 	t.Parallel()
 
 	// Test with invalid client certificate
-	_, err := newHttpClient(
+	_, err := newRestyClient(
 		false,
 		60,
 		"",
 		"invalid-cert",
 		"invalid-key",
+		time.Second,
+		10*time.Second,
 	)
 
 	require.Error(t, err)
@@ -2135,6 +2141,61 @@ func TestKeycloakDoer_ConcurrentRefresh(t *testing.T) {
 	finalRefreshCount := atomic.LoadInt32(&refreshCount)
 	assert.Greater(t, finalRefreshCount, int32(0))
 	assert.LessOrEqual(t, finalRefreshCount, int32(numRequests))
+}
+
+// TestKeycloakDoer_5xxRetriesFireViaResty proves that transient 5xx responses
+// are retried by resty's middleware (via executeViaResty) and that the caller
+// ultimately receives a successful response once the server recovers.
+func TestKeycloakDoer_5xxRetriesFireViaResty(t *testing.T) {
+	t.Parallel()
+
+	const failCount = 2 // server returns 500 for the first two attempts
+
+	var callCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/token") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(createMockTokenResponseJSON()))
+
+			return
+		}
+
+		n := callCount.Add(1)
+		if n <= failCount {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":"ok"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewKeycloakClient(
+		context.Background(),
+		server.URL,
+		testClientID,
+		WithAccessToken(testAccessToken),
+		// Use minimal wait times so the test completes quickly.
+		WithRetryWaitTime(time.Millisecond),
+		WithRetryMaxWaitTime(5*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	req, _ := http.NewRequest(http.MethodGet, server.URL+"/admin/realms", nil)
+	doer := &keycloakDoer{kc: client}
+	resp, err := doer.Do(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	// failCount failures + 1 success = failCount+1 total admin calls
+	assert.Equal(t, int32(failCount+1), callCount.Load())
 }
 
 func TestKeycloakClient_Login_ContextLogger(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a wiring bug where the Keycloak client's configured `SetRetryCount(5)` + `RetryPolicy` were never invoked.

Resty's retry middleware only runs inside `resty.Request.Execute`. The current code at [keycloak_client.go:758](pkg/client/keycloakapi/keycloak_client.go#L758) does `restyClient.GetClient()` and the doer at [keycloak_client.go:645](pkg/client/keycloakapi/keycloak_client.go#L645) calls `httpClient.Do(req)`, which bypasses retries entirely. As a result, Keycloak's transient `unknown_error` (5xx under parallel load) propagates raw to callers, causing intermittent integration-test failures and degraded production resilience.

## Changes

- `keycloakDoer.Do` now forwards every admin-API request through `restyClient.R().Execute(...)` via a new `executeViaResty` helper. Resty's existing `Backoff` retry path with the existing `RetryPolicy` (5xx / 429 / network errors) is now actually invoked.
- `SetRetryMaxWaitTime` reduced 60s → 10s so a single transient request can't block a controller reconciler for a minute. Worst-case: 1+2+4+8+10s ≈ 25s across 5 retries.

## Test plan

- [x] `go build ./...` clean
- [x] `make lint-fix` — 0 issues
- [x] `make test` (unit tests) — all pass
- [x] `TEST_KEYCLOAK_URL=http://localhost:8086 make test` — full suite passes against real Keycloak
- [x] `TEST_KEYCLOAK_URL=http://localhost:8086 go test -count=3 ./pkg/client/keycloakapi/` — three sequential runs, all pass
- [x] Verified `TestIdentityProvidersClient_GetIdentityProviders`, `TestOrganizationsClient_CRUD`, `TestOrganizationsClient_GetOrganizationByAlias` (the previously-flaky tests) pass repeatedly
- [ ] Internal CI run