### PR TITLE
fix: preserve spec zero values when updating finalizers

### DIFF
--- a/internal/controller/helper/controller_helper.go
+++ b/internal/controller/helper/controller_helper.go
@@ -113,11 +113,13 @@ func (h *Helper) SetKeycloakOwnerRef(ctx context.Context, object ObjectWithKeycl
 			return fmt.Errorf("failed to get Keycloak: %w", err)
 		}
 
+		original := deepCopyObject(object)
+
 		if err := controllerutil.SetControllerReference(kc, object, h.scheme); err != nil {
 			return fmt.Errorf("failed to set controller reference for %s: %w", object.GetName(), err)
 		}
 
-		if err := h.client.Update(ctx, object); err != nil {
+		if err := PatchObject(ctx, h.client, original, object); err != nil {
 			return fmt.Errorf("failed to update keycloak owner reference %s: %w", kc.GetName(), err)
 		}
 
@@ -131,11 +133,13 @@ func (h *Helper) SetKeycloakOwnerRef(ctx context.Context, object ObjectWithKeycl
 			return fmt.Errorf("failed to get ClusterKeycloak: %w", err)
 		}
 
+		original := deepCopyObject(object)
+
 		if err := controllerutil.SetControllerReference(clusterKc, object, h.scheme); err != nil {
 			return fmt.Errorf("failed to set controller reference for %s: %w", object.GetName(), err)
 		}
 
-		if err := h.client.Update(ctx, object); err != nil {
+		if err := PatchObject(ctx, h.client, original, object); err != nil {
 			return fmt.Errorf("failed to update keycloak owner reference %s: %w", clusterKc.GetName(), err)
 		}
 
@@ -171,11 +175,13 @@ func (h *Helper) SetRealmOwnerRef(ctx context.Context, object ObjectWithRealmRef
 			return fmt.Errorf("failed to get KeycloakRealm: %w", err)
 		}
 
+		original := deepCopyObject(object)
+
 		if err := controllerutil.SetControllerReference(realm, object, h.scheme); err != nil {
 			return fmt.Errorf("failed to set controller reference for %s: %w", object.GetName(), err)
 		}
 
-		if err := h.client.Update(ctx, object); err != nil {
+		if err := PatchObject(ctx, h.client, original, object); err != nil {
 			return fmt.Errorf("failed to update realm owner reference %s: %w", realm.GetName(), err)
 		}
 
@@ -189,11 +195,13 @@ func (h *Helper) SetRealmOwnerRef(ctx context.Context, object ObjectWithRealmRef
 			return fmt.Errorf("failed to get ClusterKeycloakRealm: %w", err)
 		}
 
+		original := deepCopyObject(object)
+
 		if err := controllerutil.SetControllerReference(clusterRealm, object, h.scheme); err != nil {
 			return fmt.Errorf("unable to set controller reference for %s: %w", object.GetName(), err)
 		}
 
-		if err := h.client.Update(ctx, object); err != nil {
+		if err := PatchObject(ctx, h.client, original, object); err != nil {
 			return fmt.Errorf("failed to update realm owner reference %s: %w", clusterRealm.GetName(), err)
 		}
 
@@ -206,8 +214,9 @@ func (h *Helper) SetRealmOwnerRef(ctx context.Context, object ObjectWithRealmRef
 
 func (h *Helper) TryRemoveFinalizer(ctx context.Context, obj client.Object, finalizer string) error {
 	if !obj.GetDeletionTimestamp().IsZero() {
+		original := deepCopyObject(obj)
 		if controllerutil.RemoveFinalizer(obj, finalizer) {
-			if err := h.client.Update(ctx, obj); err != nil {
+			if err := PatchObject(ctx, h.client, original, obj); err != nil {
 				return fmt.Errorf("unable to update instance: %w", err)
 			}
 		}
@@ -223,13 +232,15 @@ func RemoveFinalizersOnRealmNotFound(ctx context.Context, k8sClient client.Clien
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Keycloak realm not found, removing finalizers")
 
+	original := deepCopyObject(obj)
+
 	removed := false
 	for _, f := range finalizers {
 		removed = controllerutil.RemoveFinalizer(obj, f) || removed
 	}
 
 	if removed {
-		if err := k8sClient.Update(ctx, obj); err != nil {
+		if err := PatchObject(ctx, k8sClient, original, obj); err != nil {
 			return false, fmt.Errorf("failed to remove finalizers: %w", err)
 		}
 	}
@@ -245,10 +256,12 @@ func (h *Helper) TryToDelete(ctx context.Context, obj client.Object, terminator 
 	if obj.GetDeletionTimestamp().IsZero() {
 		logger.Info("instance timestamp is zero")
 
+		original := deepCopyObject(obj)
+
 		if controllerutil.AddFinalizer(obj, finalizer) {
 			logger.Info("Adding finalizer to instance")
 
-			if err := h.client.Update(ctx, obj); err != nil {
+			if err := PatchObject(ctx, h.client, original, obj); err != nil {
 				return false, fmt.Errorf("unable to update deletable object: %w", err)
 			}
 		}
@@ -266,8 +279,9 @@ func (h *Helper) TryToDelete(ctx context.Context, obj client.Object, terminator 
 
 	logger.Info("terminator removing finalizers")
 
+	original := deepCopyObject(obj)
 	if controllerutil.RemoveFinalizer(obj, finalizer) {
-		if err := h.client.Update(ctx, obj); err != nil {
+		if err := PatchObject(ctx, h.client, original, obj); err != nil {
 			return false, fmt.Errorf("unable to update instance: %w", err)
 		}
 	}
@@ -306,4 +320,26 @@ func (h *Helper) GetRealmNameFromRef(ctx context.Context, object ObjectWithRealm
 	default:
 		return "", fmt.Errorf("unknown realm kind: %s", kind)
 	}
+}
+
+// PatchObject persists obj using a merge patch against original.
+// Use this instead of Update when only metadata (finalizers, owner refs) changed,
+// so omitempty zero values in spec are not dropped from the live object.
+// MergeFromWithOptimisticLock includes resourceVersion so concurrent writers get a 409,
+// as Update would, instead of silently replacing the whole finalizers list.
+func PatchObject(ctx context.Context, c client.Client, original, obj client.Object) error {
+	if err := c.Patch(ctx, obj, client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{})); err != nil {
+		return fmt.Errorf("unable to patch object: %w", err)
+	}
+
+	return nil
+}
+
+func deepCopyObject(obj client.Object) client.Object {
+	copied, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return obj
+	}
+
+	return copied
 }

--- a/internal/controller/helper/controller_helper_test.go
+++ b/internal/controller/helper/controller_helper_test.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
@@ -593,10 +595,10 @@ func TestRemoveFinalizersOnRealmNotFound(t *testing.T) {
 			want:       func(t *testing.T, k8sCl client.Client) {},
 		},
 		{
-			name: "update fails — returns error",
+			name: "patch fails — returns error",
 			client: func(t *testing.T) client.Client {
 				mc := &K8SClientMock{}
-				mc.On("Update", testifymock.Anything, testifymock.Anything).Return(errors.New("update failed"))
+				mc.On("Patch", testifymock.Anything, testifymock.Anything, testifymock.Anything).Return(errors.New("patch failed"))
 
 				return mc
 			},
@@ -628,6 +630,118 @@ func TestRemoveFinalizersOnRealmNotFound(t *testing.T) {
 			tt.want(t, k8sCl)
 		})
 	}
+}
+
+func TestMergePatchPreservesZeroValuedSpecFields(t *testing.T) {
+	t.Run("KeycloakRealmRole", func(t *testing.T) {
+		role := &keycloakApi.KeycloakRealmRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test-role",
+				Namespace:       "test",
+				ResourceVersion: "1",
+			},
+			Spec: keycloakApi.KeycloakRealmRoleSpec{
+				Name:        "test-role",
+				Description: "",
+				Attributes:  map[string][]string{},
+				Composite:   false,
+			},
+		}
+
+		original := role.DeepCopy()
+		require.True(t, controllerutil.AddFinalizer(role, common.FinalizerName))
+
+		data, err := client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{}).Data(role)
+		require.NoError(t, err)
+
+		var patch map[string]any
+
+		require.NoError(t, json.Unmarshal(data, &patch))
+		_, hasSpec := patch["spec"]
+		assert.False(t, hasSpec, "merge patch must not rewrite spec when only finalizers change")
+
+		metadata, ok := patch["metadata"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "1", metadata["resourceVersion"])
+	})
+
+	t.Run("KeycloakAuthFlow", func(t *testing.T) {
+		flow := &keycloakApi.KeycloakAuthFlow{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test-flow",
+				Namespace:       "test",
+				ResourceVersion: "1",
+			},
+			Spec: keycloakApi.KeycloakAuthFlowSpec{
+				Alias:       "test-flow",
+				Description: "",
+				AuthenticationExecutions: []keycloakApi.AuthenticationExecution{
+					{
+						Authenticator:     "auth-cookie",
+						AuthenticatorFlow: false,
+						Priority:          0,
+					},
+				},
+			},
+		}
+
+		original := flow.DeepCopy()
+		require.True(t, controllerutil.AddFinalizer(flow, common.FinalizerName))
+
+		data, err := client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{}).Data(flow)
+		require.NoError(t, err)
+
+		var patch map[string]any
+
+		require.NoError(t, json.Unmarshal(data, &patch))
+		_, hasSpec := patch["spec"]
+		assert.False(t, hasSpec, "merge patch must not rewrite spec when only finalizers change")
+
+		metadata, ok := patch["metadata"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "1", metadata["resourceVersion"])
+	})
+}
+
+func TestTryToDelete_preservesZeroValuedSpecFields(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, keycloakApi.AddToScheme(scheme))
+
+	role := &keycloakApi.KeycloakRealmRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-role",
+			Namespace: "test",
+		},
+		Spec: keycloakApi.KeycloakRealmRoleSpec{
+			Name:        "test-role",
+			Description: "",
+			Attributes:  map[string][]string{},
+			Composite:   false,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(role).Build()
+	h := Helper{client: fakeClient}
+
+	stored := &keycloakApi.KeycloakRealmRole{}
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name:      "test-role",
+		Namespace: "test",
+	}, stored))
+
+	deleted, err := h.TryToDelete(context.Background(), stored, &testTerminator{log: logr.Discard()}, common.FinalizerName)
+	require.NoError(t, err)
+	assert.False(t, deleted)
+
+	got := &keycloakApi.KeycloakRealmRole{}
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name:      "test-role",
+		Namespace: "test",
+	}, got))
+	assert.Contains(t, got.Finalizers, common.FinalizerName)
+	assert.Empty(t, got.Spec.Description)
+	assert.Empty(t, got.Spec.Attributes)
+	assert.False(t, got.Spec.Composite)
 }
 
 func TestHelper_SetKeycloakOwnerRef(t *testing.T) {

--- a/internal/controller/keycloakauthflow/keycloakauthflow_controller.go
+++ b/internal/controller/keycloakauthflow/keycloakauthflow_controller.go
@@ -129,10 +129,11 @@ func (r *Reconcile) handleDeletion(ctx context.Context, instance *keycloakApi.Ke
 			return ctrl.Result{}, fmt.Errorf("failed to remove auth flow: %w", err)
 		}
 
+		original := instance.DeepCopy()
 		controllerutil.RemoveFinalizer(instance, common.FinalizerName)
 		controllerutil.RemoveFinalizer(instance, legacyFinalizerName)
 
-		if err := r.client.Update(ctx, instance); err != nil {
+		if err := helper.PatchObject(ctx, r.client, original, instance); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update KeycloakAuthFlow after finalizer removal: %w", err)
 		}
 	}
@@ -143,8 +144,9 @@ func (r *Reconcile) handleDeletion(ctx context.Context, instance *keycloakApi.Ke
 func (r *Reconcile) handleReconciliation(ctx context.Context, instance *keycloakApi.KeycloakAuthFlow, kClient *keycloakapi.KeycloakClient, realmName string) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
+	original := instance.DeepCopy()
 	if controllerutil.AddFinalizer(instance, common.FinalizerName) {
-		if err := r.client.Update(ctx, instance); err != nil {
+		if err := helper.PatchObject(ctx, r.client, original, instance); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer to KeycloakAuthFlow: %w", err)
 		}
 	}

--- a/internal/controller/keycloakclient/keycloakclient_controller.go
+++ b/internal/controller/keycloakclient/keycloakclient_controller.go
@@ -131,9 +131,10 @@ func (r *ReconcileKeycloakClient) handleDeletion(ctx context.Context, instance *
 			return ctrl.Result{}, fmt.Errorf("failed to remove keycloak client: %w", err)
 		}
 
+		original := instance.DeepCopy()
 		controllerutil.RemoveFinalizer(instance, keyCloakClientOperatorFinalizerName)
 
-		if err := r.client.Update(ctx, instance); err != nil {
+		if err := helper.PatchObject(ctx, r.client, original, instance); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update keycloak client after finalizer removal: %w", err)
 		}
 	}
@@ -144,8 +145,9 @@ func (r *ReconcileKeycloakClient) handleDeletion(ctx context.Context, instance *
 func (r *ReconcileKeycloakClient) handleReconciliation(ctx context.Context, instance *keycloakApi.KeycloakClient, kClient *keycloakapi.KeycloakClient, realmName string) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
+	original := instance.DeepCopy()
 	if controllerutil.AddFinalizer(instance, keyCloakClientOperatorFinalizerName) {
-		if err := r.client.Update(ctx, instance); err != nil {
+		if err := helper.PatchObject(ctx, r.client, original, instance); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer to keycloak client: %w", err)
 		}
 	}

--- a/internal/controller/keycloakclientscope/keycloakclientscope_controller.go
+++ b/internal/controller/keycloakclientscope/keycloakclientscope_controller.go
@@ -129,10 +129,11 @@ func (r *Reconcile) handleDeletion(ctx context.Context, instance *keycloakApi.Ke
 			return ctrl.Result{}, fmt.Errorf("failed to remove client scope: %w", err)
 		}
 
+		original := instance.DeepCopy()
 		controllerutil.RemoveFinalizer(instance, common.FinalizerName)
 		controllerutil.RemoveFinalizer(instance, legacyFinalizerName)
 
-		if err := r.client.Update(ctx, instance); err != nil {
+		if err := helper.PatchObject(ctx, r.client, original, instance); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update KeycloakClientScope after finalizer removal: %w", err)
 		}
 	}
@@ -143,8 +144,9 @@ func (r *Reconcile) handleDeletion(ctx context.Context, instance *keycloakApi.Ke
 func (r *Reconcile) handleReconciliation(ctx context.Context, instance *keycloakApi.KeycloakClientScope, kClient *keycloakapi.KeycloakClient, realmName string) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
+	original := instance.DeepCopy()
 	if controllerutil.AddFinalizer(instance, common.FinalizerName) {
-		if err := r.client.Update(ctx, instance); err != nil {
+		if err := helper.PatchObject(ctx, r.client, original, instance); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer to KeycloakClientScope: %w", err)
 		}
 	}

--- a/internal/controller/keycloakorganization/keycloakorganization_controller.go
+++ b/internal/controller/keycloakorganization/keycloakorganization_controller.go
@@ -100,8 +100,9 @@ func (r *ReconcileOrganization) initializeReconciliation(ctx context.Context, re
 			if organization.GetDeletionTimestamp() != nil {
 				log.Info("Keycloak realm not found, removing finalizer")
 
+				original := organization.DeepCopy()
 				if controllerutil.RemoveFinalizer(organization, common.FinalizerName) {
-					if updateErr := r.client.Update(ctx, organization); updateErr != nil {
+					if updateErr := helper.PatchObject(ctx, r.client, original, organization); updateErr != nil {
 						return nil, nil, "", fmt.Errorf("failed to remove finalizer: %w", updateErr)
 					}
 				}
@@ -129,9 +130,10 @@ func (r *ReconcileOrganization) handleDeletion(ctx context.Context, organization
 			return ctrl.Result{}, fmt.Errorf("failed to remove organization: %w", err)
 		}
 
+		original := organization.DeepCopy()
 		controllerutil.RemoveFinalizer(organization, common.FinalizerName)
 
-		if err := r.client.Update(ctx, organization); err != nil {
+		if err := helper.PatchObject(ctx, r.client, original, organization); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update organization after finalizer removal: %w", err)
 		}
 	}
@@ -142,8 +144,9 @@ func (r *ReconcileOrganization) handleDeletion(ctx context.Context, organization
 func (r *ReconcileOrganization) handleReconciliation(ctx context.Context, organization *keycloakApi.KeycloakOrganization, kClient *keycloakapi.KeycloakClient, realmName string) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
+	original := organization.DeepCopy()
 	if controllerutil.AddFinalizer(organization, common.FinalizerName) {
-		if err := r.client.Update(ctx, organization); err != nil {
+		if err := helper.PatchObject(ctx, r.client, original, organization); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer to organization: %w", err)
 		}
 	}

--- a/internal/controller/keycloakrealmcomponent/keycloakrealmcomponent_controller.go
+++ b/internal/controller/keycloakrealmcomponent/keycloakrealmcomponent_controller.go
@@ -158,10 +158,11 @@ func (r *RealmComponentReconciler) handleDeletion(
 			return ctrl.Result{}, fmt.Errorf("failed to remove realm component: %w", err)
 		}
 
+		original := instance.DeepCopy()
 		controllerutil.RemoveFinalizer(instance, common.FinalizerName)
 		controllerutil.RemoveFinalizer(instance, legacyFinalizerName)
 
-		if err := r.client.Update(ctx, instance); err != nil {
+		if err := helper.PatchObject(ctx, r.client, original, instance); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update KeycloakRealmComponent after finalizer removal: %w", err)
 		}
 	}
@@ -177,8 +178,9 @@ func (r *RealmComponentReconciler) handleReconciliation(
 ) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
+	original := instance.DeepCopy()
 	if controllerutil.AddFinalizer(instance, common.FinalizerName) {
-		if err := r.client.Update(ctx, instance); err != nil {
+		if err := helper.PatchObject(ctx, r.client, original, instance); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer to KeycloakRealmComponent: %w", err)
 		}
 	}

--- a/internal/controller/keycloakrealmidentityprovider/keycloakrealmidentityprovider_controller.go
+++ b/internal/controller/keycloakrealmidentityprovider/keycloakrealmidentityprovider_controller.go
@@ -127,10 +127,11 @@ func (r *IdentityProviderReconciler) handleDeletion(ctx context.Context, instanc
 			return ctrl.Result{}, fmt.Errorf("failed to remove identity provider: %w", err)
 		}
 
+		original := instance.DeepCopy()
 		controllerutil.RemoveFinalizer(instance, common.FinalizerName)
 		controllerutil.RemoveFinalizer(instance, legacyFinalizerName)
 
-		if err := r.client.Update(ctx, instance); err != nil {
+		if err := helper.PatchObject(ctx, r.client, original, instance); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update KeycloakRealmIdentityProvider after finalizer removal: %w", err)
 		}
 	}
@@ -141,8 +142,9 @@ func (r *IdentityProviderReconciler) handleDeletion(ctx context.Context, instanc
 func (r *IdentityProviderReconciler) handleReconciliation(ctx context.Context, instance *keycloakApi.KeycloakRealmIdentityProvider, kClient *keycloakapi.KeycloakClient, realmName string) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
+	original := instance.DeepCopy()
 	if controllerutil.AddFinalizer(instance, common.FinalizerName) {
-		if err := r.client.Update(ctx, instance); err != nil {
+		if err := helper.PatchObject(ctx, r.client, original, instance); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer to KeycloakRealmIdentityProvider: %w", err)
 		}
 	}

--- a/internal/controller/keycloakrealmrole/keycloakrealmrole_controller.go
+++ b/internal/controller/keycloakrealmrole/keycloakrealmrole_controller.go
@@ -159,9 +159,10 @@ func (r *ReconcileKeycloakRealmRole) tryReconcile(ctx context.Context, keycloakR
 				return "", fmt.Errorf("failed to remove role: %w", err)
 			}
 
+			original := keycloakRealmRole.DeepCopy()
 			controllerutil.RemoveFinalizer(keycloakRealmRole, keyCloakRealmRoleOperatorFinalizerName)
 
-			if err := r.client.Update(ctx, keycloakRealmRole); err != nil {
+			if err := helper.PatchObject(ctx, r.client, original, keycloakRealmRole); err != nil {
 				return "", fmt.Errorf("failed to remove finalizer: %w", err)
 			}
 		}
@@ -169,8 +170,9 @@ func (r *ReconcileKeycloakRealmRole) tryReconcile(ctx context.Context, keycloakR
 		return "", nil
 	}
 
+	original := keycloakRealmRole.DeepCopy()
 	if controllerutil.AddFinalizer(keycloakRealmRole, keyCloakRealmRoleOperatorFinalizerName) {
-		if err := r.client.Update(ctx, keycloakRealmRole); err != nil {
+		if err := helper.PatchObject(ctx, r.client, original, keycloakRealmRole); err != nil {
 			return "", fmt.Errorf("failed to add finalizer: %w", err)
 		}
 	}

--- a/internal/controller/keycloakrealmuser/keycloakrealmuser_controller.go
+++ b/internal/controller/keycloakrealmuser/keycloakrealmuser_controller.go
@@ -162,9 +162,10 @@ func (r *Reconcile) tryReconcile(ctx context.Context, instance *keycloakApi.Keyc
 					return fmt.Errorf("failed to remove user: %w", err)
 				}
 
+				original := instance.DeepCopy()
 				controllerutil.RemoveFinalizer(instance, finalizerName)
 
-				if err := r.client.Update(ctx, instance); err != nil {
+				if err := helper.PatchObject(ctx, r.client, original, instance); err != nil {
 					return fmt.Errorf("failed to remove finalizer: %w", err)
 				}
 			}
@@ -172,8 +173,9 @@ func (r *Reconcile) tryReconcile(ctx context.Context, instance *keycloakApi.Keyc
 			return nil
 		}
 
+		original := instance.DeepCopy()
 		if controllerutil.AddFinalizer(instance, finalizerName) {
-			if err := r.client.Update(ctx, instance); err != nil {
+			if err := helper.PatchObject(ctx, r.client, original, instance); err != nil {
 				return fmt.Errorf("failed to add finalizer: %w", err)
 			}
 		}


### PR DESCRIPTION
## Summary

- Adding or removing a finalizer (and setting owner refs) used `client.Update`, which re-encodes the whole CR. `omitempty` then drops GitOps-applied zeros (`false`, `0`, `{}`, `""`) from the live spec.
- Argo CD stays OutOfSync: `last-applied-configuration` still has those fields, kubectl/Argo three-way merge treats desired == last-applied and does not restore what the operator deleted.
- Persist those metadata-only changes with `client.MergeFrom` so spec is left as applied.

This showed up after v1.33 on new CRs (AuthFlow / ClientScope finalizer rename to `v1.edp.epam.com/finalizer` triggers one full `Update` at first reconcile).

Fixes #379 