### PR TITLE
fix(realm): error when SMTP secret or configmap key is missing

### DIFF
--- a/internal/controller/keycloakrealm/chain/configure_email.go
+++ b/internal/controller/keycloakrealm/chain/configure_email.go
@@ -116,6 +116,14 @@ func convertEmailSpecToMap(
 			return nil, fmt.Errorf("unable to get password: %w", err)
 		}
 
+		if username == "" {
+			return nil, fmt.Errorf("smtp authentication username is empty after resolving references")
+		}
+
+		if password == "" {
+			return nil, fmt.Errorf("smtp authentication password is empty after resolving references")
+		}
+
 		emailMap["password"] = password
 	}
 

--- a/internal/controller/keycloakrealm/chain/configure_email_test.go
+++ b/internal/controller/keycloakrealm/chain/configure_email_test.go
@@ -157,6 +157,144 @@ func TestConfigureEmail_ServeRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "smtp username secret key missing",
+			realm: &keycloakApi.KeycloakRealm{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "realm",
+					Namespace: "default",
+				},
+				Spec: keycloakApi.KeycloakRealmSpec{
+					RealmName: "realm",
+					Smtp: &common.SMTP{
+						Template: common.EmailTemplate{
+							From: "from@mailcom",
+						},
+						Connection: common.EmailConnection{
+							Host: "smtp-host",
+							Authentication: &common.EmailAuthentication{
+								Username: common.SourceRefOrVal{
+									SourceRef: common.SourceRef{
+										SecretKeyRef: &common.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "mailjet",
+											},
+											Key: "smtp-username",
+										},
+									},
+								},
+								Password: common.SourceRef{
+									SecretKeyRef: &common.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "mailjet",
+										},
+										Key: "smtp-password",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			k8sClient: func(t *testing.T) client.Client {
+				return fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "mailjet",
+							Namespace: "default",
+						},
+						Data: map[string][]byte{
+							"smtp-password": []byte("secretkey"),
+						},
+					},
+				).Build()
+			},
+			realmClient: func(t *testing.T) keycloakapi.RealmClient {
+				m := v2mocks.NewMockRealmClient(t)
+
+				m.EXPECT().GetRealm(mock.Anything, "realm").
+					Return(&keycloakapi.RealmRepresentation{
+						Realm: ptr.To("realm"),
+					}, nil, nil)
+
+				return m
+			},
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "unable to get username")
+			},
+		},
+		{
+			name: "smtp username and password from secret",
+			realm: &keycloakApi.KeycloakRealm{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "realm",
+					Namespace: "default",
+				},
+				Spec: keycloakApi.KeycloakRealmSpec{
+					RealmName: "realm",
+					Smtp: &common.SMTP{
+						Template: common.EmailTemplate{
+							From: "from@mailcom",
+						},
+						Connection: common.EmailConnection{
+							Host: "smtp-host",
+							Authentication: &common.EmailAuthentication{
+								Username: common.SourceRefOrVal{
+									SourceRef: common.SourceRef{
+										SecretKeyRef: &common.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "mailjet",
+											},
+											Key: "smtp-username",
+										},
+									},
+								},
+								Password: common.SourceRef{
+									SecretKeyRef: &common.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "mailjet",
+										},
+										Key: "smtp-password",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			k8sClient: func(t *testing.T) client.Client {
+				return fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "mailjet",
+							Namespace: "default",
+						},
+						Data: map[string][]byte{
+							"smtp-username": []byte("apikey"),
+							"smtp-password": []byte("secretkey"),
+						},
+					},
+				).Build()
+			},
+			realmClient: func(t *testing.T) keycloakapi.RealmClient {
+				m := v2mocks.NewMockRealmClient(t)
+
+				m.EXPECT().GetRealm(mock.Anything, "realm").
+					Return(&keycloakapi.RealmRepresentation{
+						Realm: ptr.To("realm"),
+					}, nil, nil)
+
+				m.EXPECT().UpdateRealm(mock.Anything, "realm", mock.MatchedBy(func(rep keycloakapi.RealmRepresentation) bool {
+					return rep.SmtpServer != nil &&
+						(*rep.SmtpServer)["user"] == "apikey" &&
+						(*rep.SmtpServer)["password"] == "secretkey"
+				})).Return(nil, nil)
+
+				return m
+			},
+			wantErr: require.NoError,
+		},
+		{
 			name: "failed to get realm",
 			realm: &keycloakApi.KeycloakRealm{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/secretref/sourceref.go
+++ b/pkg/secretref/sourceref.go
@@ -31,7 +31,12 @@ func GetValueFromSourceRef(
 			return "", fmt.Errorf("unable to get configmap: %w", err)
 		}
 
-		return configMap.Data[sourceRef.ConfigMapKeyRef.Key], nil
+		val, ok := configMap.Data[sourceRef.ConfigMapKeyRef.Key]
+		if !ok {
+			return "", fmt.Errorf("configmap %s does not contain key %s", sourceRef.ConfigMapKeyRef.Name, sourceRef.ConfigMapKeyRef.Key)
+		}
+
+		return val, nil
 	}
 
 	if sourceRef.SecretKeyRef != nil {
@@ -43,7 +48,12 @@ func GetValueFromSourceRef(
 			return "", fmt.Errorf("unable to get secret: %w", err)
 		}
 
-		return string(secret.Data[sourceRef.SecretKeyRef.Key]), nil
+		val, ok := secret.Data[sourceRef.SecretKeyRef.Key]
+		if !ok {
+			return "", fmt.Errorf("secret %s does not contain key %s", sourceRef.SecretKeyRef.Name, sourceRef.SecretKeyRef.Key)
+		}
+
+		return string(val), nil
 	}
 
 	return "", nil

--- a/pkg/secretref/sourceref_test.go
+++ b/pkg/secretref/sourceref_test.go
@@ -82,6 +82,63 @@ func TestGetValueFromSourceRef(t *testing.T) {
 			want:    "",
 			wantErr: require.NoError,
 		},
+		{
+			name: "secret key missing in secret",
+			sourceRef: &common.SourceRef{
+				SecretKeyRef: &common.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: "mailjet",
+					},
+					Key: "smtp-username",
+				},
+			},
+			k8sClient: func(t *testing.T) client.Client {
+				return fake.NewClientBuilder().WithObjects(
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "mailjet",
+							Namespace: "default",
+						},
+						Data: map[string][]byte{
+							"smtp-password": []byte("secretkey"),
+						},
+					},
+				).Build()
+			},
+			want: "",
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "does not contain key smtp-username")
+			},
+		},
+		{
+			name: "configmap key missing",
+			sourceRef: &common.SourceRef{
+				ConfigMapKeyRef: &common.ConfigMapKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: "configmap-with-secret",
+					},
+					Key: "missing",
+				},
+			},
+			k8sClient: func(t *testing.T) client.Client {
+				return fake.NewClientBuilder().WithObjects(
+					&v1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "configmap-with-secret",
+							Namespace: "default",
+						},
+						Data: map[string]string{
+							"key": "value",
+						},
+					}).Build()
+			},
+			want: "",
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "does not contain key missing")
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `GetValueFromSourceRef` returns an explicit error when the Secret or ConfigMap key does not exist (instead of silently returning an empty string).
- SMTP realm configuration fails with a clear message when username or password resolve to empty after reference resolution.

## Motivation
When `smtpServer.user` was set via `secretKeyRef` with a wrong key name, Keycloak kept an empty user with no reconcile error. Plain `value` worked; missing keys did not surface.

## Test plan
- [x] `go test ./pkg/secretref/... ./internal/controller/keycloakrealm/chain/...`

Made with [Cursor](https://cursor.com)