### PR TITLE
fix(KeycloakRealmGroup): prevent same-named groups from sharing one Keycloak group ID (#362)

### DIFF
--- a/bundle/manifests/edp-keycloak-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/edp-keycloak-operator.clusterserviceversion.yaml
@@ -1043,6 +1043,7 @@ spec:
         - apiGroups:
           - v1.edp.epam.com
           resources:
+          - keycloakrealmgroups
           - keycloakrealms
           verbs:
           - get
@@ -1322,3 +1323,23 @@ spec:
     targetPort: 9443
     type: ValidatingAdmissionWebhook
     webhookPath: /validate-v1-edp-epam-com-v1-keycloakrealm
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: keycloak-operator-controller-manager
+    failurePolicy: Fail
+    generateName: vkeycloakrealmgroup-v1.kb.io
+    rules:
+    - apiGroups:
+      - v1.edp.epam.com
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - keycloakrealmgroups
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-v1-edp-epam-com-v1-keycloakrealmgroup

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -363,6 +363,11 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "KeycloakClient")
 			os.Exit(1)
 		}
+
+		if err := webhookv1.SetupKeycloakRealmGroupWebhookWithManager(mgr, k8sClient); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "KeycloakRealmGroup")
+			os.Exit(1)
+		}
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -44,6 +44,7 @@ rules:
 - apiGroups:
   - v1.edp.epam.com
   resources:
+  - keycloakrealmgroups
   - keycloakrealms
   verbs:
   - get

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -50,3 +50,23 @@ webhooks:
     resources:
     - keycloakrealms
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-v1-edp-epam-com-v1-keycloakrealmgroup
+  failurePolicy: Fail
+  name: vkeycloakrealmgroup-v1.kb.io
+  rules:
+  - apiGroups:
+    - v1.edp.epam.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - keycloakrealmgroups
+  sideEffects: None

--- a/deploy-templates/templates/webhook/manifest.yaml
+++ b/deploy-templates/templates/webhook/manifest.yaml
@@ -76,4 +76,33 @@ webhooks:
     resources:
     - keycloakrealms
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ .Values.name }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-v1-edp-epam-com-v1-keycloakrealmgroup
+  failurePolicy: Fail
+  name: vkeycloakrealmgroup-v1.kb.io
+  {{- /* Namespace-scoped webhook validation to prevent cross-namespace conflicts. */ -}}
+  {{- if not .Values.clusterReconciliationEnabled }}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - {{ .Release.Namespace }}
+  {{- end }}
+  rules:
+  - apiGroups:
+    - v1.edp.epam.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - keycloakrealmgroups
+  sideEffects: None
 {{- end }}

--- a/deploy-templates/templates/webhook/rbac.yaml
+++ b/deploy-templates/templates/webhook/rbac.yaml
@@ -10,6 +10,7 @@ rules:
   - v1.edp.epam.com
   resources:
   - keycloakrealms
+  - keycloakrealmgroups
   verbs:
   - get
   - list

--- a/internal/controller/keycloakrealmgroup/chain/chain.go
+++ b/internal/controller/keycloakrealmgroup/chain/chain.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
@@ -68,11 +69,11 @@ func (ch *Chain) Serve(
 	return nil
 }
 
-func MakeChain() *Chain {
+func MakeChain(k8sClient client.Client) *Chain {
 	ch := &Chain{}
 
 	ch.Use(
-		NewCreateOrUpdateGroup(),
+		NewCreateOrUpdateGroup(k8sClient),
 		NewSyncRealmRoles(),
 		NewSyncClientRoles(),
 		NewSyncSubGroups(),

--- a/internal/controller/keycloakrealmgroup/chain/create_or_update_group.go
+++ b/internal/controller/keycloakrealmgroup/chain/create_or_update_group.go
@@ -5,15 +5,18 @@ import (
 	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 )
 
-type CreateOrUpdateGroup struct{}
+type CreateOrUpdateGroup struct {
+	k8sClient client.Client
+}
 
-func NewCreateOrUpdateGroup() *CreateOrUpdateGroup {
-	return &CreateOrUpdateGroup{}
+func NewCreateOrUpdateGroup(k8sClient client.Client) *CreateOrUpdateGroup {
+	return &CreateOrUpdateGroup{k8sClient: k8sClient}
 }
 
 func (h *CreateOrUpdateGroup) Serve(
@@ -49,6 +52,8 @@ func (h *CreateOrUpdateGroup) Serve(
 	}
 
 	// If we didn't find the group by ID, search by name.
+	foundByName := false
+
 	if existingGroup == nil {
 		if groupCtx.ParentGroupID != "" {
 			existingGroup, _, err = kClient.Groups.FindChildGroupByName(ctx, realm, groupCtx.ParentGroupID, spec.Name)
@@ -58,6 +63,27 @@ func (h *CreateOrUpdateGroup) Serve(
 
 		if err != nil && !keycloakapi.IsNotFound(err) {
 			return fmt.Errorf("unable to search for group %q: %w", spec.Name, err)
+		}
+
+		foundByName = existingGroup != nil
+	}
+
+	// A group found by name search (as opposed to by our own status.ID) may already be
+	// managed by a different KeycloakRealmGroup resource, e.g. another CR using the same
+	// spec.name/parentGroup combination. Adopting it would make two CRs share one Keycloak
+	// group ID and fight over its children on every reconcile. Refuse instead of adopting.
+	if foundByName && existingGroup.Id != nil {
+		owner, ownerErr := findOwnerCR(ctx, h.k8sClient, group, *existingGroup.Id)
+		if ownerErr != nil {
+			return fmt.Errorf("unable to check group ownership for %q: %w", spec.Name, ownerErr)
+		}
+
+		if owner != nil {
+			return fmt.Errorf(
+				"group %q (id %s) is already managed by KeycloakRealmGroup %s/%s; "+
+					"refusing to adopt it - check for a duplicate spec.name/parentGroup combination",
+				spec.Name, *existingGroup.Id, owner.Namespace, owner.Name,
+			)
 		}
 	}
 

--- a/internal/controller/keycloakrealmgroup/chain/create_or_update_group_test.go
+++ b/internal/controller/keycloakrealmgroup/chain/create_or_update_group_test.go
@@ -8,7 +8,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
@@ -20,7 +24,22 @@ const (
 	testGroupPath      = "/test-group"
 	testChildGroupName = "child-group"
 	testUpdatedPath    = "/updated-path"
+	testNamespace      = "ns1"
+	testCRNameA        = "cr-a"
+	testExistingGroup  = "existing-group"
+	testCRNameB        = "cr-b"
 )
+
+// newFakeK8sClient builds a fake controller-runtime client with the keycloakApi scheme
+// registered, pre-populated with the given KeycloakRealmGroup objects.
+func newFakeK8sClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, keycloakApi.AddToScheme(scheme))
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
 
 func TestCreateOrUpdateGroup_Serve_CreateTopLevel(t *testing.T) {
 	mockGroups := mocks.NewMockGroupsClient(t)
@@ -51,7 +70,7 @@ func TestCreateOrUpdateGroup_Serve_CreateTopLevel(t *testing.T) {
 		},
 	}, nil)
 
-	h := NewCreateOrUpdateGroup()
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	require.NoError(t, err)
 	assert.Equal(t, "group-id-123", groupCtx.GroupID)
@@ -87,7 +106,7 @@ func TestCreateOrUpdateGroup_Serve_CreateChildGroup(t *testing.T) {
 		},
 	}, nil)
 
-	h := NewCreateOrUpdateGroup()
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	require.NoError(t, err)
 	assert.Equal(t, "child-id-456", groupCtx.GroupID)
@@ -100,16 +119,16 @@ func TestCreateOrUpdateGroup_Serve_UpdateExisting(t *testing.T) {
 	groupCtx := &GroupContext{RealmName: "test-realm"}
 
 	group := &keycloakApi.KeycloakRealmGroup{}
-	group.Spec.Name = "existing-group"
+	group.Spec.Name = testExistingGroup
 	group.Spec.Description = "Updated description"
 	group.Spec.Path = testUpdatedPath
 	group.Spec.Attributes = map[string][]string{"new-key": {"new-val"}}
 
 	mockGroups.EXPECT().FindGroupByName(
-		context.Background(), "test-realm", "existing-group",
+		context.Background(), "test-realm", testExistingGroup,
 	).Return(&keycloakapi.GroupRepresentation{
 		Id:   ptr.To("existing-id"),
-		Name: ptr.To("existing-group"),
+		Name: ptr.To(testExistingGroup),
 		Path: ptr.To("/old-path"),
 	}, nil, nil)
 
@@ -117,14 +136,14 @@ func TestCreateOrUpdateGroup_Serve_UpdateExisting(t *testing.T) {
 		context.Background(), "test-realm", "existing-id",
 		keycloakapi.GroupRepresentation{
 			Id:          ptr.To("existing-id"),
-			Name:        ptr.To("existing-group"),
+			Name:        ptr.To(testExistingGroup),
 			Description: ptr.To("Updated description"),
 			Path:        ptr.To(testUpdatedPath),
 			Attributes:  &map[string][]string{"new-key": {"new-val"}},
 		},
 	).Return(nil, nil)
 
-	h := NewCreateOrUpdateGroup()
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	require.NoError(t, err)
 	assert.Equal(t, "existing-id", groupCtx.GroupID)
@@ -143,7 +162,7 @@ func TestCreateOrUpdateGroup_Serve_FindGroupError(t *testing.T) {
 		context.Background(), "test-realm", testGroupName,
 	).Return(nil, nil, errors.New("api error"))
 
-	h := NewCreateOrUpdateGroup()
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	assert.ErrorContains(t, err, "unable to search for group")
 }
@@ -173,7 +192,7 @@ func TestCreateOrUpdateGroup_Serve_CreateGroupError(t *testing.T) {
 		},
 	).Return(nil, errors.New("create failed"))
 
-	h := NewCreateOrUpdateGroup()
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	assert.ErrorContains(t, err, "unable to create group")
 }
@@ -185,15 +204,15 @@ func TestCreateOrUpdateGroup_Serve_UpdateGroupError(t *testing.T) {
 	groupCtx := &GroupContext{RealmName: "test-realm"}
 
 	group := &keycloakApi.KeycloakRealmGroup{}
-	group.Spec.Name = "existing-group"
+	group.Spec.Name = testExistingGroup
 	group.Spec.Path = testUpdatedPath
 	group.Spec.Attributes = map[string][]string{"key": {"val"}}
 
 	mockGroups.EXPECT().FindGroupByName(
-		context.Background(), "test-realm", "existing-group",
+		context.Background(), "test-realm", testExistingGroup,
 	).Return(&keycloakapi.GroupRepresentation{
 		Id:   ptr.To("existing-id"),
-		Name: ptr.To("existing-group"),
+		Name: ptr.To(testExistingGroup),
 		Path: ptr.To("/old-path"),
 	}, nil, nil)
 
@@ -201,14 +220,14 @@ func TestCreateOrUpdateGroup_Serve_UpdateGroupError(t *testing.T) {
 		context.Background(), "test-realm", "existing-id",
 		keycloakapi.GroupRepresentation{
 			Id:          ptr.To("existing-id"),
-			Name:        ptr.To("existing-group"),
+			Name:        ptr.To(testExistingGroup),
 			Description: ptr.To(""),
 			Path:        ptr.To(testUpdatedPath),
 			Attributes:  &map[string][]string{"key": {"val"}},
 		},
 	).Return(nil, errors.New("update failed"))
 
-	h := NewCreateOrUpdateGroup()
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	assert.ErrorContains(t, err, "unable to update group")
 }
@@ -243,7 +262,7 @@ func TestCreateOrUpdateGroup_Serve_UpdateExistingChildGroup(t *testing.T) {
 		},
 	).Return(nil, nil)
 
-	h := NewCreateOrUpdateGroup()
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	require.NoError(t, err)
 	assert.Equal(t, "child-id", groupCtx.GroupID)
@@ -262,7 +281,7 @@ func TestCreateOrUpdateGroup_Serve_FindChildGroupError(t *testing.T) {
 		context.Background(), "test-realm", "parent-id", testChildGroupName,
 	).Return(nil, nil, errors.New("api error"))
 
-	h := NewCreateOrUpdateGroup()
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	assert.ErrorContains(t, err, "unable to search for group")
 }
@@ -298,7 +317,7 @@ func TestCreateOrUpdateGroup_Serve_RenameByID(t *testing.T) {
 		},
 	).Return(nil, nil)
 
-	h := NewCreateOrUpdateGroup()
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	require.NoError(t, err)
 	assert.Equal(t, "existing-id", groupCtx.GroupID)
@@ -337,7 +356,7 @@ func TestCreateOrUpdateGroup_Serve_ExistingIDNotFound_FallsBackToName(t *testing
 		},
 	}, nil)
 
-	h := NewCreateOrUpdateGroup()
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	require.NoError(t, err)
 	assert.Equal(t, "new-id", groupCtx.GroupID)
@@ -356,7 +375,120 @@ func TestCreateOrUpdateGroup_Serve_GetGroupByIDError(t *testing.T) {
 		context.Background(), "test-realm", "existing-id",
 	).Return(nil, nil, errors.New("connection error"))
 
-	h := NewCreateOrUpdateGroup()
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	assert.ErrorContains(t, err, "unable to get group by ID")
+}
+
+func TestCreateOrUpdateGroup_Serve_AdoptUnownedGroupByName(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+	groupCtx := &GroupContext{RealmName: "test-realm"}
+
+	group := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameA, Namespace: testNamespace},
+	}
+	group.Spec.Name = testExistingGroup
+	group.Spec.Path = testUpdatedPath
+	group.Spec.Attributes = map[string][]string{"key": {"val"}}
+
+	mockGroups.EXPECT().FindGroupByName(
+		context.Background(), "test-realm", testExistingGroup,
+	).Return(&keycloakapi.GroupRepresentation{
+		Id:   ptr.To("existing-id"),
+		Name: ptr.To(testExistingGroup),
+		Path: ptr.To("/old-path"),
+	}, nil, nil)
+
+	mockGroups.EXPECT().UpdateGroup(
+		context.Background(), "test-realm", "existing-id",
+		keycloakapi.GroupRepresentation{
+			Id:          ptr.To("existing-id"),
+			Name:        ptr.To(testExistingGroup),
+			Description: ptr.To(""),
+			Path:        ptr.To(testUpdatedPath),
+			Attributes:  &map[string][]string{"key": {"val"}},
+		},
+	).Return(nil, nil)
+
+	// No other KeycloakRealmGroup CR owns "existing-id" - the group is up for adoption.
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	require.NoError(t, err)
+	assert.Equal(t, "existing-id", groupCtx.GroupID)
+}
+
+func TestCreateOrUpdateGroup_Serve_RefusesToAdoptGroupOwnedByAnotherCR(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+	groupCtx := &GroupContext{RealmName: "test-realm"}
+
+	group := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameB, Namespace: testNamespace},
+	}
+	group.Spec.Name = testExistingGroup
+
+	owner := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameA, Namespace: testNamespace},
+		Status:     keycloakApi.KeycloakRealmGroupStatus{ID: "existing-id"},
+	}
+
+	mockGroups.EXPECT().FindGroupByName(
+		context.Background(), "test-realm", testExistingGroup,
+	).Return(&keycloakapi.GroupRepresentation{
+		Id:   ptr.To("existing-id"),
+		Name: ptr.To(testExistingGroup),
+	}, nil, nil)
+
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t, owner))
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.ErrorContains(t, err, "already managed by KeycloakRealmGroup "+testNamespace+"/"+testCRNameA)
+	assert.Empty(t, groupCtx.GroupID)
+}
+
+func TestCreateOrUpdateGroup_Serve_ByIDPathSkipsOwnershipCheck(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+	// This CR's own status.ID is already "existing-id" - the by-ID rename path must not
+	// treat that as a conflict, since it is comparing the group against itself.
+	groupCtx := &GroupContext{RealmName: "test-realm", GroupID: "existing-id"}
+
+	group := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameA, Namespace: testNamespace},
+	}
+	group.Spec.Name = "new-name"
+	group.Spec.Path = "/new-name"
+	group.Spec.Attributes = map[string][]string{"key": {"val"}}
+
+	mockGroups.EXPECT().GetGroup(
+		context.Background(), "test-realm", "existing-id",
+	).Return(&keycloakapi.GroupRepresentation{
+		Id:   ptr.To("existing-id"),
+		Name: ptr.To("old-name"),
+		Path: ptr.To("/old-name"),
+	}, nil, nil)
+
+	mockGroups.EXPECT().UpdateGroup(
+		context.Background(), "test-realm", "existing-id",
+		keycloakapi.GroupRepresentation{
+			Id:          ptr.To("existing-id"),
+			Name:        ptr.To("new-name"),
+			Description: ptr.To(""),
+			Path:        ptr.To("/new-name"),
+			Attributes:  &map[string][]string{"key": {"val"}},
+		},
+	).Return(nil, nil)
+
+	self := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameA, Namespace: testNamespace},
+		Status:     keycloakApi.KeycloakRealmGroupStatus{ID: "existing-id"},
+	}
+
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t, self))
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	require.NoError(t, err)
+	assert.Equal(t, "existing-id", groupCtx.GroupID)
 }

--- a/internal/controller/keycloakrealmgroup/chain/ownership.go
+++ b/internal/controller/keycloakrealmgroup/chain/ownership.go
@@ -1,0 +1,44 @@
+package chain
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+)
+
+// findOwnerCR returns the KeycloakRealmGroup that already recorded groupID in its
+// status.ID, excluding self. Comparing on the actual Keycloak group ID (rather than
+// re-deriving realm/parent identity from spec) is what lets a single check work
+// uniformly for both RealmRef kinds and for namespace-local ParentGroup refs.
+func findOwnerCR(
+	ctx context.Context,
+	k8sClient client.Client,
+	self *keycloakApi.KeycloakRealmGroup,
+	groupID string,
+) (*keycloakApi.KeycloakRealmGroup, error) {
+	if groupID == "" {
+		return nil, nil
+	}
+
+	var list keycloakApi.KeycloakRealmGroupList
+	if err := k8sClient.List(ctx, &list); err != nil {
+		return nil, fmt.Errorf("unable to list KeycloakRealmGroup resources: %w", err)
+	}
+
+	for i := range list.Items {
+		candidate := &list.Items[i]
+
+		if candidate.Namespace == self.Namespace && candidate.Name == self.Name {
+			continue
+		}
+
+		if candidate.Status.ID == groupID {
+			return candidate, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/internal/controller/keycloakrealmgroup/chain/sync_sub_groups.go
+++ b/internal/controller/keycloakrealmgroup/chain/sync_sub_groups.go
@@ -57,10 +57,31 @@ func (h *SyncSubGroups) Serve(
 			subGroup, _, err := kClient.Groups.FindGroupByName(ctx, realm, claimed)
 			if err != nil {
 				if keycloakapi.IsNotFound(err) {
-					return fmt.Errorf("subgroup %q not found in realm %q", claimed, realm)
+					// The name search only matches top-level groups: a group nested under
+					// another parent is reported as not found and cannot be claimed here.
+					return fmt.Errorf(
+						"subgroup %q not found among top-level groups of realm %q; "+
+							"if it is nested under another parent group, use spec.parentGroup on that group's resource instead of the deprecated spec.subGroups field",
+						claimed, realm,
+					)
 				}
 
 				return fmt.Errorf("unable to find subgroup %q: %w", claimed, err)
+			}
+
+			// Claiming a group that is itself managed by another KeycloakRealmGroup resource is
+			// the documented behavior of this deprecated field: the move keeps the group ID, so
+			// the owning resource still resolves it via status.ID afterwards.
+			//
+			// CreateChildGroup moves an existing group to a new parent. Only allow this when
+			// the found group is currently top-level (no parent) or already a child of this
+			// group; otherwise we would silently steal it from a different parent group.
+			if subGroup.ParentId != nil && *subGroup.ParentId != groupID {
+				return fmt.Errorf(
+					"subgroup %q is already nested under a different parent group (id %s); "+
+						"use spec.parentGroup instead of the deprecated spec.subGroups field to manage it",
+					claimed, *subGroup.ParentId,
+				)
 			}
 
 			if _, err := kClient.Groups.CreateChildGroup(ctx, realm, groupID, *subGroup); err != nil {

--- a/internal/controller/keycloakrealmgroup/chain/sync_sub_groups_test.go
+++ b/internal/controller/keycloakrealmgroup/chain/sync_sub_groups_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
@@ -296,4 +297,143 @@ func TestSyncSubGroups_Serve_ErrorDetachingSubGroup(t *testing.T) {
 	h := NewSyncSubGroups()
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	assert.ErrorContains(t, err, "unable to detach subgroup")
+}
+
+func TestSyncSubGroups_Serve_ClaimsTopLevelGroupOwnedByAnotherCR(t *testing.T) {
+	// Claiming a top-level group that is itself managed by another KeycloakRealmGroup CR
+	// is the documented behavior of the deprecated SubGroups field: the move keeps the
+	// group ID, so the owning CR still resolves it via status.ID afterwards.
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+
+	groupCtx := &GroupContext{
+		RealmName: "test-realm",
+		GroupID:   "parent-group-123",
+	}
+
+	group := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameB, Namespace: testNamespace},
+	}
+	group.Spec.SubGroups = []string{"subgroup1"}
+
+	mockGroups.EXPECT().GetChildGroups(
+		context.Background(), "test-realm", "parent-group-123", (*keycloakapi.GetChildGroupsParams)(nil),
+	).Return([]keycloakapi.GroupRepresentation{}, nil, nil)
+
+	mockGroups.EXPECT().FindGroupByName(
+		context.Background(), "test-realm", "subgroup1",
+	).Return(&keycloakapi.GroupRepresentation{
+		Id: ptr.To("subgroup1-id"), Name: ptr.To("subgroup1"),
+	}, nil, nil)
+
+	mockGroups.EXPECT().CreateChildGroup(
+		context.Background(), "test-realm", "parent-group-123",
+		keycloakapi.GroupRepresentation{Id: ptr.To("subgroup1-id"), Name: ptr.To("subgroup1")},
+	).Return(nil, nil)
+
+	h := NewSyncSubGroups()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.NoError(t, err)
+}
+
+func TestSyncSubGroups_Serve_RefusesToStealSubGroupFromDifferentParent(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+
+	groupCtx := &GroupContext{
+		RealmName: "test-realm",
+		GroupID:   "parent-group-123",
+	}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.SubGroups = []string{"subgroup1"}
+
+	mockGroups.EXPECT().GetChildGroups(
+		context.Background(), "test-realm", "parent-group-123", (*keycloakapi.GetChildGroupsParams)(nil),
+	).Return([]keycloakapi.GroupRepresentation{}, nil, nil)
+
+	// subgroup1 is already nested under a different parent ("other-parent-id").
+	mockGroups.EXPECT().FindGroupByName(
+		context.Background(), "test-realm", "subgroup1",
+	).Return(&keycloakapi.GroupRepresentation{
+		Id: ptr.To("subgroup1-id"), Name: ptr.To("subgroup1"), ParentId: ptr.To("other-parent-id"),
+	}, nil, nil)
+
+	h := NewSyncSubGroups()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.ErrorContains(t, err, "already nested under a different parent group")
+	assert.ErrorContains(t, err, "spec.parentGroup")
+}
+
+func TestSyncSubGroups_Serve_ClaimsUnownedTopLevelGroup(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+
+	groupCtx := &GroupContext{
+		RealmName: "test-realm",
+		GroupID:   "parent-group-123",
+	}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.SubGroups = []string{"subgroup1"}
+
+	mockGroups.EXPECT().GetChildGroups(
+		context.Background(), "test-realm", "parent-group-123", (*keycloakapi.GetChildGroupsParams)(nil),
+	).Return([]keycloakapi.GroupRepresentation{}, nil, nil)
+
+	// subgroup1 is top-level (no ParentId) and unowned - claiming it is still allowed.
+	mockGroups.EXPECT().FindGroupByName(
+		context.Background(), "test-realm", "subgroup1",
+	).Return(&keycloakapi.GroupRepresentation{
+		Id: ptr.To("subgroup1-id"), Name: ptr.To("subgroup1"),
+	}, nil, nil)
+
+	mockGroups.EXPECT().CreateChildGroup(
+		context.Background(), "test-realm", "parent-group-123",
+		keycloakapi.GroupRepresentation{Id: ptr.To("subgroup1-id"), Name: ptr.To("subgroup1")},
+	).Return(nil, nil)
+
+	h := NewSyncSubGroups()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	require.NoError(t, err)
+}
+
+func TestSyncSubGroups_Serve_ClaimsAlreadyOwnChild(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+
+	groupCtx := &GroupContext{
+		RealmName: "test-realm",
+		GroupID:   "parent-group-123",
+	}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.SubGroups = []string{"subgroup1"}
+
+	mockGroups.EXPECT().GetChildGroups(
+		context.Background(), "test-realm", "parent-group-123", (*keycloakapi.GetChildGroupsParams)(nil),
+	).Return([]keycloakapi.GroupRepresentation{}, nil, nil)
+
+	// subgroup1 is already a child of this exact parent (e.g. pagination missed it above) -
+	// re-claiming it is a no-op move and must still be allowed.
+	mockGroups.EXPECT().FindGroupByName(
+		context.Background(), "test-realm", "subgroup1",
+	).Return(&keycloakapi.GroupRepresentation{
+		Id: ptr.To("subgroup1-id"), Name: ptr.To("subgroup1"), ParentId: ptr.To("parent-group-123"),
+	}, nil, nil)
+
+	mockGroups.EXPECT().CreateChildGroup(
+		context.Background(), "test-realm", "parent-group-123",
+		keycloakapi.GroupRepresentation{
+			Id: ptr.To("subgroup1-id"), Name: ptr.To("subgroup1"), ParentId: ptr.To("parent-group-123"),
+		},
+	).Return(nil, nil)
+
+	h := NewSyncSubGroups()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	require.NoError(t, err)
 }

--- a/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller.go
+++ b/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller.go
@@ -171,7 +171,7 @@ func (r *ReconcileKeycloakRealmGroup) tryReconcile(ctx context.Context, keycloak
 		GroupID:       keycloakRealmGroup.Status.ID,
 	}
 
-	if err := chain.MakeChain().Serve(ctx, keycloakRealmGroup, kClient, groupCtx); err != nil {
+	if err := chain.MakeChain(r.client).Serve(ctx, keycloakRealmGroup, kClient, groupCtx); err != nil {
 		return fmt.Errorf("error during realm group chain: %w", err)
 	}
 

--- a/internal/webhook/v1/keycloakrealmgroup_webhook.go
+++ b/internal/webhook/v1/keycloakrealmgroup_webhook.go
@@ -1,0 +1,186 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	keycloakAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
+)
+
+// keycloakrealmgrouplog is for logging in this package.
+var keycloakrealmgrouplog = logf.Log.WithName("keycloakrealmgroup-resource")
+
+// SetupKeycloakRealmGroupWebhookWithManager registers the webhook for KeycloakRealmGroup in the manager.
+func SetupKeycloakRealmGroupWebhookWithManager(mgr ctrl.Manager, k8sClient client.Client) error {
+	return ctrl.NewWebhookManagedBy(mgr).For(&keycloakApi.KeycloakRealmGroup{}).
+		WithValidator(NewKeycloakRealmGroupCustomValidator(k8sClient)).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/validate-v1-edp-epam-com-v1-keycloakrealmgroup,mutating=false,failurePolicy=fail,sideEffects=None,groups=v1.edp.epam.com,resources=keycloakrealmgroups,verbs=create;update,versions=v1,name=vkeycloakrealmgroup-v1.kb.io,admissionReviewVersions=v1
+
+// KeycloakRealmGroupCustomValidator validates the KeycloakRealmGroup resource on create and update.
+type KeycloakRealmGroupCustomValidator struct {
+	k8sclient client.Client
+}
+
+func NewKeycloakRealmGroupCustomValidator(k8sClient client.Client) *KeycloakRealmGroupCustomValidator {
+	return &KeycloakRealmGroupCustomValidator{
+		k8sclient: k8sClient,
+	}
+}
+
+var _ webhook.CustomValidator = &KeycloakRealmGroupCustomValidator{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type KeycloakRealmGroup.
+func (v *KeycloakRealmGroupCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	group, ok := obj.(*keycloakApi.KeycloakRealmGroup)
+	if !ok {
+		return nil, fmt.Errorf("expected a KeycloakRealmGroup object but got %T", obj)
+	}
+
+	keycloakrealmgrouplog.Info("Validation for KeycloakRealmGroup upon creation", "name", group.GetName())
+
+	return nil, v.validateGroupUniqueness(ctx, group)
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type KeycloakRealmGroup.
+// Unlike name fields on other resources, spec.name and spec.parentGroup are mutable,
+// so an update can move the group into a colliding slot and must be re-validated.
+func (v *KeycloakRealmGroupCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	group, ok := newObj.(*keycloakApi.KeycloakRealmGroup)
+	if !ok {
+		return nil, fmt.Errorf("expected a KeycloakRealmGroup object but got %T", newObj)
+	}
+
+	oldGroup, ok := oldObj.(*keycloakApi.KeycloakRealmGroup)
+	if !ok {
+		return nil, fmt.Errorf("expected a KeycloakRealmGroup object but got %T", oldObj)
+	}
+
+	keycloakrealmgrouplog.Info("Validation for KeycloakRealmGroup upon update", "name", group.GetName())
+
+	// Only re-validate when the update changes the group's identity. Identity-preserving
+	// updates (finalizer removal, labels, other spec fields) must not be blocked: otherwise
+	// duplicates that predate this webhook could never be reconciled or even deleted.
+	if oldGroup.Spec.Name == group.Spec.Name && sameGroupTarget(oldGroup, group) {
+		return nil, nil
+	}
+
+	return nil, v.validateGroupUniqueness(ctx, group)
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type KeycloakRealmGroup.
+func (v *KeycloakRealmGroupCustomValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// validateGroupUniqueness checks that no other KeycloakRealmGroup resource resolves to the
+// same Keycloak group. A group's identity is (resolved realm, parent group, name): a top-level
+// group is identified by its name within the realm, a child group by its name under its parent.
+// Without this check two resources would silently adopt the same Keycloak group ID and
+// fight over its children on every reconciliation.
+func (v *KeycloakRealmGroupCustomValidator) validateGroupUniqueness(
+	ctx context.Context,
+	group *keycloakApi.KeycloakRealmGroup,
+) error {
+	existingGroups := &keycloakApi.KeycloakRealmGroupList{}
+	if err := v.k8sclient.List(ctx, existingGroups); err != nil {
+		return fmt.Errorf("failed to list KeycloakRealmGroup resources: %w", err)
+	}
+
+	for i := range existingGroups.Items {
+		existing := &existingGroups.Items[i]
+
+		isSameResource := existing.Namespace == group.Namespace && existing.Name == group.Name
+
+		if existing.Spec.Name == group.Spec.Name && sameGroupTarget(existing, group) && !isSameResource {
+			return fmt.Errorf(
+				"group name %q is already used by KeycloakRealmGroup %s/%s (%s in realm %s)",
+				group.Spec.Name,
+				existing.Namespace,
+				existing.Name,
+				formatGroupPlacement(group),
+				formatResolvedRealm(group),
+			)
+		}
+	}
+
+	return nil
+}
+
+func sameGroupTarget(a, b *keycloakApi.KeycloakRealmGroup) bool {
+	if !sameRealmInstance(a, b) {
+		return false
+	}
+
+	aParent, bParent := a.Spec.ParentGroup, b.Spec.ParentGroup
+
+	if (aParent == nil) != (bParent == nil) {
+		return false
+	}
+
+	if aParent == nil {
+		return true
+	}
+
+	// ParentGroup is a namespace-local CR reference, so the same parent name in
+	// different namespaces refers to two distinct parent groups.
+	return aParent.Name == bParent.Name && a.Namespace == b.Namespace
+}
+
+// sameRealmInstance reports whether two KeycloakRealmGroup resources target the same realm.
+//
+// The namespaced KeycloakRealm kind is resolved within the resource's own namespace, so its
+// identity is (namespace, name). The cluster-scoped ClusterKeycloakRealm kind is resolved
+// cluster-wide, so its identity is the name alone.
+func sameRealmInstance(a, b *keycloakApi.KeycloakRealmGroup) bool {
+	if normalizeRealmKind(a.Spec.RealmRef.Kind) != normalizeRealmKind(b.Spec.RealmRef.Kind) ||
+		a.Spec.RealmRef.Name != b.Spec.RealmRef.Name {
+		return false
+	}
+
+	if normalizeRealmKind(b.Spec.RealmRef.Kind) == keycloakApi.KeycloakRealmKind {
+		return a.Namespace == b.Namespace
+	}
+
+	return true
+}
+
+// normalizeRealmKind maps an unset RealmRef.Kind to its CRD default so that resources
+// created before structural defaulting are compared consistently.
+func normalizeRealmKind(kind string) string {
+	if kind == "" {
+		return keycloakApi.KeycloakRealmKind
+	}
+
+	return kind
+}
+
+func formatGroupPlacement(group *keycloakApi.KeycloakRealmGroup) string {
+	if group.Spec.ParentGroup != nil {
+		return fmt.Sprintf("under parent group %q", group.Spec.ParentGroup.Name)
+	}
+
+	return "top-level"
+}
+
+// formatResolvedRealm returns a human-readable identity of the realm a KeycloakRealmGroup
+// targets: Kind/namespace/name for the namespaced KeycloakRealm kind, Kind/name for
+// the cluster-scoped ClusterKeycloakRealm kind.
+func formatResolvedRealm(group *keycloakApi.KeycloakRealmGroup) string {
+	kind := normalizeRealmKind(group.Spec.RealmRef.Kind)
+	if kind == keycloakAlpha.ClusterKeycloakRealmKind {
+		return fmt.Sprintf("%s/%s", kind, group.Spec.RealmRef.Name)
+	}
+
+	return fmt.Sprintf("%s/%s/%s", kind, group.Namespace, group.Spec.RealmRef.Name)
+}

--- a/internal/webhook/v1/keycloakrealmgroup_webhook_test.go
+++ b/internal/webhook/v1/keycloakrealmgroup_webhook_test.go
@@ -1,0 +1,232 @@
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/epam/edp-keycloak-operator/api/common"
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	keycloakAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
+)
+
+func newRealmGroup(ns, name, groupName string, mutate ...func(*keycloakApi.KeycloakRealmGroup)) *keycloakApi.KeycloakRealmGroup {
+	g := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: keycloakApi.KeycloakRealmGroupSpec{
+			Name: groupName,
+			RealmRef: common.RealmRef{
+				Kind: keycloakApi.KeycloakRealmKind,
+				Name: "test-realm",
+			},
+		},
+	}
+
+	for _, m := range mutate {
+		m(g)
+	}
+
+	return g
+}
+
+func withParentGroup(name string) func(*keycloakApi.KeycloakRealmGroup) {
+	return func(g *keycloakApi.KeycloakRealmGroup) {
+		g.Spec.ParentGroup = &common.GroupRef{Name: name}
+	}
+}
+
+func withClusterRealm(name string) func(*keycloakApi.KeycloakRealmGroup) {
+	return func(g *keycloakApi.KeycloakRealmGroup) {
+		g.Spec.RealmRef = common.RealmRef{
+			Kind: keycloakAlpha.ClusterKeycloakRealmKind,
+			Name: name,
+		}
+	}
+}
+
+var _ = Describe("KeycloakRealmGroup Webhook", func() {
+	cleanup := func(groups ...*keycloakApi.KeycloakRealmGroup) {
+		for _, g := range groups {
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, g))).Should(Succeed())
+		}
+	}
+
+	Context("When creating KeycloakRealmGroup", func() {
+		It("Should deny a second top-level group with the same name for the same realm in the same namespace", func() {
+			existing := newRealmGroup("ns1", "group-one", "developers")
+			Expect(k8sClient.Create(ctx, existing)).Should(Succeed())
+			defer cleanup(existing)
+
+			duplicate := newRealmGroup("ns1", "group-two", "developers")
+
+			err := k8sClient.Create(ctx, duplicate)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(
+				`group name "developers" is already used by KeycloakRealmGroup ns1/group-one (top-level in realm KeycloakRealm/ns1/test-realm)`,
+			))
+		})
+
+		It("Should allow the same group name for the same realm name in another namespace (namespaced realm kind)", func() {
+			// KeycloakRealm refs resolve in the resource's own namespace, so the same
+			// realm ref name in ns2 targets a different realm than in ns1.
+			existing := newRealmGroup("ns1", "group-one", "developers")
+			Expect(k8sClient.Create(ctx, existing)).Should(Succeed())
+			defer cleanup(existing)
+
+			other := newRealmGroup("ns2", "group-two", "developers")
+			Expect(k8sClient.Create(ctx, other)).Should(Succeed())
+			cleanup(other)
+		})
+
+		It("Should deny the same top-level group name across namespaces for the same ClusterKeycloakRealm", func() {
+			existing := newRealmGroup("ns1", "cluster-group-one", "developers", withClusterRealm("shared-realm"))
+			Expect(k8sClient.Create(ctx, existing)).Should(Succeed())
+			defer cleanup(existing)
+
+			duplicate := newRealmGroup("ns2", "cluster-group-two", "developers", withClusterRealm("shared-realm"))
+
+			err := k8sClient.Create(ctx, duplicate)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(
+				`group name "developers" is already used by KeycloakRealmGroup ns1/cluster-group-one (top-level in realm ClusterKeycloakRealm/shared-realm)`,
+			))
+		})
+
+		It("Should allow the same group name under different parent groups", func() {
+			parentA := newRealmGroup("ns1", "parent-a", "ParentA")
+			parentB := newRealmGroup("ns1", "parent-b", "ParentB")
+			rolesA := newRealmGroup("ns1", "roles-a", "Roles", withParentGroup("parent-a"))
+			rolesB := newRealmGroup("ns1", "roles-b", "Roles", withParentGroup("parent-b"))
+
+			Expect(k8sClient.Create(ctx, parentA)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, parentB)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, rolesA)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, rolesB)).Should(Succeed())
+			cleanup(rolesB, rolesA, parentB, parentA)
+		})
+
+		It("Should allow the same group name for a top-level group and a child group", func() {
+			parent := newRealmGroup("ns1", "parent-a", "ParentA")
+			topLevel := newRealmGroup("ns1", "roles-top", "Roles")
+			child := newRealmGroup("ns1", "roles-child", "Roles", withParentGroup("parent-a"))
+
+			Expect(k8sClient.Create(ctx, parent)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, topLevel)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, child)).Should(Succeed())
+			cleanup(child, topLevel, parent)
+		})
+
+		It("Should deny the same group name under the same parent group", func() {
+			parent := newRealmGroup("ns1", "parent-a", "ParentA")
+			existing := newRealmGroup("ns1", "roles-one", "Roles", withParentGroup("parent-a"))
+			Expect(k8sClient.Create(ctx, parent)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, existing)).Should(Succeed())
+			defer cleanup(existing, parent)
+
+			duplicate := newRealmGroup("ns1", "roles-two", "Roles", withParentGroup("parent-a"))
+
+			err := k8sClient.Create(ctx, duplicate)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(
+				`group name "Roles" is already used by KeycloakRealmGroup ns1/roles-one (under parent group "parent-a" in realm KeycloakRealm/ns1/test-realm)`,
+			))
+		})
+
+		It("Should allow the same group name and parent name in another namespace (parent refs are namespace-local)", func() {
+			parentNs1 := newRealmGroup("ns1", "parent-a", "ParentA")
+			childNs1 := newRealmGroup("ns1", "roles-one", "Roles", withParentGroup("parent-a"))
+			Expect(k8sClient.Create(ctx, parentNs1)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, childNs1)).Should(Succeed())
+			defer cleanup(childNs1, parentNs1)
+
+			parentNs2 := newRealmGroup("ns2", "parent-a", "ParentA")
+			childNs2 := newRealmGroup("ns2", "roles-one", "Roles", withParentGroup("parent-a"))
+			Expect(k8sClient.Create(ctx, parentNs2)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, childNs2)).Should(Succeed())
+			cleanup(childNs2, parentNs2)
+		})
+
+		It("Should allow the same group name for different realms in the same namespace", func() {
+			existing := newRealmGroup("ns1", "group-one", "developers")
+			Expect(k8sClient.Create(ctx, existing)).Should(Succeed())
+			defer cleanup(existing)
+
+			otherRealm := newRealmGroup("ns1", "group-two", "developers", func(g *keycloakApi.KeycloakRealmGroup) {
+				g.Spec.RealmRef.Name = "another-realm"
+			})
+			Expect(k8sClient.Create(ctx, otherRealm)).Should(Succeed())
+			cleanup(otherRealm)
+		})
+	})
+
+	Context("When updating KeycloakRealmGroup", func() {
+		It("Should deny renaming a group into a colliding name", func() {
+			existing := newRealmGroup("ns1", "group-one", "developers")
+			victim := newRealmGroup("ns1", "group-two", "testers")
+			Expect(k8sClient.Create(ctx, existing)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, victim)).Should(Succeed())
+			defer cleanup(victim, existing)
+
+			victim.Spec.Name = "developers"
+
+			err := k8sClient.Update(ctx, victim)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`group name "developers" is already used by KeycloakRealmGroup ns1/group-one`))
+		})
+
+		It("Should deny re-parenting a group into a colliding slot", func() {
+			parentA := newRealmGroup("ns1", "parent-a", "ParentA")
+			parentB := newRealmGroup("ns1", "parent-b", "ParentB")
+			rolesA := newRealmGroup("ns1", "roles-a", "Roles", withParentGroup("parent-a"))
+			rolesB := newRealmGroup("ns1", "roles-b", "Roles", withParentGroup("parent-b"))
+			Expect(k8sClient.Create(ctx, parentA)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, parentB)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, rolesA)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, rolesB)).Should(Succeed())
+			defer cleanup(rolesB, rolesA, parentB, parentA)
+
+			rolesB.Spec.ParentGroup = &common.GroupRef{Name: "parent-a"}
+
+			err := k8sClient.Update(ctx, rolesB)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`group name "Roles" is already used by KeycloakRealmGroup ns1/roles-a`))
+		})
+
+		It("Should allow a self-update that keeps the same identity", func() {
+			existing := newRealmGroup("ns1", "group-one", "developers")
+			Expect(k8sClient.Create(ctx, existing)).Should(Succeed())
+			defer cleanup(existing)
+
+			existing.Spec.Description = "updated description"
+			Expect(k8sClient.Update(ctx, existing)).Should(Succeed())
+		})
+
+		It("Should allow identity-preserving updates on duplicates that predate the webhook", func() {
+			// Duplicates created before the webhook existed must stay reconcilable and
+			// deletable: finalizer or metadata updates keep the identity unchanged and
+			// must not be blocked, even though the duplicate slot is occupied.
+			existing := newRealmGroup("ns1", "group-one", "developers")
+			Expect(k8sClient.Create(ctx, existing)).Should(Succeed())
+			defer cleanup(existing)
+
+			validator := NewKeycloakRealmGroupCustomValidator(k8sClient)
+
+			preexistingDuplicate := newRealmGroup("ns1", "group-legacy", "developers")
+			updated := preexistingDuplicate.DeepCopy()
+			updated.Finalizers = nil
+			updated.Labels = map[string]string{"updated": "true"}
+
+			_, err := validator.ValidateUpdate(ctx, preexistingDuplicate, updated)
+			Expect(err).ShouldNot(HaveOccurred(), "identity-preserving update on a pre-existing duplicate must be allowed")
+
+			renamed := preexistingDuplicate.DeepCopy()
+			renamed.Spec.Name = "testers"
+			_, err = validator.ValidateUpdate(ctx, preexistingDuplicate, renamed)
+			Expect(err).ShouldNot(HaveOccurred(), "renaming a duplicate into a free slot must be allowed")
+		})
+	})
+})

--- a/internal/webhook/v1/rbac.go
+++ b/internal/webhook/v1/rbac.go
@@ -1,2 +1,3 @@
 // +kubebuilder:rbac:groups=v1.edp.epam.com,resources=keycloakrealms,verbs=get;list;watch
+// +kubebuilder:rbac:groups=v1.edp.epam.com,resources=keycloakrealmgroups,verbs=get;list;watch
 package v1

--- a/internal/webhook/v1/webhook_suite_test.go
+++ b/internal/webhook/v1/webhook_suite_test.go
@@ -93,6 +93,9 @@ var _ = BeforeSuite(func() {
 	err = SetupKeycloakClientWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = SetupKeycloakRealmGroupWebhookWithManager(mgr, k8sClient)
+	Expect(err).NotTo(HaveOccurred())
+
 	// +kubebuilder:scaffold:webhook
 
 	go func() {


### PR DESCRIPTION


Two KeycloakRealmGroup resources with the same spec.name targeting the same realm silently resolved to the same Keycloak group: the reconciler adopted any group found by name search, after which both resources fought over the group's children on every reconciliation, moving and detaching each other's subgroups indefinitely.

- add a validating webhook that rejects a resource whose identity (resolved realm, parent group or top-level, name) collides with an existing resource; updates are re-validated only when the identity changes, so duplicates that predate the webhook remain reconcilable and deletable
- refuse to adopt a group by name search when another resource already records its ID in status, so corruption is prevented even with webhooks disabled
- in the deprecated subGroups sync, only move groups that are top-level or already owned, and point users to spec.parentGroup when a claimed group is nested elsewhere

Fixes #362 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.
