### PR TITLE
feat(helm): make operator replica count configurable

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -145,6 +145,7 @@ Development versions are also available from the [snapshot helm chart repository
 | name | string | `"keycloak-operator"` | Application name string |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | podLabels | object | `{}` | Labels to be added to the pod |
+| replicaCount | int | `1` | Number of operator replicas. |
 | resources | object | `{"limits":{"memory":"192Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | Resource limits and requests for the pod |
 | securityContext | object | `{"runAsNonRoot":true}` | Deployment Security Context Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | serviceAccount | object | `{"annotations":{},"create":true,"labels":{},"name":"edp-keycloak-operator"}` | ServiceAccount configuration |

--- a/deploy-templates/templates/deployment.yaml
+++ b/deploy-templates/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- end }}
   name: {{ .Values.name }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       name: {{ .Values.name }}

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -1,5 +1,7 @@
 # -- Application name string
 name: keycloak-operator
+# -- Number of operator replicas.
+replicaCount: 1
 # -- Annotations to be added to the Deployment
 annotations: {}
 # -- Cluster domain for constructing service DNS names


### PR DESCRIPTION
## Summary
- Exposes `replicaCount` in `deploy-templates/values.yaml` (default `1`, preserves current behavior).
- Wires `{{ .Values.replicaCount }}` into the operator Deployment.
- Regenerated `deploy-templates/README.md` via `make helm-docs`.

No operator code changes are required. The leader-with-lease machinery (`--leader-elect` flag, `LeaderElectionID`, lease RBAC in `templates/leader_election_role.yaml`) is already wired in `cmd/main.go` and the chart — only the hardcoded `replicas: 1` was blocking HA.

Refs: #347

## Test plan
- [x] `helm lint deploy-templates/` — passes.
- [x] `helm template … --set replicaCount=3` renders `replicas: 3`; default renders `replicas: 1`.
- [x] `kubectl apply --dry-run=client` accepts the rendered manifests.
- [x] `make helm-docs` regenerated README; `make validate-docs` will pass.
- [x] Live test on fresh `kind` (`make delete-kind && make start-kind`):
  - [x] `helm install --set replicaCount=3` deploys 3 pods Running.
  - [x] Exactly one pod holds the lease (`coordination.k8s.io/leases/edp-keycloak-operator-lock`) and logs `Starting workers`; standby pods log `attempting to acquire leader lease` and back off.
  - [x] Deleting the leader pod transfers the lease to a standby in ~16s (default 15s lease duration); deployment recreates the killed pod and the cluster returns to 3/3 with a healthy new leader.