### PR TITLE
fix(bundle): publish to all current and future OpenShift versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,9 +250,9 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	# Add OpenShift version to bundle.Dockerfile and bundle/metadata/annotations.yaml manually because operator-sdk cleans any additional labels.
 	echo "" >> bundle.Dockerfile
-	echo "LABEL com.redhat.openshift.versions=v4.7-v4.20" >> bundle.Dockerfile
+	echo "LABEL com.redhat.openshift.versions=v4.7" >> bundle.Dockerfile
 	echo "" >> bundle/metadata/annotations.yaml
-	echo "  com.redhat.openshift.versions: v4.7-v4.20" >> bundle/metadata/annotations.yaml
+	echo "  com.redhat.openshift.versions: v4.7" >> bundle/metadata/annotations.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: build-installer

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -20,4 +20,4 @@ COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/
 
-LABEL com.redhat.openshift.versions=v4.7-v4.20
+LABEL com.redhat.openshift.versions=v4.7

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -14,4 +14,4 @@ annotations:
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 
-  com.redhat.openshift.versions: v4.7-v4.20
+  com.redhat.openshift.versions: v4.7


### PR DESCRIPTION
Change com.redhat.openshift.versions from the closed range "v4.7-v4.20" to the open-ended "v4.7" so the operator is distributed to OpenShift 4.21, 4.22 and every future release instead of being capped at 4.20.

A closed range excludes the bundle from any catalog outside the range, which left 4.21/4.22 clusters with only the alpha channel. Per upstream guidance a maximum version is required only when the bundle ships deprecated APIs; this operator ships none, so the cap served no purpose and had to be bumped every OpenShift release (see #266).

Refs: https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/packaging-required-criteria-ocp/

Closes #363
