### PR TITLE
fix(KeycloakRealmUser): keep role mappings when spec.roles is unset (#371)

### DIFF
--- a/api/v1/keycloakclient_types.go
+++ b/api/v1/keycloakclient_types.go
@@ -251,7 +251,7 @@ type UserClientRole struct {
 	// Roles is a list of client roles names assigned to user.
 	// +nullable
 	// +optional
-	Roles []string `json:"roles,omitempty"`
+	Roles []string `json:"roles"` // no omitempty: an empty list has to stay distinguishable from an omitted one
 }
 
 type ClientRole struct {

--- a/api/v1/keycloakrealmuser_types.go
+++ b/api/v1/keycloakrealmuser_types.go
@@ -40,12 +40,16 @@ type KeycloakRealmUserSpec struct {
 	// +optional
 	RequiredUserActions []string `json:"requiredUserActions,omitempty"`
 
-	// Roles is a list of roles assigned to user.
+	// Roles is a list of realm roles assigned to user.
+	// Omitting the field, or setting it to null, leaves the realm roles the user already has untouched,
+	// including the defaults Keycloak grants on creation.
+	// An explicit empty list removes every realm role from the user.
 	// +nullable
 	// +optional
 	Roles []string `json:"roles"` // no omitempty: an empty list has to stay distinguishable from an omitted one
 
 	// ClientRoles is a list of client roles assigned to user.
+	// The same rule as for Roles applies per client: omitting an entry's roles list leaves that client's roles untouched, an empty list removes all of them.
 	// +nullable
 	// +optional
 	ClientRoles []UserClientRole `json:"clientRoles,omitempty"`

--- a/api/v1/keycloakrealmuser_types.go
+++ b/api/v1/keycloakrealmuser_types.go
@@ -43,7 +43,7 @@ type KeycloakRealmUserSpec struct {
 	// Roles is a list of roles assigned to user.
 	// +nullable
 	// +optional
-	Roles []string `json:"roles,omitempty"`
+	Roles []string `json:"roles"` // no omitempty: an empty list has to stay distinguishable from an omitted one
 
 	// ClientRoles is a list of client roles assigned to user.
 	// +nullable

--- a/api/v1/keycloakrealmuser_types_test.go
+++ b/api/v1/keycloakrealmuser_types_test.go
@@ -1,0 +1,55 @@
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The user controller reads an omitted role list as "not managed" and an empty one as "remove
+// every role". The controller also rewrites the whole resource when it adds its finalizer or
+// migrates attributes, so an empty list has to survive a marshal/unmarshal cycle: with omitempty
+// on the json tag it would come back as omitted and silently downgrade to "not managed".
+func TestKeycloakRealmUserSpec_EmptyRoleListsSurviveSerialization(t *testing.T) {
+	spec := KeycloakRealmUserSpec{
+		Username: "testuser",
+		Roles:    []string{},
+		ClientRoles: []UserClientRole{
+			{ClientID: "client1", Roles: []string{}},
+		},
+	}
+
+	raw, err := json.Marshal(spec)
+	require.NoError(t, err)
+
+	var decoded KeycloakRealmUserSpec
+
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+
+	assert.NotNil(t, decoded.Roles, "empty spec.roles must not decode back as omitted")
+	assert.Empty(t, decoded.Roles)
+
+	require.Len(t, decoded.ClientRoles, 1)
+	assert.NotNil(t, decoded.ClientRoles[0].Roles, "empty spec.clientRoles[].roles must not decode back as omitted")
+	assert.Empty(t, decoded.ClientRoles[0].Roles)
+}
+
+// An omitted role list must stay omitted, so that "not managed" is not confused with "remove
+// every role" in the other direction either.
+func TestKeycloakRealmUserSpec_OmittedRoleListsStayOmitted(t *testing.T) {
+	raw, err := json.Marshal(KeycloakRealmUserSpec{
+		Username:    "testuser",
+		ClientRoles: []UserClientRole{{ClientID: "client1"}},
+	})
+	require.NoError(t, err)
+
+	var decoded KeycloakRealmUserSpec
+
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+
+	assert.Nil(t, decoded.Roles)
+	require.Len(t, decoded.ClientRoles, 1)
+	assert.Nil(t, decoded.ClientRoles[0].Roles)
+}

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml
@@ -63,7 +63,9 @@ spec:
                 nullable: true
                 type: object
               clientRoles:
-                description: ClientRoles is a list of client roles assigned to user.
+                description: |-
+                  ClientRoles is a list of client roles assigned to user.
+                  The same rule as for Roles applies per client: omitting an entry's roles list leaves that client's roles untouched, an empty list removes all of them.
                 items:
                   properties:
                     clientId:
@@ -177,7 +179,11 @@ spec:
                 nullable: true
                 type: array
               roles:
-                description: Roles is a list of roles assigned to user.
+                description: |-
+                  Roles is a list of realm roles assigned to user.
+                  Omitting the field, or setting it to null, leaves the realm roles the user already has untouched,
+                  including the defaults Keycloak grants on creation.
+                  An explicit empty list removes every realm role from the user.
                 items:
                   type: string
                 nullable: true

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml
@@ -63,7 +63,9 @@ spec:
                 nullable: true
                 type: object
               clientRoles:
-                description: ClientRoles is a list of client roles assigned to user.
+                description: |-
+                  ClientRoles is a list of client roles assigned to user.
+                  The same rule as for Roles applies per client: omitting an entry's roles list leaves that client's roles untouched, an empty list removes all of them.
                 items:
                   properties:
                     clientId:
@@ -177,7 +179,11 @@ spec:
                 nullable: true
                 type: array
               roles:
-                description: Roles is a list of roles assigned to user.
+                description: |-
+                  Roles is a list of realm roles assigned to user.
+                  Omitting the field, or setting it to null, leaves the realm roles the user already has untouched,
+                  including the defaults Keycloak grants on creation.
+                  An explicit empty list removes every realm role from the user.
                 items:
                   type: string
                 nullable: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -8053,7 +8053,8 @@ Each attribute can have multiple values.<br/>
         <td><b><a href="#keycloakrealmuserspecclientrolesindex">clientRoles</a></b></td>
         <td>[]object</td>
         <td>
-          ClientRoles is a list of client roles assigned to user.<br/>
+          ClientRoles is a list of client roles assigned to user.
+The same rule as for Roles applies per client: omitting an entry's roles list leaves that client's roles untouched, an empty list removes all of them.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -8154,7 +8155,10 @@ If set to full, user will be created if it does not exist, or updated if it exis
         <td><b>roles</b></td>
         <td>[]string</td>
         <td>
-          Roles is a list of roles assigned to user.<br/>
+          Roles is a list of realm roles assigned to user.
+Omitting the field, or setting it to null, leaves the realm roles the user already has untouched,
+including the defaults Keycloak grants on creation.
+An explicit empty list removes every realm role from the user.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/internal/controller/keycloakrealmuser/chain/sync_user_roles.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_roles.go
@@ -49,6 +49,14 @@ func (h *SyncUserRoles) syncRealmRoles(
 	desiredRoleNames []string,
 	addOnly bool,
 ) error {
+	// A nil desired list means the field was omitted, so the resource does not manage realm roles
+	// at all and Keycloak is left alone. An empty but non-nil list still means "no roles" and
+	// clears every mapping. Normalising the field anywhere upstream would silently turn
+	// "not managed" into "delete everything".
+	if desiredRoleNames == nil {
+		return nil
+	}
+
 	currentRoles, _, err := h.kClient.Users.GetUserRealmRoleMappings(ctx, realmName, userID)
 	if err != nil {
 		return fmt.Errorf("unable to get user realm role mappings: %w", err)
@@ -113,6 +121,12 @@ func (h *SyncUserRoles) syncClientRoles(
 	addOnly bool,
 ) error {
 	for _, cr := range clientRoles {
+		// As in syncRealmRoles, an omitted role list means this client's roles are not managed,
+		// which leaves nothing to do for the entry at all.
+		if cr.Roles == nil {
+			continue
+		}
+
 		clients, _, err := h.kClient.Clients.GetClients(ctx, realmName, &keycloakapi.GetClientsParams{ClientId: &cr.ClientID})
 		if err != nil {
 			return fmt.Errorf("unable to get client %q: %w", cr.ClientID, err)

--- a/internal/controller/keycloakrealmuser/chain/sync_user_roles_test.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_roles_test.go
@@ -98,6 +98,87 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 			wantErr: require.NoError,
 		},
 		{
+			name: "success - unset roles keep existing realm roles (full strategy)",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{},
+			},
+			userCtx: &UserContext{UserID: "user-unset"},
+			mockSetup: func(_ *v2mocks.MockUsersClient, _ *v2mocks.MockRolesClient, _ *v2mocks.MockClientsClient) {
+				// Keycloak must not be touched at all: spec.roles is unset, so realm roles
+				// (including the default-roles-<realm> Keycloak grants on creation) are unmanaged.
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "success - empty roles remove every realm role (full strategy)",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec: keycloakApi.KeycloakRealmUserSpec{
+					Roles: []string{},
+				},
+			},
+			userCtx: &UserContext{UserID: "user-empty"},
+			mockSetup: func(u *v2mocks.MockUsersClient, r *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
+				u.EXPECT().GetUserRealmRoleMappings(context.Background(), "test-realm", "user-empty").
+					Return([]keycloakapi.RoleRepresentation{
+						{Id: ptr.To("id1"), Name: ptr.To("role1")},
+					}, nil, nil)
+				u.EXPECT().DeleteUserRealmRoles(context.Background(), "test-realm", "user-empty", []keycloakapi.RoleRepresentation{
+					{Id: ptr.To("id1"), Name: ptr.To("role1")},
+				}).Return(nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "success - unset client roles keep existing client roles (full strategy)",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec: keycloakApi.KeycloakRealmUserSpec{
+					ClientRoles: []keycloakApi.UserClientRole{
+						{ClientID: "client-unset"},
+						{ClientID: "client-managed", Roles: []string{"crole1"}},
+					},
+				},
+			},
+			userCtx: &UserContext{UserID: "user-unset-client"},
+			mockSetup: func(u *v2mocks.MockUsersClient, _ *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
+				// client-unset is skipped whole: not even looked up, so a stale or misspelled
+				// clientId in an unmanaged entry cannot fail the reconciliation.
+				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakapi.GetClientsParams{ClientId: ptr.To("client-managed")}).
+					Return([]keycloakapi.ClientRepresentation{{Id: ptr.To("client-uuid-2")}}, nil, nil)
+				u.EXPECT().GetUserClientRoleMappings(context.Background(), "test-realm", "user-unset-client", "client-uuid-2").
+					Return([]keycloakapi.RoleRepresentation{
+						{Id: ptr.To("crid1"), Name: ptr.To("crole1")},
+					}, nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "success - empty client roles remove every client role (full strategy)",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec: keycloakApi.KeycloakRealmUserSpec{
+					ClientRoles: []keycloakApi.UserClientRole{
+						{ClientID: "client-empty", Roles: []string{}},
+					},
+				},
+			},
+			userCtx: &UserContext{UserID: "user-empty-client"},
+			mockSetup: func(u *v2mocks.MockUsersClient, _ *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
+				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakapi.GetClientsParams{ClientId: ptr.To("client-empty")}).
+					Return([]keycloakapi.ClientRepresentation{{Id: ptr.To("client-uuid-1")}}, nil, nil)
+				u.EXPECT().GetUserClientRoleMappings(context.Background(), "test-realm", "user-empty-client", "client-uuid-1").
+					Return([]keycloakapi.RoleRepresentation{
+						{Id: ptr.To("crid1"), Name: ptr.To("crole1")},
+					}, nil, nil)
+				u.EXPECT().DeleteUserClientRoles(context.Background(), "test-realm", "user-empty-client", "client-uuid-1", []keycloakapi.RoleRepresentation{
+					{Id: ptr.To("crid1"), Name: ptr.To("crole1")},
+				}).Return(nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
 			name: "success - sync client roles",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
@@ -109,9 +190,6 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 			},
 			userCtx: &UserContext{UserID: "user-4"},
 			mockSetup: func(u *v2mocks.MockUsersClient, r *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
-				// no realm roles
-				u.EXPECT().GetUserRealmRoleMappings(context.Background(), "test-realm", "user-4").
-					Return(nil, nil, nil)
 				// client lookup
 				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakapi.GetClientsParams{ClientId: ptr.To("client1")}).
 					Return([]keycloakapi.ClientRepresentation{{Id: ptr.To("client-uuid-1")}}, nil, nil)
@@ -141,8 +219,6 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 			},
 			userCtx: &UserContext{UserID: "user-5"},
 			mockSetup: func(u *v2mocks.MockUsersClient, r *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
-				u.EXPECT().GetUserRealmRoleMappings(context.Background(), "test-realm", "user-5").
-					Return(nil, nil, nil)
 				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakapi.GetClientsParams{ClientId: ptr.To("client1")}).
 					Return([]keycloakapi.ClientRepresentation{{Id: ptr.To("client-uuid-1")}}, nil, nil)
 				u.EXPECT().GetUserClientRoleMappings(context.Background(), "test-realm", "user-5", "client-uuid-1").
@@ -206,9 +282,7 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 				},
 			},
 			userCtx: &UserContext{UserID: "user-err3"},
-			mockSetup: func(u *v2mocks.MockUsersClient, r *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
-				u.EXPECT().GetUserRealmRoleMappings(context.Background(), "test-realm", "user-err3").
-					Return(nil, nil, nil)
+			mockSetup: func(_ *v2mocks.MockUsersClient, _ *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
 				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakapi.GetClientsParams{ClientId: ptr.To("no-such-client")}).
 					Return(nil, nil, nil)
 			},


### PR DESCRIPTION
`spec.roles` is optional, but with the default `reconciliationStrategy: full` leaving it out wipes every realm role the user has. The nil list reads as "the desired set is empty", so the removal pass deletes everything it finds, `default-roles-<realm>` included. The user is left without `offline_access`, `uma_authorization` and the `account` client roles Keycloak gave it at creation. A `clientRoles` entry with no `roles` list does the same to that client's mappings.

Now an omitted (or null) list means the resource does not manage those roles, and existing mappings are left alone. `roles: []` still means "no roles" and clears them all. Same rule per client entry in `clientRoles`.

Half of the fix is in the JSON tags. Both role fields had `omitempty`, so an explicit `[]` disappeared on the first update the operator itself made to the object and came back indistinguishable from omitted. They lost `omitempty` (both are already `+nullable`, the CRD schema does not change), and a serialization test now pins empty and omitted as distinct values.

`spec.identityProviders` already works like this, it just carries the distinction in its type (`*[]string`). Making `Roles` a pointer too would be the honest spelling, but that is an API break for a bug fix, so I left the nil slice to carry it here.

One side effect worth knowing: an unmanaged `clientRoles` entry is now skipped before the client lookup, so a stale `clientId` on an entry without a `roles` list no longer fails reconciliation. That removes an error signal that existed before, but failing the whole user over an entry the resource does not manage seemed worse.

Behavior change for anyone who was omitting `roles` to strip a user down to nothing: write `roles: []` instead.
