### PR TITLE
chore(ci): Update development version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,21 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+
+<a name="v1.35.0"></a>
+## [v1.35.0] - 2026-07-13
+### Features
+- **realm:** add brute force detection support
+
+### Bug Fixes
+- **KeycloakRealmGroup:** prevent same-named groups from sharing one Keycloak group ID ([#362](https://github.com/epam/edp-keycloak-operator/issues/362))
+- **bundle:** publish to all current and future OpenShift versions
+- **webhook:** scope realm uniqueness to the resolved Keycloak instance ([#360](https://github.com/epam/edp-keycloak-operator/issues/360))
+
 ### Routine
+- **ci:** Update development version
 - **ci:** Publish 1.34 on operatorhub
+- **deps:** Bump golang.org/x/net from 0.48.0 to 0.55.0
 
 
 <a name="v1.34.0"></a>
@@ -403,7 +416,8 @@ Users can disable webhooks by setting \`enableWebhooks: false\` in Helm values.
 <a name="v1.17.0"></a>
 ## [v1.17.0] - 2023-08-17
 
-[Unreleased]: https://github.com/epam/edp-keycloak-operator/compare/v1.34.0...HEAD
+[Unreleased]: https://github.com/epam/edp-keycloak-operator/compare/v1.35.0...HEAD
+[v1.35.0]: https://github.com/epam/edp-keycloak-operator/compare/v1.34.0...v1.35.0
 [v1.34.0]: https://github.com/epam/edp-keycloak-operator/compare/v1.33.0...v1.34.0
 [v1.33.0]: https://github.com/epam/edp-keycloak-operator/compare/v1.32.0...v1.33.0
 [v1.32.0]: https://github.com/epam/edp-keycloak-operator/compare/v1.31.1...v1.32.0

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To install the Keycloak Operator, follow the steps below:
      ```bash
      helm search repo epamedp/keycloak-operator -l
      NAME                           CHART VERSION   APP VERSION     DESCRIPTION
-     epamedp/keycloak-operator      1.33.0          1.33.0          A Helm chart for KRCI Keycloak Operator
+     epamedp/keycloak-operator      1.35.0          1.35.0          A Helm chart for KRCI Keycloak Operator
      ```
 
     _**NOTE:** It is highly recommended to use the latest stable version._

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=edp-keycloak-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable,alpha
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.3
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/bundle/manifests/edp-keycloak-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/edp-keycloak-operator.clusterserviceversion.yaml
@@ -839,8 +839,8 @@ metadata:
       ]
     capabilities: Deep Insights
     categories: Security
-    containerImage: docker.io/epamedp/keycloak-operator:1.34.0
-    createdAt: "2026-05-19T15:59:33Z"
+    containerImage: docker.io/epamedp/keycloak-operator:1.35.0
+    createdAt: "2026-07-13T09:23:42Z"
     description: An Operator for managing Keycloak
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -853,11 +853,11 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: <1.34.0
-    operators.operatorframework.io/builder: operator-sdk-v1.42.2
+    operators.operatorframework.io/builder: operator-sdk-v1.42.3
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/epam/edp-keycloak-operator
     support: KubeRocketCI
-  name: edp-keycloak-operator.v1.34.0
+  name: edp-keycloak-operator.v1.35.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1099,7 +1099,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: docker.io/epamedp/keycloak-operator:1.34.0
+                image: docker.io/epamedp/keycloak-operator:1.35.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -1281,7 +1281,7 @@ spec:
   provider:
     name: KubeRocketCI
     url: https://docs.kuberocketci.io/
-  version: 1.34.0
+  version: 1.35.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/bundle/manifests/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -71,6 +71,74 @@ spec:
                   apply to HTTP responses from the realm's browser clients.
                 nullable: true
                 type: object
+              bruteForceDetection:
+                description: |-
+                  BruteForceDetection configures brute force attack detection for the realm.
+                  The realm's "Brute Force Mode" is derived from a combination of fields on this struct rather than being a single value:
+                  Disabled - BruteForceProtected is false.
+                  Lockout permanently - BruteForceProtected is true and PermanentLockout is true.
+                  Lockout temporarily - BruteForceProtected is true, PermanentLockout is false, and MaxTemporaryLockouts is 0 or unset.
+                  Lockout permanently after temporary lockout - BruteForceProtected is true, PermanentLockout is false, and MaxTemporaryLockouts is greater than 0.
+                nullable: true
+                properties:
+                  bruteForceProtected:
+                    description: BruteForceProtected enables/disables brute force
+                      detection for the realm.
+                    nullable: true
+                    type: boolean
+                  bruteForceStrategy:
+                    description: BruteForceStrategy determines how the failure count
+                      and wait time are calculated once detection triggers.
+                    enum:
+                    - LINEAR
+                    - MULTIPLE
+                    type: string
+                  failureFactor:
+                    description: FailureFactor is the number of login failures before
+                      an account is locked out.
+                    nullable: true
+                    type: integer
+                  maxDeltaTimeSeconds:
+                    description: MaxDeltaTimeSeconds is the time period, in seconds,
+                      over which failures are tracked before the counter resets.
+                    nullable: true
+                    type: integer
+                  maxFailureWaitSeconds:
+                    description: MaxFailureWaitSeconds is the max time, in seconds,
+                      a user is locked out for.
+                    nullable: true
+                    type: integer
+                  maxTemporaryLockouts:
+                    description: |-
+                      MaxTemporaryLockouts is the number of temporary lockouts allowed before the account is locked out permanently.
+                      A value of 0 disables permanent lockout after temporary lockouts.
+                    nullable: true
+                    type: integer
+                  minimumQuickLoginWaitSeconds:
+                    description: MinimumQuickLoginWaitSeconds is the wait time applied
+                      when a "quick" failure occurs (a failure soon after the previous
+                      one).
+                    nullable: true
+                    type: integer
+                  permanentLockout:
+                    description: PermanentLockout locks a user out permanently once
+                      the failure threshold is exceeded, requiring admin intervention
+                      to unlock.
+                    nullable: true
+                    type: boolean
+                  quickLoginCheckMilliSeconds:
+                    description: QuickLoginCheckMilliSeconds is the time window, in
+                      milliseconds, within which a login failure is considered a "quick"
+                      failure.
+                    format: int64
+                    nullable: true
+                    type: integer
+                  waitIncrementSeconds:
+                    description: WaitIncrementSeconds is the amount of time added
+                      to the lockout wait for each subsequent failure.
+                    nullable: true
+                    type: integer
+                type: object
               clusterKeycloakRef:
                 description: ClusterKeycloakRef is a name of the ClusterKeycloak instance
                   that owns the realm.

--- a/bundle/manifests/v1.edp.epam.com_keycloakrealms.yaml
+++ b/bundle/manifests/v1.edp.epam.com_keycloakrealms.yaml
@@ -68,6 +68,74 @@ spec:
                   apply to HTTP responses from the realm's browser clients.
                 nullable: true
                 type: object
+              bruteForceDetection:
+                description: |-
+                  BruteForceDetection configures brute force attack detection for the realm.
+                  The realm's "Brute Force Mode" is derived from a combination of fields on this struct rather than being a single value:
+                  Disabled - BruteForceProtected is false.
+                  Lockout permanently - BruteForceProtected is true and PermanentLockout is true.
+                  Lockout temporarily - BruteForceProtected is true, PermanentLockout is false, and MaxTemporaryLockouts is 0 or unset.
+                  Lockout permanently after temporary lockout - BruteForceProtected is true, PermanentLockout is false, and MaxTemporaryLockouts is greater than 0.
+                nullable: true
+                properties:
+                  bruteForceProtected:
+                    description: BruteForceProtected enables/disables brute force
+                      detection for the realm.
+                    nullable: true
+                    type: boolean
+                  bruteForceStrategy:
+                    description: BruteForceStrategy determines how the failure count
+                      and wait time are calculated once detection triggers.
+                    enum:
+                    - LINEAR
+                    - MULTIPLE
+                    type: string
+                  failureFactor:
+                    description: FailureFactor is the number of login failures before
+                      an account is locked out.
+                    nullable: true
+                    type: integer
+                  maxDeltaTimeSeconds:
+                    description: MaxDeltaTimeSeconds is the time period, in seconds,
+                      over which failures are tracked before the counter resets.
+                    nullable: true
+                    type: integer
+                  maxFailureWaitSeconds:
+                    description: MaxFailureWaitSeconds is the max time, in seconds,
+                      a user is locked out for.
+                    nullable: true
+                    type: integer
+                  maxTemporaryLockouts:
+                    description: |-
+                      MaxTemporaryLockouts is the number of temporary lockouts allowed before the account is locked out permanently.
+                      A value of 0 disables permanent lockout after temporary lockouts.
+                    nullable: true
+                    type: integer
+                  minimumQuickLoginWaitSeconds:
+                    description: MinimumQuickLoginWaitSeconds is the wait time applied
+                      when a "quick" failure occurs (a failure soon after the previous
+                      one).
+                    nullable: true
+                    type: integer
+                  permanentLockout:
+                    description: PermanentLockout locks a user out permanently once
+                      the failure threshold is exceeded, requiring admin intervention
+                      to unlock.
+                    nullable: true
+                    type: boolean
+                  quickLoginCheckMilliSeconds:
+                    description: QuickLoginCheckMilliSeconds is the time window, in
+                      milliseconds, within which a login failure is considered a "quick"
+                      failure.
+                    format: int64
+                    nullable: true
+                    type: integer
+                  waitIncrementSeconds:
+                    description: WaitIncrementSeconds is the amount of time added
+                      to the lockout wait for each subsequent failure.
+                    nullable: true
+                    type: integer
+                type: object
               displayHtmlName:
                 description: DisplayHTMLName name to render in the UI
                 type: string

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: edp-keycloak-operator
   operators.operatorframework.io.bundle.channels.v1: stable,alpha
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.2
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.3
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: docker.io/epamedp/keycloak-operator
-  newTag: 1.34.0
+  newTag: 1.35.0

--- a/deploy-templates/Chart.yaml
+++ b/deploy-templates/Chart.yaml
@@ -3,8 +3,8 @@ description: A Helm chart for KubeRocketCI Keycloak Operator
 home: https://docs.kuberocketci.io/
 name: keycloak-operator
 type: application
-version: 1.35.0-SNAPSHOT
-appVersion: 1.35.0-SNAPSHOT
+version: 1.36.0-SNAPSHOT
+appVersion: 1.36.0-SNAPSHOT
 icon: https://docs.kuberocketci.io/img/logo.svg
 keywords:
   - authentication
@@ -29,8 +29,8 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/operator: "true"
   artifacthub.io/images: |
-    - name: keycloak-operator:1.34.0
-      image: epamedp/keycloak-operator:1.34.0
+    - name: keycloak-operator:1.35.0
+      image: epamedp/keycloak-operator:1.35.0
   artifacthub.io/operatorCapabilities: Deep Insights
   artifacthub.io/crds: |
     - kind: Keycloak

--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -1,6 +1,6 @@
 # keycloak-operator
 
-![Version: 1.35.0-SNAPSHOT](https://img.shields.io/badge/Version-1.35.0--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.35.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.35.0--SNAPSHOT-informational?style=flat-square)
+![Version: 1.36.0-SNAPSHOT](https://img.shields.io/badge/Version-1.36.0--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.36.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.36.0--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for KubeRocketCI Keycloak Operator
 


### PR DESCRIPTION
- Bump Helm chart to 1.36.0-SNAPSHOT and roll operator image tag to 1.35.0
- Cut CHANGELOG v1.35.0 section and reset Unreleased
- Regenerate OLM bundle and helm docs for the 1.35.0 release

