### PR TITLE
docs(README): add note about keycloakapi as standalone library

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ For comprehensive local development setup, testing, debugging, and common develo
 
 Development versions are also available from the [snapshot Helm Chart repository](https://epam.github.io/edp-helm-charts/snapshot/) page.
 
+## Using the Keycloak Client as a Library
+
+The [`pkg/client/keycloakapi`](pkg/client/keycloakapi/) package is a standalone Go client for the Keycloak Admin REST API (Keycloak 25+, including Red Hat build of Keycloak) and can be imported independently of the operator. See the [package documentation on pkg.go.dev](https://pkg.go.dev/github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi) for usage, supported authentication options, and the available sub-clients.
+
 ### Related Articles
 
 * [Install KubeRocketCI](https://docs.kuberocketci.io/docs/operator-guide/install-kuberocketci)

--- a/internal/controller/keycloakrealm/keycloakrealm_controller_integration_test.go
+++ b/internal/controller/keycloakrealm/keycloakrealm_controller_integration_test.go
@@ -52,7 +52,7 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 					EnabledEventTypes:         []string{"UPDATE_CONSENT_ERROR", "CLIENT_LOGIN"},
 					EventsEnabled:             true,
 					EventsExpiration:          15000,
-					EventsListeners:           []string{"jboss-logging"},
+					EventsListeners:           []string{"jboss-logging", "email"},
 					AdminEventsExpiration:     100,
 				},
 				PasswordPolicies: []common.PasswordPolicy{
@@ -225,7 +225,7 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 			g.Expect(realm.AdminEventsEnabled).Should(Equal(ptr.To(true)))
 			g.Expect(realm.EventsEnabled).Should(Equal(ptr.To(true)))
 			g.Expect(realm.EventsExpiration).Should(Equal(ptr.To(int64(15000))))
-			g.Expect(*realm.EventsListeners).Should(ContainElement("jboss-logging"))
+			g.Expect(*realm.EventsListeners).Should(ContainElements("jboss-logging", "email"))
 			g.Expect(*realm.EnabledEventTypes).Should(ContainElements("UPDATE_CONSENT_ERROR", "CLIENT_LOGIN"))
 
 			// Verify adminEventsExpiration stored as realm attribute

--- a/internal/webhook/v1/webhook_suite_test.go
+++ b/internal/webhook/v1/webhook_suite_test.go
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = SetupKeycloakRealmWebhookWithManager(mgr, mgr.GetClient())
+	err = SetupKeycloakRealmWebhookWithManager(mgr, k8sClient)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = SetupKeycloakClientWebhookWithManager(mgr)


### PR DESCRIPTION
## Summary
- Add a section in the README mentioning `pkg/client/keycloakapi` as a standalone Go client for the Keycloak Admin REST API, linking to its pkg.go.dev documentation.
- Extend the KeycloakRealm integration test to verify multiple event listeners (`jboss-logging`, `email`).

## Test plan
- [ ] README renders correctly on GitHub
- [ ] `make test` passes (with Keycloak running for integration test)