### PR TITLE
fix(realm): preserve externally-set display name and organizations flag on reconcile (#376)

### DIFF
--- a/api/v1/keycloakrealm_types.go
+++ b/api/v1/keycloakrealm_types.go
@@ -57,9 +57,11 @@ type KeycloakRealmSpec struct {
 	// +optional
 	PasswordPolicies []common.PasswordPolicy `json:"passwordPolicy,omitempty"`
 
-	// DisplayHTMLName name to render in the UI
+	// DisplayHTMLName name to render in the UI.
+	// Set to an empty string to clear the value in Keycloak.
+	// +nullable
 	// +optional
-	DisplayHTMLName string `json:"displayHtmlName,omitempty"`
+	DisplayHTMLName *string `json:"displayHtmlName,omitempty"`
 
 	// FrontendURL Set the frontend URL for the realm. Use in combination with the default hostname provider to override the base URL for frontend requests for a specific realm.
 	// +optional
@@ -71,15 +73,17 @@ type KeycloakRealmSpec struct {
 	TokenSettings *common.TokenSettings `json:"tokenSettings,omitempty"`
 
 	// DisplayName is the display name of the realm.
+	// Set to an empty string to clear the value in Keycloak.
+	// +nullable
 	// +optional
-	DisplayName string `json:"displayName,omitempty"`
+	DisplayName *string `json:"displayName,omitempty"`
 
 	// OrganizationsEnabled enables Keycloak Organizations feature for this realm.
 	// When enabled, this realm can support Organization resources for multi-tenant scenarios,
 	// identity provider groupings, and domain-based user routing.
+	// +nullable
 	// +optional
-	// +kubebuilder:default=false
-	OrganizationsEnabled bool `json:"organizationsEnabled,omitempty"`
+	OrganizationsEnabled *bool `json:"organizationsEnabled,omitempty"`
 
 	// UserProfileConfig is the configuration for user profiles in the realm.
 	// Attributes and groups will be added to the current realm configuration.

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1459,9 +1459,24 @@ func (in *KeycloakRealmSpec) DeepCopyInto(out *KeycloakRealmSpec) {
 		*out = make([]common.PasswordPolicy, len(*in))
 		copy(*out, *in)
 	}
+	if in.DisplayHTMLName != nil {
+		in, out := &in.DisplayHTMLName, &out.DisplayHTMLName
+		*out = new(string)
+		**out = **in
+	}
 	if in.TokenSettings != nil {
 		in, out := &in.TokenSettings, &out.TokenSettings
 		*out = new(common.TokenSettings)
+		**out = **in
+	}
+	if in.DisplayName != nil {
+		in, out := &in.DisplayName, &out.DisplayName
+		*out = new(string)
+		**out = **in
+	}
+	if in.OrganizationsEnabled != nil {
+		in, out := &in.OrganizationsEnabled, &out.OrganizationsEnabled
+		*out = new(bool)
 		**out = **in
 	}
 	if in.UserProfileConfig != nil {

--- a/api/v1alpha1/clusterkeycloakrealm_types.go
+++ b/api/v1alpha1/clusterkeycloakrealm_types.go
@@ -57,19 +57,23 @@ type ClusterKeycloakRealmSpec struct {
 	AuthenticationFlow *AuthenticationFlow `json:"authenticationFlows,omitempty"`
 
 	// DisplayHTMLName name to render in the UI.
+	// Set to an empty string to clear the value in Keycloak.
+	// +nullable
 	// +optional
-	DisplayHTMLName string `json:"displayHtmlName,omitempty"`
+	DisplayHTMLName *string `json:"displayHtmlName,omitempty"`
 
 	// DisplayName is the display name of the realm.
+	// Set to an empty string to clear the value in Keycloak.
+	// +nullable
 	// +optional
-	DisplayName string `json:"displayName,omitempty"`
+	DisplayName *string `json:"displayName,omitempty"`
 
 	// OrganizationsEnabled enables Keycloak Organizations feature for this realm.
 	// When enabled, this realm can support Organization resources for multi-tenant scenarios,
 	// identity provider groupings, and domain-based user routing.
+	// +nullable
 	// +optional
-	// +kubebuilder:default=false
-	OrganizationsEnabled bool `json:"organizationsEnabled,omitempty"`
+	OrganizationsEnabled *bool `json:"organizationsEnabled,omitempty"`
 
 	// UserProfileConfig is the configuration for user profiles in the realm.
 	// +nullable

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -187,6 +187,21 @@ func (in *ClusterKeycloakRealmSpec) DeepCopyInto(out *ClusterKeycloakRealmSpec) 
 		*out = new(AuthenticationFlow)
 		**out = **in
 	}
+	if in.DisplayHTMLName != nil {
+		in, out := &in.DisplayHTMLName, &out.DisplayHTMLName
+		*out = new(string)
+		**out = **in
+	}
+	if in.DisplayName != nil {
+		in, out := &in.DisplayName, &out.DisplayName
+		*out = new(string)
+		**out = **in
+	}
+	if in.OrganizationsEnabled != nil {
+		in, out := &in.OrganizationsEnabled, &out.OrganizationsEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	if in.UserProfileConfig != nil {
 		in, out := &in.UserProfileConfig, &out.UserProfileConfig
 		*out = new(common.UserProfileConfig)

--- a/config/crd/bases/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/config/crd/bases/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -144,10 +144,16 @@ spec:
                   that owns the realm.
                 type: string
               displayHtmlName:
-                description: DisplayHTMLName name to render in the UI.
+                description: |-
+                  DisplayHTMLName name to render in the UI.
+                  Set to an empty string to clear the value in Keycloak.
+                nullable: true
                 type: string
               displayName:
-                description: DisplayName is the display name of the realm.
+                description: |-
+                  DisplayName is the display name of the realm.
+                  Set to an empty string to clear the value in Keycloak.
+                nullable: true
                 type: string
               frontendUrl:
                 description: |-
@@ -227,11 +233,11 @@ spec:
                     type: boolean
                 type: object
               organizationsEnabled:
-                default: false
                 description: |-
                   OrganizationsEnabled enables Keycloak Organizations feature for this realm.
                   When enabled, this realm can support Organization resources for multi-tenant scenarios,
                   identity provider groupings, and domain-based user routing.
+                nullable: true
                 type: boolean
               passwordPolicy:
                 description: PasswordPolicies is a list of password policies to apply

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
@@ -137,10 +137,16 @@ spec:
                     type: integer
                 type: object
               displayHtmlName:
-                description: DisplayHTMLName name to render in the UI
+                description: |-
+                  DisplayHTMLName name to render in the UI.
+                  Set to an empty string to clear the value in Keycloak.
+                nullable: true
                 type: string
               displayName:
-                description: DisplayName is the display name of the realm.
+                description: |-
+                  DisplayName is the display name of the realm.
+                  Set to an empty string to clear the value in Keycloak.
+                nullable: true
                 type: string
               frontendUrl:
                 description: FrontendURL Set the frontend URL for the realm. Use in
@@ -241,11 +247,11 @@ spec:
                     type: boolean
                 type: object
               organizationsEnabled:
-                default: false
                 description: |-
                   OrganizationsEnabled enables Keycloak Organizations feature for this realm.
                   When enabled, this realm can support Organization resources for multi-tenant scenarios,
                   identity provider groupings, and domain-based user routing.
+                nullable: true
                 type: boolean
               passwordPolicy:
                 description: PasswordPolicies is a list of password policies to apply

--- a/deploy-templates/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -144,10 +144,16 @@ spec:
                   that owns the realm.
                 type: string
               displayHtmlName:
-                description: DisplayHTMLName name to render in the UI.
+                description: |-
+                  DisplayHTMLName name to render in the UI.
+                  Set to an empty string to clear the value in Keycloak.
+                nullable: true
                 type: string
               displayName:
-                description: DisplayName is the display name of the realm.
+                description: |-
+                  DisplayName is the display name of the realm.
+                  Set to an empty string to clear the value in Keycloak.
+                nullable: true
                 type: string
               frontendUrl:
                 description: |-
@@ -227,11 +233,11 @@ spec:
                     type: boolean
                 type: object
               organizationsEnabled:
-                default: false
                 description: |-
                   OrganizationsEnabled enables Keycloak Organizations feature for this realm.
                   When enabled, this realm can support Organization resources for multi-tenant scenarios,
                   identity provider groupings, and domain-based user routing.
+                nullable: true
                 type: boolean
               passwordPolicy:
                 description: PasswordPolicies is a list of password policies to apply

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
@@ -137,10 +137,16 @@ spec:
                     type: integer
                 type: object
               displayHtmlName:
-                description: DisplayHTMLName name to render in the UI
+                description: |-
+                  DisplayHTMLName name to render in the UI.
+                  Set to an empty string to clear the value in Keycloak.
+                nullable: true
                 type: string
               displayName:
-                description: DisplayName is the display name of the realm.
+                description: |-
+                  DisplayName is the display name of the realm.
+                  Set to an empty string to clear the value in Keycloak.
+                nullable: true
                 type: string
               frontendUrl:
                 description: FrontendURL Set the frontend URL for the realm. Use in
@@ -241,11 +247,11 @@ spec:
                     type: boolean
                 type: object
               organizationsEnabled:
-                default: false
                 description: |-
                   OrganizationsEnabled enables Keycloak Organizations feature for this realm.
                   When enabled, this realm can support Organization resources for multi-tenant scenarios,
                   identity provider groupings, and domain-based user routing.
+                nullable: true
                 type: boolean
               passwordPolicy:
                 description: PasswordPolicies is a list of password policies to apply

--- a/docs/api.md
+++ b/docs/api.md
@@ -132,14 +132,16 @@ Lockout permanently after temporary lockout - BruteForceProtected is true, Perma
         <td><b>displayHtmlName</b></td>
         <td>string</td>
         <td>
-          DisplayHTMLName name to render in the UI.<br/>
+          DisplayHTMLName name to render in the UI.
+Set to an empty string to clear the value in Keycloak.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>displayName</b></td>
         <td>string</td>
         <td>
-          DisplayName is the display name of the realm.<br/>
+          DisplayName is the display name of the realm.
+Set to an empty string to clear the value in Keycloak.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -171,8 +173,6 @@ Use in combination with the default hostname provider to override the base URL f
           OrganizationsEnabled enables Keycloak Organizations feature for this realm.
 When enabled, this realm can support Organization resources for multi-tenant scenarios,
 identity provider groupings, and domain-based user routing.<br/>
-          <br/>
-            <i>Default</i>: false<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6294,14 +6294,16 @@ Lockout permanently after temporary lockout - BruteForceProtected is true, Perma
         <td><b>displayHtmlName</b></td>
         <td>string</td>
         <td>
-          DisplayHTMLName name to render in the UI<br/>
+          DisplayHTMLName name to render in the UI.
+Set to an empty string to clear the value in Keycloak.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>displayName</b></td>
         <td>string</td>
         <td>
-          DisplayName is the display name of the realm.<br/>
+          DisplayName is the display name of the realm.
+Set to an empty string to clear the value in Keycloak.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6339,8 +6341,6 @@ Lockout permanently after temporary lockout - BruteForceProtected is true, Perma
           OrganizationsEnabled enables Keycloak Organizations feature for this realm.
 When enabled, this realm can support Organization resources for multi-tenant scenarios,
 identity provider groupings, and domain-based user routing.<br/>
-          <br/>
-            <i>Default</i>: false<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/internal/controller/clusterkeycloakrealm/chain/put_realm_settings_test.go
+++ b/internal/controller/clusterkeycloakrealm/chain/put_realm_settings_test.go
@@ -47,9 +47,9 @@ func TestPutRealmSettings_ServeRequest(t *testing.T) {
 				Spec: v1alpha1.ClusterKeycloakRealmSpec{
 					RealmName:            "test-realm",
 					FrontendURL:          "https://example.com",
-					DisplayHTMLName:      "<div>Test</div>",
-					DisplayName:          "Test Realm",
-					OrganizationsEnabled: true,
+					DisplayHTMLName:      ptr.To("<div>Test</div>"),
+					DisplayName:          ptr.To("Test Realm"),
+					OrganizationsEnabled: ptr.To(true),
 					RealmEventConfig: &common.RealmEventConfig{
 						AdminEventsDetailsEnabled: ptr.To(true),
 						AdminEventsEnabled:        ptr.To(true),

--- a/internal/controller/clusterkeycloakrealm/clusterkeycloakrealm_controller_integration_test.go
+++ b/internal/controller/clusterkeycloakrealm/clusterkeycloakrealm_controller_integration_test.go
@@ -42,8 +42,8 @@ var _ = Describe("ClusterKeycloakRealm controller", func() {
 					ActionTokenGeneratedByUserLifespan:  234,
 					ActionTokenGeneratedByAdminLifespan: 235,
 				},
-				DisplayName:     "Test Realm",
-				DisplayHTMLName: "<b>Test Realm</b>",
+				DisplayName:     ptr.To("Test Realm"),
+				DisplayHTMLName: ptr.To("<b>Test Realm</b>"),
 				RealmEventConfig: &common.RealmEventConfig{
 					AdminEventsEnabled:    ptr.To(true),
 					AdminEventsExpiration: 100,

--- a/internal/controller/keycloakorganization/suite_test.go
+++ b/internal/controller/keycloakorganization/suite_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -166,7 +167,7 @@ var _ = BeforeSuite(func() {
 				Kind: keycloakApi.KeycloakKind,
 				Name: keycloak.Name,
 			},
-			OrganizationsEnabled: true,
+			OrganizationsEnabled: ptr.To(true),
 		},
 	}
 	Expect(k8sClient.Create(ctx, keycloakRealm)).Should(Succeed())

--- a/internal/controller/keycloakrealm/chain/realm_settings_test.go
+++ b/internal/controller/keycloakrealm/chain/realm_settings_test.go
@@ -51,7 +51,7 @@ func TestRealmSettings_ServeRequest(t *testing.T) {
 					PasswordPolicies: []common.PasswordPolicy{
 						{Type: "foo", Value: "bar"},
 					},
-					DisplayHTMLName: "<div class=\"kc-logo-text\"><span>Example</span></div>",
+					DisplayHTMLName: ptr.To("<div class=\"kc-logo-text\"><span>Example</span></div>"),
 					FrontendURL:     "http://example.com",
 				},
 			},

--- a/internal/controller/keycloakrealm/keycloakrealm_controller_integration_test.go
+++ b/internal/controller/keycloakrealm/keycloakrealm_controller_integration_test.go
@@ -78,8 +78,8 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 					ActionTokenGeneratedByUserLifespan:  234,
 					ActionTokenGeneratedByAdminLifespan: 235,
 				},
-				DisplayName:     "Test Realm",
-				DisplayHTMLName: "<b>Test Realm</b>",
+				DisplayName:     ptr.To("Test Realm"),
+				DisplayHTMLName: ptr.To("<b>Test Realm</b>"),
 				UserProfileConfig: &common.UserProfileConfig{
 					Attributes: []common.UserProfileAttribute{
 						{

--- a/internal/controller/keycloakrealm/keycloakrealm_external_settings_integration_test.go
+++ b/internal/controller/keycloakrealm/keycloakrealm_external_settings_integration_test.go
@@ -1,0 +1,96 @@
+package keycloakrealm
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/epam/edp-keycloak-operator/api/common"
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+)
+
+var _ = Describe("KeycloakRealm externally-managed settings", Ordered, func() {
+	const (
+		crName    = "test-keycloak-realm-external"
+		realmName = "test-realm-external-managed"
+	)
+
+	It("Should preserve externally-set realm settings not defined in the CR", func() {
+		By("Creating a minimal KeycloakRealm without display name or organizations settings")
+		keycloakRealm := &keycloakApi.KeycloakRealm{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      crName,
+				Namespace: ns,
+			},
+			Spec: keycloakApi.KeycloakRealmSpec{
+				RealmName: realmName,
+				KeycloakRef: common.KeycloakRef{
+					Name: keycloakCR,
+					Kind: keycloakApi.KeycloakKind,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, keycloakRealm)).Should(Succeed())
+
+		Eventually(func() bool {
+			createdRealm := &keycloakApi.KeycloakRealm{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, createdRealm)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			if !createdRealm.Status.Available {
+				GinkgoWriter.Println("KeycloakRealm status error: ", createdRealm.Status.Value)
+			}
+
+			return createdRealm.Status.Available
+		}, time.Minute, time.Second*5).Should(BeTrue())
+
+		By("Setting display name and organizations flag directly in Keycloak (external tooling)")
+		realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmName)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		realm.DisplayName = ptr.To("Externally Set")
+		realm.DisplayNameHtml = ptr.To("<b>Externally Set</b>")
+		realm.OrganizationsEnabled = ptr.To(true)
+		_, err = keycloakApiClient.Realms.UpdateRealm(ctx, realmName, *realm)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		By("Triggering reconciliation via an unrelated spec change")
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, keycloakRealm)).Should(Succeed())
+		keycloakRealm.Spec.FrontendURL = "https://external-trigger.example.com"
+		Expect(k8sClient.Update(ctx, keycloakRealm)).Should(Succeed())
+
+		By("Verifying externally-set settings survive reconciliation")
+		Eventually(func(g Gomega) {
+			updatedRealm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmName)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(updatedRealm).ShouldNot(BeNil())
+
+			// Proves the reconcile loop processed the spec change.
+			g.Expect(updatedRealm.Attributes).ShouldNot(BeNil())
+			g.Expect((*updatedRealm.Attributes)["frontendUrl"]).Should(Equal("https://external-trigger.example.com"))
+
+			// Fields absent from the CR must keep their externally-set values.
+			g.Expect(updatedRealm.DisplayName).Should(Equal(ptr.To("Externally Set")))
+			g.Expect(updatedRealm.DisplayNameHtml).Should(Equal(ptr.To("<b>Externally Set</b>")))
+			g.Expect(updatedRealm.OrganizationsEnabled).Should(Equal(ptr.To(true)))
+		}, time.Second*30, time.Second).Should(Succeed())
+	})
+
+	It("Should clean up the externally-managed test realm", func() {
+		keycloakRealm := &keycloakApi.KeycloakRealm{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, keycloakRealm)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, keycloakRealm)).Should(Succeed())
+		Eventually(func() bool {
+			deletedRealm := &keycloakApi.KeycloakRealm{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, deletedRealm)
+
+			return k8sErrors.IsNotFound(err)
+		}, timeout, interval).Should(BeTrue(), "KeycloakRealm should be deleted")
+	})
+})

--- a/pkg/realmbuilder/settings_builder.go
+++ b/pkg/realmbuilder/settings_builder.go
@@ -18,9 +18,9 @@ import (
 // commonRealmSpec holds the normalized, API-version-agnostic fields shared by
 // KeycloakRealmSpec and ClusterKeycloakRealmSpec.
 type commonRealmSpec struct {
-	DisplayName                 string
-	DisplayHTMLName             string
-	OrganizationsEnabled        bool
+	DisplayName                 *string
+	DisplayHTMLName             *string
+	OrganizationsEnabled        *bool
 	FrontendURL                 string
 	BrowserSecurityHeaders      *map[string]string
 	PasswordPolicy              string // pre-formatted "type(value) and …" string, empty if none
@@ -227,9 +227,9 @@ func buildPasswordPolicy(policies []common.PasswordPolicy) string {
 // normalized common spec. All version-specific field mapping is done by the callers.
 func buildRealmRepresentationFromCommon(spec commonRealmSpec) keycloakapi.RealmRepresentation {
 	rep := keycloakapi.RealmRepresentation{
-		DisplayName:                 ptr.To(spec.DisplayName),
-		DisplayNameHtml:             ptr.To(spec.DisplayHTMLName),
-		OrganizationsEnabled:        ptr.To(spec.OrganizationsEnabled),
+		DisplayName:                 spec.DisplayName,
+		DisplayNameHtml:             spec.DisplayHTMLName,
+		OrganizationsEnabled:        spec.OrganizationsEnabled,
 		LoginTheme:                  spec.LoginTheme,
 		AccountTheme:                spec.AccountTheme,
 		AdminTheme:                  spec.AdminTheme,

--- a/pkg/realmbuilder/settings_builder_test.go
+++ b/pkg/realmbuilder/settings_builder_test.go
@@ -29,17 +29,45 @@ func TestBuildRealmRepresentationFromV1(t *testing.T) {
 			name: "minimal configuration",
 			realm: &keycloakApi.KeycloakRealm{
 				Spec: keycloakApi.KeycloakRealmSpec{
-					DisplayName:     "Test Realm",
-					DisplayHTMLName: "<b>Test</b>",
+					DisplayName:     ptr.To("Test Realm"),
+					DisplayHTMLName: ptr.To("<b>Test</b>"),
 				},
 			},
 			check: func(t *testing.T, got keycloakapi.RealmRepresentation) {
 				t.Helper()
 				assert.Equal(t, ptr.To("Test Realm"), got.DisplayName)
 				assert.Equal(t, ptr.To("<b>Test</b>"), got.DisplayNameHtml)
-				assert.Equal(t, ptr.To(false), got.OrganizationsEnabled)
+				assert.Nil(t, got.OrganizationsEnabled)
 				assert.Nil(t, got.LoginTheme)
 				assert.Nil(t, got.Attributes)
+			},
+		},
+		{
+			name: "unset display fields stay nil to preserve live Keycloak values",
+			realm: &keycloakApi.KeycloakRealm{
+				Spec: keycloakApi.KeycloakRealmSpec{RealmName: "test"},
+			},
+			check: func(t *testing.T, got keycloakapi.RealmRepresentation) {
+				t.Helper()
+				assert.Nil(t, got.DisplayName)
+				assert.Nil(t, got.DisplayNameHtml)
+				assert.Nil(t, got.OrganizationsEnabled)
+			},
+		},
+		{
+			name: "empty display values explicitly clear the fields",
+			realm: &keycloakApi.KeycloakRealm{
+				Spec: keycloakApi.KeycloakRealmSpec{
+					DisplayName:          ptr.To(""),
+					DisplayHTMLName:      ptr.To(""),
+					OrganizationsEnabled: ptr.To(false),
+				},
+			},
+			check: func(t *testing.T, got keycloakapi.RealmRepresentation) {
+				t.Helper()
+				assert.Equal(t, ptr.To(""), got.DisplayName)
+				assert.Equal(t, ptr.To(""), got.DisplayNameHtml)
+				assert.Equal(t, ptr.To(false), got.OrganizationsEnabled)
 			},
 		},
 		{
@@ -341,15 +369,27 @@ func TestBuildRealmRepresentationFromV1Alpha1(t *testing.T) {
 			name: "minimal configuration",
 			realm: &v1alpha1.ClusterKeycloakRealm{
 				Spec: v1alpha1.ClusterKeycloakRealmSpec{
-					DisplayName:     "Test Realm",
-					DisplayHTMLName: "<b>Test</b>",
+					DisplayName:     ptr.To("Test Realm"),
+					DisplayHTMLName: ptr.To("<b>Test</b>"),
 				},
 			},
 			check: func(t *testing.T, got keycloakapi.RealmRepresentation) {
 				t.Helper()
 				assert.Equal(t, ptr.To("Test Realm"), got.DisplayName)
 				assert.Equal(t, ptr.To("<b>Test</b>"), got.DisplayNameHtml)
-				assert.Equal(t, ptr.To(false), got.OrganizationsEnabled)
+				assert.Nil(t, got.OrganizationsEnabled)
+			},
+		},
+		{
+			name: "unset display fields stay nil to preserve live Keycloak values",
+			realm: &v1alpha1.ClusterKeycloakRealm{
+				Spec: v1alpha1.ClusterKeycloakRealmSpec{RealmName: "test"},
+			},
+			check: func(t *testing.T, got keycloakapi.RealmRepresentation) {
+				t.Helper()
+				assert.Nil(t, got.DisplayName)
+				assert.Nil(t, got.DisplayNameHtml)
+				assert.Nil(t, got.OrganizationsEnabled)
 			},
 		},
 		{
@@ -852,6 +892,26 @@ func TestApplyRealmSettings(t *testing.T) {
 					Return(&keycloakapi.RealmRepresentation{}, nil, nil)
 				m.EXPECT().UpdateRealm(mock.Anything, "test-realm", mock.MatchedBy(func(rep keycloakapi.RealmRepresentation) bool {
 					return rep.DisplayName != nil && *rep.DisplayName == "My Realm"
+				})).Return(nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "unset fields in overlay preserve externally-set Keycloak values",
+			overlay: BuildRealmRepresentationFromV1(&keycloakApi.KeycloakRealm{
+				Spec: keycloakApi.KeycloakRealmSpec{RealmName: "test-realm"},
+			}),
+			setupMock: func(m *v2mocks.MockRealmClient) {
+				m.EXPECT().GetRealm(mock.Anything, "test-realm").
+					Return(&keycloakapi.RealmRepresentation{
+						DisplayName:          ptr.To("Externally Set"),
+						DisplayNameHtml:      ptr.To("<b>Externally Set</b>"),
+						OrganizationsEnabled: ptr.To(true),
+					}, nil, nil)
+				m.EXPECT().UpdateRealm(mock.Anything, "test-realm", mock.MatchedBy(func(rep keycloakapi.RealmRepresentation) bool {
+					return rep.DisplayName != nil && *rep.DisplayName == "Externally Set" &&
+						rep.DisplayNameHtml != nil && *rep.DisplayNameHtml == "<b>Externally Set</b>" &&
+						rep.OrganizationsEnabled != nil && *rep.OrganizationsEnabled
 				})).Return(nil, nil)
 			},
 			wantErr: require.NoError,


### PR DESCRIPTION


The operator unconditionally wrote displayName, displayNameHtml and organizationsEnabled on every realm reconcile, clearing values managed by external tooling when the CR omitted them. Convert the three fields to pointer types so nil means "not managed by the CR" and the existing merge machinery preserves the live Keycloak value; an explicit empty string still clears, and explicit false still disables.

- drop the organizationsEnabled schema default so omitting the field no longer persists an explicit false into new and edited CRs
- add regression coverage: builder/merge unit tests plus an integration test asserting externally-set realm settings survive reconciliation of a minimal CR

Upgrade notes: CRs created under the old CRD carry a persisted organizationsEnabled: false injected by the removed default and keep managing that flag until the field is removed from the spec. Helm applies the crds/ directory on install only, so upgrades must apply the updated CRDs manually for the schema changes to take effect.

