### PR TITLE
fix(realm): preserve externally-set adminEventsExpiration when CR omits it

### DIFF
--- a/api/common/realm.go
+++ b/api/common/realm.go
@@ -308,8 +308,9 @@ type RealmEventConfig struct {
 
 	// AdminEventsExpiration sets the expiration for events in seconds.
 	// Expired events are periodically deleted from the database.
+	// +nullable
 	// +optional
-	AdminEventsExpiration int `json:"adminEventsExpiration,omitempty"`
+	AdminEventsExpiration *int `json:"adminEventsExpiration,omitempty"`
 
 	// EnabledEventTypes is a list of event types to enable.
 	// +optional

--- a/api/common/zz_generated.deepcopy.go
+++ b/api/common/zz_generated.deepcopy.go
@@ -251,6 +251,11 @@ func (in *RealmEventConfig) DeepCopyInto(out *RealmEventConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AdminEventsExpiration != nil {
+		in, out := &in.AdminEventsExpiration, &out.AdminEventsExpiration
+		*out = new(int)
+		**out = **in
+	}
 	if in.EnabledEventTypes != nil {
 		in, out := &in.EnabledEventTypes, &out.EnabledEventTypes
 		*out = make([]string, len(*in))

--- a/config/crd/bases/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/config/crd/bases/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -277,6 +277,7 @@ spec:
                     description: |-
                       AdminEventsExpiration sets the expiration for events in seconds.
                       Expired events are periodically deleted from the database.
+                    nullable: true
                     type: integer
                   enabledEventTypes:
                     description: EnabledEventTypes is a list of event types to enable.

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
@@ -291,6 +291,7 @@ spec:
                     description: |-
                       AdminEventsExpiration sets the expiration for events in seconds.
                       Expired events are periodically deleted from the database.
+                    nullable: true
                     type: integer
                   enabledEventTypes:
                     description: EnabledEventTypes is a list of event types to enable.

--- a/deploy-templates/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -277,6 +277,7 @@ spec:
                     description: |-
                       AdminEventsExpiration sets the expiration for events in seconds.
                       Expired events are periodically deleted from the database.
+                    nullable: true
                     type: integer
                   enabledEventTypes:
                     description: EnabledEventTypes is a list of event types to enable.

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
@@ -291,6 +291,7 @@ spec:
                     description: |-
                       AdminEventsExpiration sets the expiration for events in seconds.
                       Expired events are periodically deleted from the database.
+                    nullable: true
                     type: integer
                   enabledEventTypes:
                     description: EnabledEventTypes is a list of event types to enable.

--- a/internal/controller/clusterkeycloakrealm/chain/put_realm_settings_test.go
+++ b/internal/controller/clusterkeycloakrealm/chain/put_realm_settings_test.go
@@ -53,7 +53,7 @@ func TestPutRealmSettings_ServeRequest(t *testing.T) {
 					RealmEventConfig: &common.RealmEventConfig{
 						AdminEventsDetailsEnabled: ptr.To(true),
 						AdminEventsEnabled:        ptr.To(true),
-						AdminEventsExpiration:     3600,
+						AdminEventsExpiration:     ptr.To(3600),
 						EnabledEventTypes:         []string{"LOGIN", "LOGOUT"},
 						EventsEnabled:             ptr.To(true),
 						EventsExpiration:          ptr.To(7200),

--- a/internal/controller/clusterkeycloakrealm/clusterkeycloakrealm_controller_integration_test.go
+++ b/internal/controller/clusterkeycloakrealm/clusterkeycloakrealm_controller_integration_test.go
@@ -46,7 +46,7 @@ var _ = Describe("ClusterKeycloakRealm controller", func() {
 				DisplayHTMLName: ptr.To("<b>Test Realm</b>"),
 				RealmEventConfig: &common.RealmEventConfig{
 					AdminEventsEnabled:    ptr.To(true),
-					AdminEventsExpiration: 100,
+					AdminEventsExpiration: ptr.To(100),
 				},
 			},
 		}

--- a/internal/controller/keycloakrealm/chain/realm_settings_test.go
+++ b/internal/controller/keycloakrealm/chain/realm_settings_test.go
@@ -72,7 +72,7 @@ func TestRealmSettings_ServeRequest(t *testing.T) {
 					RealmEventConfig: &common.RealmEventConfig{
 						EventsListeners:       []string{"foo", "bar"},
 						AdminEventsEnabled:    ptr.To(true),
-						AdminEventsExpiration: 100,
+						AdminEventsExpiration: ptr.To(100),
 					},
 				},
 			},

--- a/internal/controller/keycloakrealm/keycloakrealm_controller_integration_test.go
+++ b/internal/controller/keycloakrealm/keycloakrealm_controller_integration_test.go
@@ -54,7 +54,7 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 					EventsEnabled:             ptr.To(true),
 					EventsExpiration:          ptr.To(15000),
 					EventsListeners:           []string{"jboss-logging", "email"},
-					AdminEventsExpiration:     100,
+					AdminEventsExpiration:     ptr.To(100),
 				},
 				PasswordPolicies: []common.PasswordPolicy{
 					{

--- a/internal/controller/keycloakrealm/keycloakrealm_external_settings_integration_test.go
+++ b/internal/controller/keycloakrealm/keycloakrealm_external_settings_integration_test.go
@@ -15,6 +15,84 @@ import (
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 )
 
+var _ = Describe("KeycloakRealm admin events expiration", Ordered, func() {
+	const (
+		crName    = "test-keycloak-realm-admin-events"
+		realmName = "test-realm-admin-events"
+	)
+
+	It("Should preserve externally-set adminEventsExpiration when the CR omits it", func() {
+		By("Creating a KeycloakRealm without realmEventConfig")
+		keycloakRealm := &keycloakApi.KeycloakRealm{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      crName,
+				Namespace: ns,
+			},
+			Spec: keycloakApi.KeycloakRealmSpec{
+				RealmName: realmName,
+				KeycloakRef: common.KeycloakRef{
+					Name: keycloakCR,
+					Kind: keycloakApi.KeycloakKind,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, keycloakRealm)).Should(Succeed())
+
+		Eventually(func() bool {
+			createdRealm := &keycloakApi.KeycloakRealm{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, createdRealm)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			return createdRealm.Status.Available
+		}, time.Minute, time.Second*5).Should(BeTrue())
+
+		By("Setting adminEventsExpiration directly in Keycloak (external tooling)")
+		realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmName)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		if realm.Attributes == nil {
+			realm.Attributes = &map[string]string{}
+		}
+
+		(*realm.Attributes)["adminEventsExpiration"] = "3600"
+		_, err = keycloakApiClient.Realms.UpdateRealm(ctx, realmName, *realm)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		By("Enabling admin events via the CR without setting adminEventsExpiration")
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, keycloakRealm)).Should(Succeed())
+		keycloakRealm.Spec.RealmEventConfig = &common.RealmEventConfig{
+			AdminEventsEnabled: ptr.To(true),
+		}
+		Expect(k8sClient.Update(ctx, keycloakRealm)).Should(Succeed())
+
+		By("Verifying the externally-set expiration survives reconciliation")
+		Eventually(func(g Gomega) {
+			eventsConfig, _, err := keycloakApiClient.Events.GetEventsConfig(ctx, realmName)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			// Proves the reconcile loop applied the managed part of the config.
+			g.Expect(eventsConfig.AdminEventsEnabled).Should(Equal(ptr.To(true)))
+
+			updatedRealm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmName)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(updatedRealm.Attributes).ShouldNot(BeNil())
+			g.Expect((*updatedRealm.Attributes)["adminEventsExpiration"]).Should(Equal("3600"))
+		}, time.Second*30, time.Second).Should(Succeed())
+	})
+
+	It("Should clean up the admin events test realm", func() {
+		keycloakRealm := &keycloakApi.KeycloakRealm{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, keycloakRealm)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, keycloakRealm)).Should(Succeed())
+		Eventually(func() bool {
+			deletedRealm := &keycloakApi.KeycloakRealm{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, deletedRealm)
+
+			return k8sErrors.IsNotFound(err)
+		}, timeout, interval).Should(BeTrue(), "KeycloakRealm should be deleted")
+	})
+})
+
 var _ = Describe("KeycloakRealm externally-managed settings", Ordered, func() {
 	const (
 		crName    = "test-keycloak-realm-external"

--- a/pkg/realmbuilder/settings_builder.go
+++ b/pkg/realmbuilder/settings_builder.go
@@ -272,13 +272,14 @@ func buildRealmRepresentationFromCommon(spec commonRealmSpec) keycloakapi.RealmR
 	}
 
 	eventCfg := spec.RealmEventConfig
-	if eventCfg != nil && eventCfg.AdminEventsEnabled != nil && *eventCfg.AdminEventsEnabled {
+	if eventCfg != nil && eventCfg.AdminEventsEnabled != nil && *eventCfg.AdminEventsEnabled &&
+		eventCfg.AdminEventsExpiration != nil {
 		if rep.Attributes == nil {
 			attrs := make(map[string]string)
 			rep.Attributes = &attrs
 		}
 
-		(*rep.Attributes)["adminEventsExpiration"] = strconv.Itoa(eventCfg.AdminEventsExpiration)
+		(*rep.Attributes)["adminEventsExpiration"] = strconv.Itoa(*eventCfg.AdminEventsExpiration)
 	}
 
 	if l := spec.Login; l != nil {

--- a/pkg/realmbuilder/settings_builder_test.go
+++ b/pkg/realmbuilder/settings_builder_test.go
@@ -166,7 +166,7 @@ func TestBuildRealmRepresentationFromV1(t *testing.T) {
 				Spec: keycloakApi.KeycloakRealmSpec{
 					RealmEventConfig: &common.RealmEventConfig{
 						AdminEventsEnabled:    ptr.To(true),
-						AdminEventsExpiration: 3600,
+						AdminEventsExpiration: ptr.To(3600),
 					},
 				},
 			},
@@ -177,12 +177,28 @@ func TestBuildRealmRepresentationFromV1(t *testing.T) {
 			},
 		},
 		{
+			name: "unset admin events expiration is not written when admin events enabled",
+			realm: &keycloakApi.KeycloakRealm{
+				Spec: keycloakApi.KeycloakRealmSpec{
+					RealmEventConfig: &common.RealmEventConfig{
+						AdminEventsEnabled: ptr.To(true),
+					},
+				},
+			},
+			check: func(t *testing.T, got keycloakapi.RealmRepresentation) {
+				t.Helper()
+				if got.Attributes != nil {
+					assert.NotContains(t, *got.Attributes, "adminEventsExpiration")
+				}
+			},
+		},
+		{
 			name: "admin events expiration not set when admin events disabled",
 			realm: &keycloakApi.KeycloakRealm{
 				Spec: keycloakApi.KeycloakRealmSpec{
 					RealmEventConfig: &common.RealmEventConfig{
 						AdminEventsEnabled:    ptr.To(false),
-						AdminEventsExpiration: 3600,
+						AdminEventsExpiration: ptr.To(3600),
 					},
 				},
 			},
@@ -198,7 +214,7 @@ func TestBuildRealmRepresentationFromV1(t *testing.T) {
 			realm: &keycloakApi.KeycloakRealm{
 				Spec: keycloakApi.KeycloakRealmSpec{
 					RealmEventConfig: &common.RealmEventConfig{
-						AdminEventsExpiration: 3600,
+						AdminEventsExpiration: ptr.To(3600),
 					},
 				},
 			},
@@ -491,7 +507,7 @@ func TestBuildRealmRepresentationFromV1Alpha1(t *testing.T) {
 				Spec: v1alpha1.ClusterKeycloakRealmSpec{
 					RealmEventConfig: &common.RealmEventConfig{
 						AdminEventsEnabled:    ptr.To(true),
-						AdminEventsExpiration: 7200,
+						AdminEventsExpiration: ptr.To(7200),
 					},
 				},
 			},


### PR DESCRIPTION


Enabling admin events via realmEventConfig without setting adminEventsExpiration wrote "0" into the realm attribute on every reconcile, overwriting an expiration configured by external tooling. Change the field to *int so nil means "not managed by the CR" and the attribute key is only written when the value is explicitly set, completing the RealmEventConfig pointer conversion started for the other fields.

Add regression coverage: a builder unit test for the unset case and an integration test asserting an externally-set expiration survives reconciliation when the CR enables admin events without it.
