### PR TITLE
fix(KeycloakRealmGroup): scope group ownership to the resolved realm instance

### DIFF
--- a/internal/controller/keycloakrealmgroup/chain/create_or_update_group_test.go
+++ b/internal/controller/keycloakrealmgroup/chain/create_or_update_group_test.go
@@ -14,7 +14,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	keycloakAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi/mocks"
 )
@@ -28,17 +30,38 @@ const (
 	testCRNameA        = "cr-a"
 	testExistingGroup  = "existing-group"
 	testCRNameB        = "cr-b"
+	testRealmRefName   = "test"
 )
 
-// newFakeK8sClient builds a fake controller-runtime client with the keycloakApi scheme
-// registered, pre-populated with the given KeycloakRealmGroup objects.
+// newFakeK8sClient builds a fake controller-runtime client with the keycloak
+// schemes registered, pre-populated with the given objects.
 func newFakeK8sClient(t *testing.T, objs ...client.Object) client.Client {
 	t.Helper()
 
 	scheme := runtime.NewScheme()
 	require.NoError(t, keycloakApi.AddToScheme(scheme))
+	require.NoError(t, keycloakAlpha.AddToScheme(scheme))
 
 	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+func namespacedKeycloakStack(ns, realmName, url string) []client.Object {
+	return []client.Object{
+		&keycloakApi.Keycloak{
+			ObjectMeta: metav1.ObjectMeta{Name: "keycloak", Namespace: ns},
+			Spec:       keycloakApi.KeycloakSpec{Url: url},
+		},
+		&keycloakApi.KeycloakRealm{
+			ObjectMeta: metav1.ObjectMeta{Name: testRealmRefName, Namespace: ns},
+			Spec: keycloakApi.KeycloakRealmSpec{
+				RealmName: realmName,
+				KeycloakRef: common.KeycloakRef{
+					Kind: keycloakApi.KeycloakKind,
+					Name: "keycloak",
+				},
+			},
+		},
+	}
 }
 
 func TestCreateOrUpdateGroup_Serve_CreateTopLevel(t *testing.T) {
@@ -445,6 +468,162 @@ func TestCreateOrUpdateGroup_Serve_RefusesToAdoptGroupOwnedByAnotherCR(t *testin
 	h := NewCreateOrUpdateGroup(newFakeK8sClient(t, owner))
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	assert.ErrorContains(t, err, "already managed by KeycloakRealmGroup "+testNamespace+"/"+testCRNameA)
+	assert.Empty(t, groupCtx.GroupID)
+}
+
+func TestCreateOrUpdateGroup_Serve_AllowsSameGroupIDOnNamespacedRealmInAnotherNamespace(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+	groupCtx := &GroupContext{RealmName: "test-realm"}
+
+	group := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameB, Namespace: testNamespace},
+	}
+	group.Spec.Name = testExistingGroup
+	group.Spec.Path = testUpdatedPath
+	group.Spec.Attributes = map[string][]string{"key": {"val"}}
+	group.Spec.RealmRef.Kind = keycloakApi.KeycloakRealmKind
+	group.Spec.RealmRef.Name = testRealmRefName
+
+	owner := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameA, Namespace: "other-ns"},
+		Status:     keycloakApi.KeycloakRealmGroupStatus{ID: "existing-id"},
+	}
+	owner.Spec.RealmRef.Kind = keycloakApi.KeycloakRealmKind
+	owner.Spec.RealmRef.Name = testRealmRefName
+
+	mockGroups.EXPECT().FindGroupByName(
+		context.Background(), "test-realm", testExistingGroup,
+	).Return(&keycloakapi.GroupRepresentation{
+		Id:   ptr.To("existing-id"),
+		Name: ptr.To(testExistingGroup),
+		Path: ptr.To("/old-path"),
+	}, nil, nil)
+
+	mockGroups.EXPECT().UpdateGroup(
+		context.Background(), "test-realm", "existing-id",
+		keycloakapi.GroupRepresentation{
+			Id:          ptr.To("existing-id"),
+			Name:        ptr.To(testExistingGroup),
+			Description: ptr.To(""),
+			Path:        ptr.To(testUpdatedPath),
+			Attributes:  &map[string][]string{"key": {"val"}},
+		},
+	).Return(nil, nil)
+
+	objs := make([]client.Object, 0, 5)
+	objs = append(objs, owner)
+	objs = append(objs, namespacedKeycloakStack(testNamespace, "test-realm", "http://kc-a.example")...)
+	objs = append(objs, namespacedKeycloakStack("other-ns", "test-realm", "http://kc-b.example")...)
+
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t, objs...))
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	require.NoError(t, err)
+	assert.Equal(t, "existing-id", groupCtx.GroupID)
+}
+
+func TestCreateOrUpdateGroup_Serve_RefusesSameGroupIDOnClusterRealmAcrossNamespaces(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+	groupCtx := &GroupContext{RealmName: "test-realm"}
+
+	group := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameB, Namespace: testNamespace},
+	}
+	group.Spec.Name = testExistingGroup
+	group.Spec.RealmRef.Kind = keycloakAlpha.ClusterKeycloakRealmKind
+	group.Spec.RealmRef.Name = "shared-realm"
+
+	owner := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameA, Namespace: "other-ns"},
+		Status:     keycloakApi.KeycloakRealmGroupStatus{ID: "existing-id"},
+	}
+	owner.Spec.RealmRef.Kind = keycloakAlpha.ClusterKeycloakRealmKind
+	owner.Spec.RealmRef.Name = "shared-realm"
+
+	mockGroups.EXPECT().FindGroupByName(
+		context.Background(), "test-realm", testExistingGroup,
+	).Return(&keycloakapi.GroupRepresentation{
+		Id:   ptr.To("existing-id"),
+		Name: ptr.To(testExistingGroup),
+	}, nil, nil)
+
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t, owner))
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.ErrorContains(t, err, "already managed by KeycloakRealmGroup other-ns/"+testCRNameA)
+	assert.Empty(t, groupCtx.GroupID)
+}
+
+func TestCreateOrUpdateGroup_Serve_RefusesSameGroupIDOnSharedKeycloakURLAcrossNamespaces(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+	groupCtx := &GroupContext{RealmName: "test-realm"}
+
+	group := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameB, Namespace: testNamespace},
+	}
+	group.Spec.Name = testExistingGroup
+	group.Spec.RealmRef.Kind = keycloakApi.KeycloakRealmKind
+	group.Spec.RealmRef.Name = testRealmRefName
+
+	owner := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameA, Namespace: "other-ns"},
+		Status:     keycloakApi.KeycloakRealmGroupStatus{ID: "existing-id"},
+	}
+	owner.Spec.RealmRef.Kind = keycloakApi.KeycloakRealmKind
+	owner.Spec.RealmRef.Name = testRealmRefName
+
+	mockGroups.EXPECT().FindGroupByName(
+		context.Background(), "test-realm", testExistingGroup,
+	).Return(&keycloakapi.GroupRepresentation{
+		Id:   ptr.To("existing-id"),
+		Name: ptr.To(testExistingGroup),
+	}, nil, nil)
+
+	objs := make([]client.Object, 0, 5)
+	objs = append(objs, owner)
+	objs = append(objs, namespacedKeycloakStack(testNamespace, "test-realm", "http://shared.example")...)
+	objs = append(objs, namespacedKeycloakStack("other-ns", "test-realm", "http://shared.example/")...)
+
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t, objs...))
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.ErrorContains(t, err, "already managed by KeycloakRealmGroup other-ns/"+testCRNameA)
+	assert.Empty(t, groupCtx.GroupID)
+}
+
+func TestCreateOrUpdateGroup_Serve_FailsClosedWhenRealmTargetCannotBeResolved(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+	groupCtx := &GroupContext{RealmName: "test-realm"}
+
+	group := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameB, Namespace: testNamespace},
+	}
+	group.Spec.Name = testExistingGroup
+	group.Spec.RealmRef.Kind = keycloakApi.KeycloakRealmKind
+	group.Spec.RealmRef.Name = testRealmRefName
+
+	owner := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameA, Namespace: "other-ns"},
+		Status:     keycloakApi.KeycloakRealmGroupStatus{ID: "existing-id"},
+	}
+	owner.Spec.RealmRef.Kind = keycloakApi.KeycloakRealmKind
+	owner.Spec.RealmRef.Name = testRealmRefName
+
+	mockGroups.EXPECT().FindGroupByName(
+		context.Background(), "test-realm", testExistingGroup,
+	).Return(&keycloakapi.GroupRepresentation{
+		Id:   ptr.To("existing-id"),
+		Name: ptr.To(testExistingGroup),
+	}, nil, nil)
+
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t, owner))
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.ErrorContains(t, err, "unable to resolve realm target for ownership check")
 	assert.Empty(t, groupCtx.GroupID)
 }
 

--- a/internal/controller/keycloakrealmgroup/chain/ownership.go
+++ b/internal/controller/keycloakrealmgroup/chain/ownership.go
@@ -3,16 +3,29 @@ package chain
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	keycloakAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
 )
 
+// realmServerTarget is the Keycloak server URL plus realm name a group actually talks to.
+type realmServerTarget struct {
+	url       string
+	realmName string
+}
+
 // findOwnerCR returns the KeycloakRealmGroup that already recorded groupID in its
-// status.ID, excluding self. Comparing on the actual Keycloak group ID (rather than
-// re-deriving realm/parent identity from spec) is what lets a single check work
-// uniformly for both RealmRef kinds and for namespace-local ParentGroup refs.
+// status.ID, excluding self, and only if it targets the same Keycloak realm.
+// Comparing on the Keycloak group ID (rather than re-deriving parent identity from
+// spec) is what lets a single check work uniformly for namespace-local ParentGroup
+// refs. The ID is unique per Keycloak server, not cluster-wide: cloned instances
+// reuse UUIDs, so matching refs is enough to refuse, while differing refs are
+// resolved to (spec.url, realmName) from the informer cache.
 func findOwnerCR(
 	ctx context.Context,
 	k8sClient client.Client,
@@ -22,6 +35,10 @@ func findOwnerCR(
 	if groupID == "" {
 		return nil, nil
 	}
+
+	// Resolved once per scan; a resolution error surfaces only when a same-ID
+	// candidate actually needs the resolved-target comparison.
+	selfTarget, selfResolveErr := resolveRealmTarget(ctx, k8sClient, self)
 
 	var list keycloakApi.KeycloakRealmGroupList
 	if err := k8sClient.List(ctx, &list); err != nil {
@@ -35,10 +52,137 @@ func findOwnerCR(
 			continue
 		}
 
-		if candidate.Status.ID == groupID {
+		if candidate.Status.ID != groupID {
+			continue
+		}
+
+		if sameRealmTarget(self, candidate) {
+			return candidate, nil
+		}
+
+		candidateTarget, err := resolveRealmTarget(ctx, k8sClient, candidate)
+		if err != nil {
+			return nil, fmt.Errorf("unable to resolve realm target for ownership check: %w", err)
+		}
+
+		if selfResolveErr != nil {
+			return nil, fmt.Errorf("unable to resolve realm target for ownership check: %w", selfResolveErr)
+		}
+
+		if selfTarget == candidateTarget {
 			return candidate, nil
 		}
 	}
 
 	return nil, nil
+}
+
+// sameRealmTarget reports whether two KeycloakRealmGroup resources target the same
+// realm instance. Mirrors sameKeycloakInstance on KeycloakRealm: the namespaced
+// KeycloakRealm kind is resolved in the group's own namespace, so identity is
+// (namespace, name). ClusterKeycloakRealm is cluster-scoped, so identity is the
+// name alone.
+func sameRealmTarget(a, b *keycloakApi.KeycloakRealmGroup) bool {
+	if realmRefKind(a) != realmRefKind(b) || a.Spec.RealmRef.Name != b.Spec.RealmRef.Name {
+		return false
+	}
+
+	if realmRefKind(a) == keycloakApi.KeycloakRealmKind {
+		return a.Namespace == b.Namespace
+	}
+
+	return true
+}
+
+func realmRefKind(group *keycloakApi.KeycloakRealmGroup) string {
+	if group.Spec.RealmRef.Kind == "" {
+		return keycloakApi.KeycloakRealmKind
+	}
+
+	return group.Spec.RealmRef.Kind
+}
+
+func resolveRealmTarget(
+	ctx context.Context,
+	k8sClient client.Client,
+	group *keycloakApi.KeycloakRealmGroup,
+) (realmServerTarget, error) {
+	name := group.Spec.RealmRef.Name
+
+	switch realmRefKind(group) {
+	case keycloakApi.KeycloakRealmKind:
+		realm := &keycloakApi.KeycloakRealm{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      name,
+			Namespace: group.Namespace,
+		}, realm); err != nil {
+			return realmServerTarget{}, fmt.Errorf("unable to get KeycloakRealm %s/%s: %w", group.Namespace, name, err)
+		}
+
+		url, err := resolveKeycloakURL(ctx, k8sClient, realm.Namespace, realm.Spec.KeycloakRef)
+		if err != nil {
+			return realmServerTarget{}, err
+		}
+
+		return realmServerTarget{url: url, realmName: realm.Spec.RealmName}, nil
+
+	case keycloakAlpha.ClusterKeycloakRealmKind:
+		clusterRealm := &keycloakAlpha.ClusterKeycloakRealm{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name}, clusterRealm); err != nil {
+			return realmServerTarget{}, fmt.Errorf("unable to get ClusterKeycloakRealm %s: %w", name, err)
+		}
+
+		url, err := resolveKeycloakURL(ctx, k8sClient, "", common.KeycloakRef{
+			Kind: keycloakAlpha.ClusterKeycloakKind,
+			Name: clusterRealm.Spec.ClusterKeycloakRef,
+		})
+		if err != nil {
+			return realmServerTarget{}, err
+		}
+
+		return realmServerTarget{url: url, realmName: clusterRealm.Spec.RealmName}, nil
+
+	default:
+		return realmServerTarget{}, fmt.Errorf("unknown realm kind: %s", realmRefKind(group))
+	}
+}
+
+func resolveKeycloakURL(
+	ctx context.Context,
+	k8sClient client.Client,
+	namespace string,
+	ref common.KeycloakRef,
+) (string, error) {
+	kind := ref.Kind
+	if kind == "" {
+		kind = keycloakApi.KeycloakKind
+	}
+
+	switch kind {
+	case keycloakApi.KeycloakKind:
+		kc := &keycloakApi.Keycloak{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      ref.Name,
+			Namespace: namespace,
+		}, kc); err != nil {
+			return "", fmt.Errorf("unable to get Keycloak %s/%s: %w", namespace, ref.Name, err)
+		}
+
+		return normalizeKeycloakURL(kc.Spec.Url), nil
+
+	case keycloakAlpha.ClusterKeycloakKind:
+		kc := &keycloakAlpha.ClusterKeycloak{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: ref.Name}, kc); err != nil {
+			return "", fmt.Errorf("unable to get ClusterKeycloak %s: %w", ref.Name, err)
+		}
+
+		return normalizeKeycloakURL(kc.Spec.Url), nil
+
+	default:
+		return "", fmt.Errorf("unknown keycloak kind: %s", kind)
+	}
+}
+
+func normalizeKeycloakURL(url string) string {
+	return strings.TrimRight(url, "/")
 }

--- a/internal/controller/keycloakrealmgroup/chain/ownership_test.go
+++ b/internal/controller/keycloakrealmgroup/chain/ownership_test.go
@@ -1,0 +1,169 @@
+package chain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/epam/edp-keycloak-operator/api/common"
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	keycloakAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
+)
+
+func TestSameRealmTarget(t *testing.T) {
+	namespaced := func(ns, realm string) *keycloakApi.KeycloakRealmGroup {
+		g := &keycloakApi.KeycloakRealmGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: "group", Namespace: ns},
+		}
+		g.Spec.RealmRef.Kind = keycloakApi.KeycloakRealmKind
+		g.Spec.RealmRef.Name = realm
+
+		return g
+	}
+
+	t.Run("same namespaced realm in same namespace", func(t *testing.T) {
+		assert.True(t, sameRealmTarget(namespaced("ns-a", testRealmRefName), namespaced("ns-a", testRealmRefName)))
+	})
+
+	t.Run("same namespaced realm name in another namespace", func(t *testing.T) {
+		assert.False(t, sameRealmTarget(namespaced("ns-a", testRealmRefName), namespaced("ns-b", testRealmRefName)))
+	})
+
+	t.Run("empty kind defaults to KeycloakRealm", func(t *testing.T) {
+		a := namespaced("ns-a", testRealmRefName)
+		b := namespaced("ns-a", testRealmRefName)
+		b.Spec.RealmRef.Kind = ""
+
+		assert.True(t, sameRealmTarget(a, b))
+	})
+
+	t.Run("cluster realm is cluster-wide", func(t *testing.T) {
+		a := namespaced("ns-a", "shared")
+		b := namespaced("ns-b", "shared")
+		a.Spec.RealmRef.Kind = keycloakAlpha.ClusterKeycloakRealmKind
+		b.Spec.RealmRef.Kind = keycloakAlpha.ClusterKeycloakRealmKind
+
+		assert.True(t, sameRealmTarget(a, b))
+	})
+}
+
+func TestNormalizeKeycloakURL(t *testing.T) {
+	assert.Equal(t, "http://kc.example", normalizeKeycloakURL("http://kc.example/"))
+	assert.Equal(t, "http://kc.example", normalizeKeycloakURL("http://kc.example"))
+}
+
+func TestResolveRealmTarget_ClusterKeycloakRealm(t *testing.T) {
+	group := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "ns-a"},
+	}
+	group.Spec.RealmRef.Kind = keycloakAlpha.ClusterKeycloakRealmKind
+	group.Spec.RealmRef.Name = "crealm"
+
+	got, err := resolveRealmTarget(context.Background(), newFakeK8sClient(t,
+		&keycloakAlpha.ClusterKeycloak{
+			ObjectMeta: metav1.ObjectMeta{Name: "ckc"},
+			Spec:       keycloakAlpha.ClusterKeycloakSpec{Url: "http://cluster-kc.example/"},
+		},
+		&keycloakAlpha.ClusterKeycloakRealm{
+			ObjectMeta: metav1.ObjectMeta{Name: "crealm"},
+			Spec: keycloakAlpha.ClusterKeycloakRealmSpec{
+				ClusterKeycloakRef: "ckc",
+				RealmName:          "shared",
+			},
+		},
+	), group)
+	require.NoError(t, err)
+	assert.Equal(t, realmServerTarget{url: "http://cluster-kc.example", realmName: "shared"}, got)
+}
+
+func TestFindOwnerCR_SharedURLIsConflict(t *testing.T) {
+	self := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameB, Namespace: "ns-a"},
+	}
+	self.Spec.RealmRef.Kind = keycloakApi.KeycloakRealmKind
+	self.Spec.RealmRef.Name = testRealmRefName
+
+	owner := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameA, Namespace: "ns-b"},
+		Status:     keycloakApi.KeycloakRealmGroupStatus{ID: "gid"},
+	}
+	owner.Spec.RealmRef.Kind = keycloakApi.KeycloakRealmKind
+	owner.Spec.RealmRef.Name = testRealmRefName
+
+	objs := make([]client.Object, 0, 5)
+	objs = append(objs, owner)
+	objs = append(objs, namespacedKeycloakStack("ns-a", testRealmRefName, "http://shared.example")...)
+	objs = append(objs, namespacedKeycloakStack("ns-b", testRealmRefName, "http://shared.example/")...)
+
+	got, err := findOwnerCR(context.Background(), newFakeK8sClient(t, objs...), self, "gid")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "ns-b", got.Namespace)
+	assert.Equal(t, testCRNameA, got.Name)
+}
+
+func TestFindOwnerCR_CloneDifferentURLIsNotConflict(t *testing.T) {
+	self := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameB, Namespace: "ns-a"},
+	}
+	self.Spec.RealmRef.Kind = keycloakApi.KeycloakRealmKind
+	self.Spec.RealmRef.Name = testRealmRefName
+
+	owner := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameA, Namespace: "ns-b"},
+		Status:     keycloakApi.KeycloakRealmGroupStatus{ID: "gid"},
+	}
+	owner.Spec.RealmRef.Kind = keycloakApi.KeycloakRealmKind
+	owner.Spec.RealmRef.Name = testRealmRefName
+
+	objs := make([]client.Object, 0, 5)
+	objs = append(objs, owner)
+	objs = append(objs, namespacedKeycloakStack("ns-a", testRealmRefName, "http://kc-a.example")...)
+	objs = append(objs, namespacedKeycloakStack("ns-b", testRealmRefName, "http://kc-b.example")...)
+
+	got, err := findOwnerCR(context.Background(), newFakeK8sClient(t, objs...), self, "gid")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestFindOwnerCR_ResolutionFailure(t *testing.T) {
+	self := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameB, Namespace: "ns-a"},
+	}
+	self.Spec.RealmRef.Name = testRealmRefName
+
+	owner := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameA, Namespace: "ns-b"},
+		Status:     keycloakApi.KeycloakRealmGroupStatus{ID: "gid"},
+	}
+	owner.Spec.RealmRef.Name = testRealmRefName
+
+	_, err := findOwnerCR(context.Background(), newFakeK8sClient(t, owner), self, "gid")
+	assert.ErrorContains(t, err, "unable to resolve realm target for ownership check")
+}
+
+func TestResolveKeycloakURL_EmptyKindDefaultsToKeycloak(t *testing.T) {
+	url, err := resolveKeycloakURL(
+		context.Background(),
+		newFakeK8sClient(t, &keycloakApi.Keycloak{
+			ObjectMeta: metav1.ObjectMeta{Name: "kc", Namespace: "ns-a"},
+			Spec:       keycloakApi.KeycloakSpec{Url: "http://kc.example"},
+		}),
+		"ns-a",
+		common.KeycloakRef{Name: "kc"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "http://kc.example", url)
+}
+
+func TestResolveRealmTarget_UnknownKind(t *testing.T) {
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.RealmRef.Kind = "Nope"
+
+	_, err := resolveRealmTarget(context.Background(), newFakeK8sClient(t), group)
+	assert.ErrorContains(t, err, "unknown realm kind")
+}


### PR DESCRIPTION
## Summary

- Scope `KeycloakRealmGroup` ownership to the resolved realm instance so cloned group UUIDs no longer conflict across namespaces.

Closes #381