### PR TITLE
fix(KeycloakAuthFlow): preserve execution priority on creation

### DIFF
--- a/internal/controller/keycloakauthflow/chain/sync_auth_flow_executions.go
+++ b/internal/controller/keycloakauthflow/chain/sync_auth_flow_executions.go
@@ -60,7 +60,7 @@ func (h *SyncAuthFlowExecutions) Serve(ctx context.Context, flow *keycloakApi.Ke
 	for i := range execsToAdd {
 		e := &execsToAdd[i]
 
-		execID, err := h.addExecution(ctx, realmName, flowID, e.Authenticator, e.Requirement)
+		execID, err := h.addExecution(ctx, realmName, flowID, e.Authenticator, e.Requirement, e.Priority)
 		if err != nil {
 			return fmt.Errorf("failed to add execution %q: %w", e.Authenticator, err)
 		}
@@ -110,11 +110,19 @@ func (h *SyncAuthFlowExecutions) clearNonFlowExecutions(ctx context.Context, flo
 }
 
 // addExecution posts a new execution to the flow and returns the new execution ID from the Location header.
-func (h *SyncAuthFlowExecutions) addExecution(ctx context.Context, realmName, flowID, authenticator, requirement string) (string, error) {
+// Priority is always serialized (even when zero) so that Keycloak does not auto-assign it sequentially —
+// auto-assigned priorities collide with later adjustChildFlowsPriority updates when a parent flow mixes
+// non-flow executions with a child sub-flow.
+func (h *SyncAuthFlowExecutions) addExecution(
+	ctx context.Context, realmName, flowID, authenticator, requirement string, priority int,
+) (string, error) {
+	p := int32(priority)
+
 	resp, err := h.kClient.AuthFlows.AddExecutionToFlow(ctx, realmName, keycloakapi.AuthenticationExecutionRepresentation{
 		Authenticator: &authenticator,
 		ParentFlow:    &flowID,
 		Requirement:   &requirement,
+		Priority:      &p,
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to post execution: %w", err)

--- a/internal/controller/keycloakauthflow/chain/sync_auth_flow_executions_test.go
+++ b/internal/controller/keycloakauthflow/chain/sync_auth_flow_executions_test.go
@@ -108,6 +108,7 @@ func TestSyncAuthFlowExecutions_Serve_AddExecution(t *testing.T) {
 			Authenticator: ptr.To("basic-auth"),
 			ParentFlow:    ptr.To(testFlowID),
 			Requirement:   ptr.To(""),
+			Priority:      ptr.To(int32(0)),
 		},
 	).Return(locationResponse(testExecID), nil)
 
@@ -145,6 +146,7 @@ func TestSyncAuthFlowExecutions_Serve_AddExecutionWithConfig(t *testing.T) {
 			Authenticator: ptr.To("identity-provider-redirector"),
 			ParentFlow:    ptr.To(testFlowID),
 			Requirement:   ptr.To(""),
+			Priority:      ptr.To(int32(0)),
 		},
 	).Return(locationResponse(testExecID), nil)
 
@@ -269,6 +271,7 @@ func TestSyncAuthFlowExecutions_Serve_AddExecutionError(t *testing.T) {
 			Authenticator: ptr.To("basic-auth"),
 			ParentFlow:    ptr.To(testFlowID),
 			Requirement:   ptr.To(""),
+			Priority:      ptr.To(int32(0)),
 		},
 	).Return(nil, errors.New("add failed"))
 
@@ -296,4 +299,33 @@ func TestSyncAuthFlowExecutions_Serve_EmptyFlowID(t *testing.T) {
 	err := h.Serve(context.Background(), flow, testRealmName)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "flow ID is empty")
+}
+
+func TestSyncAuthFlowExecutions_Serve_AddExecutionPropagatesPriority(t *testing.T) {
+	mockFlows := mocks.NewMockAuthFlowsClient(t)
+	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
+
+	flow := &keycloakApi.KeycloakAuthFlow{}
+	flow.Spec.Alias = testFlowAlias
+	flow.Status.ID = testFlowID
+	flow.Spec.AuthenticationExecutions = []keycloakApi.AuthenticationExecution{
+		{Authenticator: "basic-auth", AuthenticatorFlow: false, Priority: 5, Requirement: "REQUIRED"},
+	}
+
+	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
+		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{}, nil, nil)
+
+	mockFlows.EXPECT().AddExecutionToFlow(
+		context.Background(), testRealmName,
+		keycloakapi.AuthenticationExecutionRepresentation{
+			Authenticator: ptr.To("basic-auth"),
+			ParentFlow:    ptr.To(testFlowID),
+			Requirement:   ptr.To("REQUIRED"),
+			Priority:      ptr.To(int32(5)),
+		},
+	).Return(locationResponse(testExecID), nil)
+
+	h := NewSyncAuthFlowExecutions(kc)
+	err := h.Serve(context.Background(), flow, testRealmName)
+	require.NoError(t, err)
 }

--- a/internal/controller/keycloakauthflow/keycloakrauthflow_controller_integration_test.go
+++ b/internal/controller/keycloakauthflow/keycloakrauthflow_controller_integration_test.go
@@ -242,6 +242,107 @@ var _ = Describe("KeycloakAuthFlow controller", Ordered, func() {
 			g.Expect(*exec.Requirement).Should(Equal("REQUIRED"))
 		}, timeout, interval).Should(Succeed())
 	})
+	It("Should preserve priority ordering when parent mixes non-flow execs and a child sub-flow", func() {
+		By("Creating a parent KeycloakAuthFlow with two non-flow execs and a child sub-flow reference")
+		parentAuthFlow := &keycloakApi.KeycloakAuthFlow{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-auth-flow-priority-parent",
+				Namespace: ns,
+			},
+			Spec: keycloakApi.KeycloakAuthFlowSpec{
+				RealmRef: common.RealmRef{
+					Kind: keycloakApi.KeycloakRealmKind,
+					Name: KeycloakRealmCR,
+				},
+				Alias:       "test-auth-flow-priority-parent",
+				Description: "test-auth-flow-priority-parent",
+				ProviderID:  "basic-flow",
+				TopLevel:    true,
+				AuthenticationExecutions: []keycloakApi.AuthenticationExecution{
+					{
+						Authenticator: "auth-cookie",
+						Requirement:   "ALTERNATIVE",
+						Priority:      0,
+					},
+					{
+						Authenticator: "identity-provider-redirector",
+						Requirement:   "ALTERNATIVE",
+						Priority:      1,
+					},
+					{
+						Alias:             "test-auth-flow-priority-child",
+						Authenticator:     "basic-flow",
+						AuthenticatorFlow: true,
+						Requirement:       "ALTERNATIVE",
+						Priority:          2,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, parentAuthFlow)).Should(Succeed())
+
+		By("Creating the child KeycloakAuthFlow referenced by the parent")
+		childAuthFlow := &keycloakApi.KeycloakAuthFlow{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-auth-flow-priority-child",
+				Namespace: ns,
+			},
+			Spec: keycloakApi.KeycloakAuthFlowSpec{
+				RealmRef: common.RealmRef{
+					Kind: keycloakApi.KeycloakRealmKind,
+					Name: KeycloakRealmCR,
+				},
+				Alias:            "test-auth-flow-priority-child",
+				Description:      "test-auth-flow-priority-child",
+				ParentName:       parentAuthFlow.Name,
+				ChildType:        "basic-flow",
+				ProviderID:       "registration-page-form",
+				ChildRequirement: "ALTERNATIVE",
+			},
+		}
+		Expect(k8sClient.Create(ctx, childAuthFlow)).Should(Succeed())
+
+		By("Waiting for both parent and child to reach StatusOK")
+		Eventually(func(g Gomega) {
+			gotParent := &keycloakApi.KeycloakAuthFlow{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: parentAuthFlow.Name, Namespace: ns}, gotParent)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(gotParent.Status.Value).Should(Equal(common.StatusOK))
+
+			gotChild := &keycloakApi.KeycloakAuthFlow{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: childAuthFlow.Name, Namespace: ns}, gotChild)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(gotChild.Status.Value).Should(Equal(common.StatusOK))
+		}).WithTimeout(time.Second * 20).WithPolling(time.Second).Should(Succeed())
+
+		By("Verifying executions priority and ordering via Keycloak API")
+		Eventually(func(g Gomega) {
+			execs, _, err := keycloakApiClient.AuthFlows.GetFlowExecutions(ctx, KeycloakRealmCR, "test-auth-flow-priority-parent")
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(execs).Should(HaveLen(3))
+
+			cookie := findExecutionByProviderId(execs, "auth-cookie")
+			g.Expect(cookie).ShouldNot(BeNil())
+			g.Expect(cookie.Priority).ShouldNot(BeNil())
+			g.Expect(*cookie.Priority).Should(Equal(int32(0)))
+			g.Expect(cookie.Index).ShouldNot(BeNil())
+			g.Expect(*cookie.Index).Should(Equal(int32(0)))
+
+			idp := findExecutionByProviderId(execs, "identity-provider-redirector")
+			g.Expect(idp).ShouldNot(BeNil())
+			g.Expect(idp.Priority).ShouldNot(BeNil())
+			g.Expect(*idp.Priority).Should(Equal(int32(1)))
+			g.Expect(idp.Index).ShouldNot(BeNil())
+			g.Expect(*idp.Index).Should(Equal(int32(1)))
+
+			subFlow := findExecutionByDisplayName(execs, "test-auth-flow-priority-child")
+			g.Expect(subFlow).ShouldNot(BeNil())
+			g.Expect(subFlow.Priority).ShouldNot(BeNil())
+			g.Expect(*subFlow.Priority).Should(Equal(int32(2)))
+			g.Expect(subFlow.Index).ShouldNot(BeNil())
+			g.Expect(*subFlow.Index).Should(Equal(int32(2)))
+		}, timeout, interval).Should(Succeed())
+	})
 })
 
 func findAuthFlowByAlias(flows []keycloakapi.AuthFlowRepresentation, alias string) *keycloakapi.AuthFlowRepresentation {


### PR DESCRIPTION
## Summary
- Always serialize the `Priority` field on `POST /authentication/executions` so Keycloak does not auto-assign priorities sequentially in creation order.
- Without this, the priority of a child sub-flow set by `adjustChildFlowsPriority` collided with the auto-assigned priority of the last non-flow execution, breaking the ordering of any parent flow that mixed non-flow executions with a child sub-flow.
- Regression introduced in v1.33.0 by the migration to the `keycloakapi` client (the generated `Priority *int32` with `omitempty` dropped the field; the legacy `Priority int` always serialized).

## Test plan
- [x] `make test` (unit + integration against a real Keycloak on `:8086`) — passes; new integration test fails on master, passes with the fix.
- [x] New unit test `TestSyncAuthFlowExecutions_Serve_AddExecutionPropagatesPriority` locks in propagation of a non-zero priority.
- [x] Three existing mock expectations updated to include `Priority: ptr.To(int32(0))`.
- [x] `make lint-fix` — clean.
- [x] Manual sanity check on a kind cluster running the operator against Keycloak: applied a parent flow with `auth-cookie` (priority 0), `identity-provider-redirector` (priority 1) and a child sub-flow (priority 2). API confirms priorities/indices `0, 1, 2` — no collisions.

Closes #346