### PR TITLE
fix(webhook): scope realm uniqueness to the resolved Keycloak instance (#360)

### DIFF
--- a/internal/webhook/v1/keycloakrealm_webhook.go
+++ b/internal/webhook/v1/keycloakrealm_webhook.go
@@ -71,7 +71,9 @@ func (v *KeycloakRealmCustomValidator) ValidateCreate(ctx context.Context, obj r
 
 	keycloakrealmlog.Info("Validation for KeycloakRealm upon creation", "name", keycloakrealm.GetName())
 
-	// Check if the combination of RealmName and KeycloakRef is unique across all KeycloakRealm resources in the cluster.
+	// Check that the combination of RealmName and the resolved Keycloak instance is
+	// unique across KeycloakRealm resources. Uniqueness must be enforced per target
+	// Keycloak instance, not per KeycloakRef name string.
 	existingKeycloakRealms := &keycloakApi.KeycloakRealmList{}
 	if err := v.k8sclient.List(ctx, existingKeycloakRealms); err != nil {
 		return nil, fmt.Errorf("failed to list KeycloakRealm resources: %w", err)
@@ -80,22 +82,52 @@ func (v *KeycloakRealmCustomValidator) ValidateCreate(ctx context.Context, obj r
 	for _, existingRealm := range existingKeycloakRealms.Items {
 		isSameResource := existingRealm.Namespace == keycloakrealm.Namespace && existingRealm.Name == keycloakrealm.Name
 
-		isSameKeycloakInstance := existingRealm.Spec.KeycloakRef.Kind == keycloakrealm.Spec.KeycloakRef.Kind &&
-			existingRealm.Spec.KeycloakRef.Name == keycloakrealm.Spec.KeycloakRef.Name
-
-		if existingRealm.Spec.RealmName == keycloakrealm.Spec.RealmName && isSameKeycloakInstance && !isSameResource {
+		if existingRealm.Spec.RealmName == keycloakrealm.Spec.RealmName &&
+			sameKeycloakInstance(&existingRealm, keycloakrealm) && !isSameResource {
 			return nil, fmt.Errorf(
-				"realm name %s is already in use by another KeycloakRealm resource (%s/%s) for Keycloak instance %s/%s",
+				"realm name %q is already used by KeycloakRealm %s/%s targeting %s",
 				keycloakrealm.Spec.RealmName,
 				existingRealm.Namespace,
 				existingRealm.Name,
-				keycloakrealm.Spec.KeycloakRef.Kind,
-				keycloakrealm.Spec.KeycloakRef.Name,
+				formatResolvedKeycloakInstance(keycloakrealm),
 			)
 		}
 	}
 
 	return duplicateInternationalizationWarning(keycloakrealm), nil
+}
+
+// formatResolvedKeycloakInstance returns a human-readable identity for the Keycloak
+// instance resolved from a KeycloakRealm reference. For the namespaced Keycloak kind
+// this includes the realm namespace (Kind/namespace/name); for ClusterKeycloak it is
+// cluster-scoped (Kind/name).
+func formatResolvedKeycloakInstance(realm *keycloakApi.KeycloakRealm) string {
+	ref := realm.Spec.KeycloakRef
+	if ref.Kind == keycloakApi.KeycloakKind {
+		return fmt.Sprintf("%s/%s/%s", ref.Kind, realm.Namespace, ref.Name)
+	}
+
+	return fmt.Sprintf("%s/%s", ref.Kind, ref.Name)
+}
+
+// sameKeycloakInstance reports whether two KeycloakRealm resources target the same
+// Keycloak instance.
+//
+// The namespaced Keycloak kind is resolved within the realm's own namespace, so its
+// instance identity is (namespace, name): the same KeycloakRef name in two different
+// namespaces refers to two distinct Keycloak instances. The cluster-scoped
+// ClusterKeycloak kind is resolved cluster-wide, so its identity is the name alone.
+func sameKeycloakInstance(a, b *keycloakApi.KeycloakRealm) bool {
+	if a.Spec.KeycloakRef.Kind != b.Spec.KeycloakRef.Kind ||
+		a.Spec.KeycloakRef.Name != b.Spec.KeycloakRef.Name {
+		return false
+	}
+
+	if b.Spec.KeycloakRef.Kind == keycloakApi.KeycloakKind {
+		return a.Namespace == b.Namespace
+	}
+
+	return true
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type KeycloakRealm.

--- a/internal/webhook/v1/keycloakrealm_webhook_test.go
+++ b/internal/webhook/v1/keycloakrealm_webhook_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	keycloakAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -54,6 +55,7 @@ var _ = Describe("KeycloakRealm Webhook", func() {
 
 			err := k8sClient.Create(ctx, duplicateObj)
 			Expect(err).Should(HaveOccurred(), "expected error when creating KeycloakRealm with duplicate RealmName in the same namespace")
+			Expect(err.Error()).To(ContainSubstring(`realm name "test-realm" is already used by KeycloakRealm ns1/test-realm targeting Keycloak/ns1/test-keycloak`))
 		})
 
 		It("Should allow creation with the same RealmName for a different Keycloak in another namespace", func() {
@@ -76,23 +78,66 @@ var _ = Describe("KeycloakRealm Webhook", func() {
 			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, objInNs2))).Should(Succeed(), "failed to delete KeycloakRealm in ns2")
 		})
 
-		It("Should deny creation with the same RealmName for the same Keycloak across namespaces", func() {
+		It("Should allow creation with the same RealmName and same Keycloak name in another namespace (namespaced kind)", func() {
+			// The namespaced Keycloak kind resolves in the realm's own namespace, so
+			// "test-keycloak" in ns2 is a different instance than "test-keycloak" in ns1.
 			objInNs2 := &keycloakApi.KeycloakRealm{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-realm-ns2",
 					Namespace: "ns2",
 				},
 				Spec: keycloakApi.KeycloakRealmSpec{
-					RealmName: "test-realm", // Same RealmName as the existing one but in a different namespace
+					RealmName: "test-realm",
 					KeycloakRef: common.KeycloakRef{
 						Kind: keycloakApi.KeycloakKind,
-						Name: "test-keycloak",
+						Name: "test-keycloak", // Same KeycloakRef name, but resolved in ns2
 					},
 				},
 			}
 
 			err := k8sClient.Create(ctx, objInNs2)
-			Expect(err).Should(HaveOccurred(), "expected error when creating KeycloakRealm with same RealmName for the same Keycloak in a different namespace")
+			Expect(err).ShouldNot(HaveOccurred(), "unexpected error when creating KeycloakRealm referencing a namespaced Keycloak with the same name in a different namespace")
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, objInNs2))).Should(Succeed(), "failed to delete KeycloakRealm in ns2")
+		})
+
+		It("Should deny creation with the same RealmName for the same ClusterKeycloak across namespaces", func() {
+			// ClusterKeycloak is cluster-scoped, so the same ref name across namespaces
+			// targets the same instance and must conflict.
+			clusterRealmNs1 := &keycloakApi.KeycloakRealm{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-realm-ns1",
+					Namespace: "ns1",
+				},
+				Spec: keycloakApi.KeycloakRealmSpec{
+					RealmName: "shared-realm",
+					KeycloakRef: common.KeycloakRef{
+						Kind: keycloakAlpha.ClusterKeycloakKind,
+						Name: "shared-keycloak",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, clusterRealmNs1)).Should(Succeed(), "failed to create cluster-scoped KeycloakRealm in ns1")
+			defer func() {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, clusterRealmNs1))).Should(Succeed())
+			}()
+
+			clusterRealmNs2 := &keycloakApi.KeycloakRealm{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-realm-ns2",
+					Namespace: "ns2",
+				},
+				Spec: keycloakApi.KeycloakRealmSpec{
+					RealmName: "shared-realm",
+					KeycloakRef: common.KeycloakRef{
+						Kind: keycloakAlpha.ClusterKeycloakKind,
+						Name: "shared-keycloak",
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, clusterRealmNs2)
+			Expect(err).Should(HaveOccurred(), "expected error when creating KeycloakRealm with same RealmName for the same ClusterKeycloak in a different namespace")
+			Expect(err.Error()).To(ContainSubstring(`realm name "shared-realm" is already used by KeycloakRealm ns1/cluster-realm-ns1 targeting ClusterKeycloak/shared-keycloak`))
 		})
 	})
 


### PR DESCRIPTION
Proposal fix for #360.

The KeycloakRealm webhook was incorrectly rejecting valid realms when two namespaces had a Keycloak with the same name. Uniqueness is now based on the resolved Keycloak instance (namespace included for Keycloak; unchanged for ClusterKeycloak).