### PR TITLE
feat(Keycloak): add adminPermissionsEnabled field for fine-grained permissions v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ docker-push: ## Push docker image with the manager.
 
 .PHONY: start-keycloak
 start-keycloak: ## Start Keycloak instance for testing
-	docker run -d -p 8086:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -e KC_FEATURES=admin-fine-grained-authz:v1 --name keycloak-test quay.io/keycloak/keycloak:latest start-dev
+	docker run -d -p 8086:8080 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin --name keycloak-test quay.io/keycloak/keycloak:latest start-dev
 
 .PHONY: delete-keycloak
 delete-keycloak: ## Stop Keycloak test instance

--- a/api/v1/keycloakrealm_types.go
+++ b/api/v1/keycloakrealm_types.go
@@ -81,6 +81,10 @@ type KeycloakRealmSpec struct {
 	// +kubebuilder:default=false
 	OrganizationsEnabled bool `json:"organizationsEnabled,omitempty"`
 
+	// AdminPermissionsEnabled enables Keycloak fine-grained v2 admin permissions for this realm.
+	// +optional
+	AdminPermissionsEnabled bool `json:"adminPermissionsEnabled,omitempty"`
+
 	// UserProfileConfig is the configuration for user profiles in the realm.
 	// Attributes and groups will be added to the current realm configuration.
 	// Deletion of attributes and groups is not supported.

--- a/api/v1alpha1/clusterkeycloakrealm_types.go
+++ b/api/v1alpha1/clusterkeycloakrealm_types.go
@@ -71,6 +71,10 @@ type ClusterKeycloakRealmSpec struct {
 	// +kubebuilder:default=false
 	OrganizationsEnabled bool `json:"organizationsEnabled,omitempty"`
 
+	// AdminPermissionsEnabled enables Keycloak fine-grained v2 admin permissions for this realm.
+	// +optional
+	AdminPermissionsEnabled bool `json:"adminPermissionsEnabled,omitempty"`
+
 	// UserProfileConfig is the configuration for user profiles in the realm.
 	// +nullable
 	// +optional

--- a/config/crd/bases/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/config/crd/bases/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -53,6 +53,10 @@ spec:
           spec:
             description: ClusterKeycloakRealmSpec defines the desired state of ClusterKeycloakRealm.
             properties:
+              adminPermissionsEnabled:
+                description: AdminPermissionsEnabled enables Keycloak fine-grained v2
+                  admin permissions for this realm.
+                type: boolean
               authenticationFlows:
                 description: AuthenticationFlow is the configuration for authentication
                   flows in the realm.

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
@@ -56,6 +56,10 @@ spec:
           spec:
             description: KeycloakRealmSpec defines the desired state of KeycloakRealm.
             properties:
+              adminPermissionsEnabled:
+                description: AdminPermissionsEnabled enables Keycloak fine-grained v2
+                  admin permissions for this realm.
+                type: boolean
               browserFlow:
                 description: BrowserFlow specifies the authentication flow to use
                   for the realm's browser clients.

--- a/config/samples/v1_v1_keycloakrealm.yaml
+++ b/config/samples/v1_v1_keycloakrealm.yaml
@@ -6,6 +6,7 @@ spec:
   id: d1-id-kc-realm-name
   realmName: d2-id-kc-realm-name
   organizationsEnabled: true
+  adminPermissionsEnabled: true
   keycloakRef:
     name: keycloak-sample
     kind: Keycloak

--- a/config/samples/v1_v1alpha1_clusterkeycloakrealm.yaml
+++ b/config/samples/v1_v1alpha1_clusterkeycloakrealm.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   clusterKeycloakRef: clusterkeycloak-sample
   realmName: realm-sample
+  adminPermissionsEnabled: true
   organizationsEnabled: false
   localization:
     internationalizationEnabled: true

--- a/deploy-templates/_crd_examples/clusterkeycloakrealm.yaml
+++ b/deploy-templates/_crd_examples/clusterkeycloakrealm.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   clusterKeycloakRef: clusterkeycloak-sample
   realmName: realm-sample1234
+  adminPermissionsEnabled: true
   authenticationFlows:
     browserFlow: browserFlow-sample
   login:

--- a/deploy-templates/_crd_examples/keycloakrealm.yaml
+++ b/deploy-templates/_crd_examples/keycloakrealm.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keycloakrealm-sample
 spec:
   realmName: realm-sample
+  adminPermissionsEnabled: true
   keycloakRef:
     name: keycloak-sample
     kind: Keycloak

--- a/deploy-templates/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -53,6 +53,10 @@ spec:
           spec:
             description: ClusterKeycloakRealmSpec defines the desired state of ClusterKeycloakRealm.
             properties:
+              adminPermissionsEnabled:
+                description: AdminPermissionsEnabled enables Keycloak fine-grained v2
+                  admin permissions for this realm.
+                type: boolean
               authenticationFlows:
                 description: AuthenticationFlow is the configuration for authentication
                   flows in the realm.

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
@@ -56,6 +56,10 @@ spec:
           spec:
             description: KeycloakRealmSpec defines the desired state of KeycloakRealm.
             properties:
+              adminPermissionsEnabled:
+                description: AdminPermissionsEnabled enables Keycloak fine-grained v2
+                  admin permissions for this realm.
+                type: boolean
               browserFlow:
                 description: BrowserFlow specifies the authentication flow to use
                   for the realm's browser clients.

--- a/docs/api.md
+++ b/docs/api.md
@@ -103,6 +103,13 @@ ClusterKeycloakRealmSpec defines the desired state of ClusterKeycloakRealm.
         </td>
         <td>true</td>
       </tr><tr>
+        <td><b>adminPermissionsEnabled</b></td>
+        <td>boolean</td>
+        <td>
+          AdminPermissionsEnabled enables Keycloak fine-grained v2 admin permissions for this realm.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#clusterkeycloakrealmspecauthenticationflows">authenticationFlows</a></b></td>
         <td>object</td>
         <td>
@@ -6152,6 +6159,13 @@ KeycloakRealmSpec defines the desired state of KeycloakRealm.
             <i>Validations</i>:<li>self == oldSelf: Value is immutable</li>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b>adminPermissionsEnabled</b></td>
+        <td>boolean</td>
+        <td>
+          AdminPermissionsEnabled enables Keycloak fine-grained v2 admin permissions for this realm.<br/>
+        </td>
+        <td>false</td>
       </tr><tr>
         <td><b>browserFlow</b></td>
         <td>string</td>

--- a/internal/controller/keycloakrealm/keycloakrealm_controller_integration_test.go
+++ b/internal/controller/keycloakrealm/keycloakrealm_controller_integration_test.go
@@ -79,6 +79,7 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 				},
 				DisplayName:     "Test Realm",
 				DisplayHTMLName: "<b>Test Realm</b>",
+				AdminPermissionsEnabled: true,
 				UserProfileConfig: &common.UserProfileConfig{
 					Attributes: []common.UserProfileAttribute{
 						{
@@ -209,6 +210,8 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 			g.Expect(realm.DisplayName).Should(Equal(ptr.To("Test Realm")))
 			g.Expect(realm.DisplayNameHtml).Should(Equal(ptr.To("<b>Test Realm</b>")))
 			g.Expect(realm.BrowserFlow).Should(Equal(ptr.To("browser")))
+			g.Expect(realm.AdminPermissionsEnabled).ShouldNot(BeNil())
+			g.Expect(*realm.AdminPermissionsEnabled).Should(BeTrue())
 
 			// Verify token settings
 			g.Expect(realm.DefaultSignatureAlgorithm).Should(Equal(ptr.To("RS256")))

--- a/pkg/realmbuilder/settings_builder.go
+++ b/pkg/realmbuilder/settings_builder.go
@@ -21,6 +21,7 @@ type commonRealmSpec struct {
 	DisplayName                 string
 	DisplayHTMLName             string
 	OrganizationsEnabled        bool
+	AdminPermissionsEnabled     bool
 	FrontendURL                 string
 	BrowserSecurityHeaders      *map[string]string
 	PasswordPolicy              string // pre-formatted "type(value) and …" string, empty if none
@@ -99,16 +100,17 @@ func BuildRealmRepresentationFromV1(realm *keycloakApi.KeycloakRealm) keycloakap
 	spec := &realm.Spec
 
 	c := commonRealmSpec{
-		DisplayName:            spec.DisplayName,
-		DisplayHTMLName:        spec.DisplayHTMLName,
-		OrganizationsEnabled:   spec.OrganizationsEnabled,
-		FrontendURL:            spec.FrontendURL,
-		BrowserSecurityHeaders: spec.BrowserSecurityHeaders,
-		TokenSettings:          spec.TokenSettings,
-		RealmEventConfig:       spec.RealmEventConfig,
-		Login:                  spec.Login,
-		Sessions:               spec.Sessions,
-		PasswordPolicy:         buildPasswordPolicy(spec.PasswordPolicies),
+		DisplayName:             spec.DisplayName,
+		DisplayHTMLName:         spec.DisplayHTMLName,
+		OrganizationsEnabled:    spec.OrganizationsEnabled,
+		AdminPermissionsEnabled: spec.AdminPermissionsEnabled,
+		FrontendURL:             spec.FrontendURL,
+		BrowserSecurityHeaders:  spec.BrowserSecurityHeaders,
+		TokenSettings:           spec.TokenSettings,
+		RealmEventConfig:        spec.RealmEventConfig,
+		Login:                   spec.Login,
+		Sessions:                spec.Sessions,
+		PasswordPolicy:          buildPasswordPolicy(spec.PasswordPolicies),
 	}
 
 	if spec.Themes != nil {
@@ -145,16 +147,17 @@ func BuildRealmRepresentationFromV1Alpha1(realm *v1alpha1.ClusterKeycloakRealm) 
 	spec := &realm.Spec
 
 	c := commonRealmSpec{
-		DisplayName:            spec.DisplayName,
-		DisplayHTMLName:        spec.DisplayHTMLName,
-		OrganizationsEnabled:   spec.OrganizationsEnabled,
-		FrontendURL:            spec.FrontendURL,
-		BrowserSecurityHeaders: spec.BrowserSecurityHeaders,
-		TokenSettings:          spec.TokenSettings,
-		RealmEventConfig:       spec.RealmEventConfig,
-		Login:                  spec.Login,
-		Sessions:               spec.Sessions,
-		PasswordPolicy:         buildPasswordPolicy(spec.PasswordPolicies),
+		DisplayName:             spec.DisplayName,
+		DisplayHTMLName:         spec.DisplayHTMLName,
+		OrganizationsEnabled:    spec.OrganizationsEnabled,
+		AdminPermissionsEnabled: spec.AdminPermissionsEnabled,
+		FrontendURL:             spec.FrontendURL,
+		BrowserSecurityHeaders:  spec.BrowserSecurityHeaders,
+		TokenSettings:           spec.TokenSettings,
+		RealmEventConfig:        spec.RealmEventConfig,
+		Login:                   spec.Login,
+		Sessions:                spec.Sessions,
+		PasswordPolicy:          buildPasswordPolicy(spec.PasswordPolicies),
 	}
 
 	if spec.Themes != nil {
@@ -205,6 +208,7 @@ func buildRealmRepresentationFromCommon(spec commonRealmSpec) keycloakapi.RealmR
 		DisplayName:                 ptr.To(spec.DisplayName),
 		DisplayNameHtml:             ptr.To(spec.DisplayHTMLName),
 		OrganizationsEnabled:        ptr.To(spec.OrganizationsEnabled),
+		AdminPermissionsEnabled:     ptr.To(spec.AdminPermissionsEnabled),
 		LoginTheme:                  spec.LoginTheme,
 		AccountTheme:                spec.AccountTheme,
 		AdminTheme:                  spec.AdminTheme,
@@ -285,6 +289,7 @@ func mergeRealmAppearance(base, overlay *keycloakapi.RealmRepresentation) {
 	mergePtr(&base.DisplayName, &overlay.DisplayName)
 	mergePtr(&base.DisplayNameHtml, &overlay.DisplayNameHtml)
 	mergePtr(&base.OrganizationsEnabled, &overlay.OrganizationsEnabled)
+	mergePtr(&base.AdminPermissionsEnabled, &overlay.AdminPermissionsEnabled)
 	mergePtr(&base.LoginTheme, &overlay.LoginTheme)
 	mergePtr(&base.AccountTheme, &overlay.AccountTheme)
 	mergePtr(&base.AdminTheme, &overlay.AdminTheme)

--- a/pkg/realmbuilder/settings_builder_test.go
+++ b/pkg/realmbuilder/settings_builder_test.go
@@ -38,6 +38,7 @@ func TestBuildRealmRepresentationFromV1(t *testing.T) {
 				assert.Equal(t, ptr.To("Test Realm"), got.DisplayName)
 				assert.Equal(t, ptr.To("<b>Test</b>"), got.DisplayNameHtml)
 				assert.Equal(t, ptr.To(false), got.OrganizationsEnabled)
+				assert.Equal(t, ptr.To(false), got.AdminPermissionsEnabled)
 				assert.Nil(t, got.LoginTheme)
 				assert.Nil(t, got.Attributes)
 			},
@@ -252,6 +253,18 @@ func TestBuildRealmRepresentationFromV1(t *testing.T) {
 				assert.Nil(t, got.LocalizationTexts)
 			},
 		},
+		{
+			name: "with admin permissions enabled",
+			realm: &keycloakApi.KeycloakRealm{
+				Spec: keycloakApi.KeycloakRealmSpec{
+					AdminPermissionsEnabled: true,
+				},
+			},
+			check: func(t *testing.T, got keycloakapi.RealmRepresentation) {
+				t.Helper()
+				assert.Equal(t, ptr.To(true), got.AdminPermissionsEnabled)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -283,6 +296,7 @@ func TestBuildRealmRepresentationFromV1Alpha1(t *testing.T) {
 				assert.Equal(t, ptr.To("Test Realm"), got.DisplayName)
 				assert.Equal(t, ptr.To("<b>Test</b>"), got.DisplayNameHtml)
 				assert.Equal(t, ptr.To(false), got.OrganizationsEnabled)
+				assert.Equal(t, ptr.To(false), got.AdminPermissionsEnabled)
 			},
 		},
 		{
@@ -454,6 +468,19 @@ func TestMergeRealmRepresentation(t *testing.T) {
 
 		assert.Equal(t, ptr.To("Original"), base.DisplayName)
 		assert.Equal(t, ptr.To(true), base.OrganizationsEnabled)
+	})
+
+	t.Run("AdminPermissionsEnabled merged from overlay", func(t *testing.T) {
+		base := keycloakapi.RealmRepresentation{
+			AdminPermissionsEnabled: ptr.To(false),
+		}
+		overlay := keycloakapi.RealmRepresentation{
+			AdminPermissionsEnabled: ptr.To(true),
+		}
+
+		MergeRealmRepresentation(&base, &overlay)
+
+		assert.Equal(t, ptr.To(true), base.AdminPermissionsEnabled)
 	})
 
 	t.Run("non-nil overlay pointer fields overwrite base", func(t *testing.T) {


### PR DESCRIPTION
Hello,

## Description
Adds optional adminPermissionsEnabled on KeycloakRealm and ClusterKeycloakRealm

## Notes
I would like your guidance on how to support FGAP v1 and FGAP v2 in parallel in this operator and in the test layout.

Today, management-permissions coverage in pkg/client/keycloakapi still depends on the v1 preview flag (admin-fine-grained-authz:v1), while realm-level adminPermissionsEnabled and the current Admin Console flows align more with v2. A single make start-keycloak profile cannot satisfy both assumptions.

Could you suggest a direction you would accept in this repo?
For example: two Makefile targets or two CI jobs with different Keycloak feature sets, a build tag or separate package for v1-only integration tests, or documenting that TEST_KEYCLOAK_URL must point at a v1-enabled instance for part of the suite. Happy to adjust the PR once there is a preferred pattern.

Have a good day,
Thomas