### PR TITLE
fix(KeycloakClientScope): skip Keycloak writes when state already matches spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,9 @@ KEYCLOAK_VERSION=26.5.2 make generate-keycloak-go-client   # regenerate oapi cli
 2. Wire it into `chain/chain.go` in the correct call order.
 3. Add a `_test.go` alongside it; use Ginkgo + Gomega.
 
+### Reconciliation idempotency
+Skip Keycloak writes when actual state matches the spec; track `status.observedGeneration` and force writes on generation change so spec removals propagate. Never delete-and-recreate child resources — diff by name (reference: `internal/controller/keycloakclientscope/chain/`).
+
 ### Never edit generated code
 `pkg/client/keycloakapi/generated/client_generated.go` is auto-generated — do not edit manually.
 Edit `pkg/client/keycloakapi/openapi.yaml` then re-run `make generate-keycloak-go-client`.

--- a/api/v1/keycloakclientscope_types.go
+++ b/api/v1/keycloakclientscope_types.go
@@ -63,6 +63,10 @@ type KeycloakClientScopeStatus struct {
 
 	// +optional
 	FailureCount int64 `json:"failureCount,omitempty"`
+
+	// ObservedGeneration is the generation last successfully reconciled to Keycloak.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/v1.edp.epam.com_keycloakclientscopes.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakclientscopes.yaml
@@ -130,6 +130,11 @@ spec:
                 type: integer
               id:
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the generation last successfully
+                  reconciled to Keycloak.
+                format: int64
+                type: integer
               value:
                 type: string
             type: object

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakclientscopes.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakclientscopes.yaml
@@ -130,6 +130,11 @@ spec:
                 type: integer
               id:
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the generation last successfully
+                  reconciled to Keycloak.
+                format: int64
+                type: integer
               value:
                 type: string
             type: object

--- a/docs/api.md
+++ b/docs/api.md
@@ -4761,6 +4761,15 @@ KeycloakClientScopeStatus defines the observed state of KeycloakClientScope.
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>observedGeneration</b></td>
+        <td>integer</td>
+        <td>
+          ObservedGeneration is the generation last successfully reconciled to Keycloak.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>

--- a/internal/controller/keycloakclientscope/chain/compare.go
+++ b/internal/controller/keycloakclientscope/chain/compare.go
@@ -1,0 +1,24 @@
+package chain
+
+import (
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+)
+
+// Update endpoints PUT the full representation: a spec edit must force the
+// write so keys removed from the spec are dropped in Keycloak.
+func specChanged(scope *keycloakApi.KeycloakClientScope) bool {
+	return scope.Generation != scope.Status.ObservedGeneration
+}
+
+// Keycloak injects default config keys on write (e.g. introspection.token.claim);
+// exact comparison would never converge.
+func containsConfig(existing, desired map[string]string) bool {
+	for k, v := range desired {
+		existingValue, ok := existing[k]
+		if !ok || existingValue != v {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/controller/keycloakclientscope/chain/create_or_update_scope.go
+++ b/internal/controller/keycloakclientscope/chain/create_or_update_scope.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
@@ -55,20 +56,29 @@ func (h *CreateOrUpdateScope) Serve(
 			scope.Status.ID = *existingScope.Id
 		}
 
-		_, err := scopesClient.UpdateClientScope(ctx, realmName, scope.Status.ID, keycloakapi.ClientScopeRepresentation{
-			Name:        &spec.Name,
-			Protocol:    &protocol,
-			Description: &desc,
-			Attributes:  &attrs,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to update client scope: %w", err)
+		if specChanged(scope) || !clientScopeMatchesSpec(existingScope, &spec) {
+			_, err := scopesClient.UpdateClientScope(ctx, realmName, scope.Status.ID, keycloakapi.ClientScopeRepresentation{
+				Name:        &spec.Name,
+				Protocol:    &protocol,
+				Description: &desc,
+				Attributes:  &attrs,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to update client scope: %w", err)
+			}
 		}
 	}
 
 	log.Info("Client scope has been synced")
 
 	return nil
+}
+
+func clientScopeMatchesSpec(existing *keycloakapi.ClientScopeRepresentation, spec *keycloakApi.KeycloakClientScopeSpec) bool {
+	return ptr.Deref(existing.Name, "") == spec.Name &&
+		ptr.Deref(existing.Protocol, "") == spec.Protocol &&
+		ptr.Deref(existing.Description, "") == spec.Description &&
+		containsConfig(ptr.Deref(existing.Attributes, nil), spec.Attributes)
 }
 
 func (h *CreateOrUpdateScope) findScopeByName(

--- a/internal/controller/keycloakclientscope/chain/create_or_update_scope_test.go
+++ b/internal/controller/keycloakclientscope/chain/create_or_update_scope_test.go
@@ -16,10 +16,11 @@ import (
 )
 
 const (
-	testScopeName    = "test-scope"
-	testScopeID      = "scope-id-123"
-	testRealmName    = "test-realm"
-	testProtocolOIDC = "openid-connect"
+	testScopeName        = "test-scope"
+	testScopeID          = "scope-id-123"
+	testRealmName        = "test-realm"
+	testProtocolOIDC     = "openid-connect"
+	testScopeDescription = "Test description"
 )
 
 func TestCreateOrUpdateScope_Serve_CreateNew(t *testing.T) {
@@ -29,14 +30,14 @@ func TestCreateOrUpdateScope_Serve_CreateNew(t *testing.T) {
 	scope := &keycloakApi.KeycloakClientScope{}
 	scope.Spec.Name = testScopeName
 	scope.Spec.Protocol = testProtocolOIDC
-	scope.Spec.Description = "Test description"
+	scope.Spec.Description = testScopeDescription
 	scope.Spec.Attributes = map[string]string{"key": "val"}
 
 	mockScopes.EXPECT().GetClientScopes(
 		context.Background(), testRealmName,
 	).Return([]keycloakapi.ClientScopeRepresentation{}, nil, nil)
 
-	desc := "Test description"
+	desc := testScopeDescription
 	protocol := testProtocolOIDC
 	attrs := map[string]string{"key": "val"}
 
@@ -92,6 +93,86 @@ func TestCreateOrUpdateScope_Serve_UpdateExisting(t *testing.T) {
 			Protocol:    &protocol,
 			Description: &desc,
 			Attributes:  &nilAttrs,
+		},
+	).Return(nil, nil)
+
+	h := NewCreateOrUpdateScope(kClient)
+	err := h.Serve(context.Background(), scope, testRealmName)
+	require.NoError(t, err)
+	assert.Equal(t, testScopeID, scope.Status.ID)
+}
+
+func TestCreateOrUpdateScope_Serve_SkipUpdateWhenInSync(t *testing.T) {
+	mockScopes := mocks.NewMockClientScopesClient(t)
+	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
+
+	scope := &keycloakApi.KeycloakClientScope{}
+	scope.Spec.Name = testScopeName
+	scope.Spec.Protocol = testProtocolOIDC
+	scope.Spec.Description = testScopeDescription
+	scope.Spec.Attributes = map[string]string{"key": "val"}
+
+	// Server-added default attributes must not trigger an update.
+	existingAttrs := map[string]string{"key": "val", "display.on.consent.screen": "true"}
+
+	// Existing state matches spec: no UpdateClientScope call expected.
+	mockScopes.EXPECT().GetClientScopes(
+		context.Background(), testRealmName,
+	).Return([]keycloakapi.ClientScopeRepresentation{
+		{
+			Id:          ptr.To(testScopeID),
+			Name:        ptr.To(testScopeName),
+			Protocol:    ptr.To(testProtocolOIDC),
+			Description: ptr.To(testScopeDescription),
+			Attributes:  &existingAttrs,
+		},
+	}, nil, nil)
+
+	h := NewCreateOrUpdateScope(kClient)
+	err := h.Serve(context.Background(), scope, testRealmName)
+	require.NoError(t, err)
+	assert.Equal(t, testScopeID, scope.Status.ID)
+}
+
+func TestCreateOrUpdateScope_Serve_ForceUpdateOnSpecChange(t *testing.T) {
+	mockScopes := mocks.NewMockClientScopesClient(t)
+	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
+
+	// Generation ahead of ObservedGeneration: PUT must fire even though the
+	// declared attributes match, so keys removed from the spec are dropped.
+	scope := &keycloakApi.KeycloakClientScope{}
+	scope.Generation = 2
+	scope.Status.ObservedGeneration = 1
+	scope.Spec.Name = testScopeName
+	scope.Spec.Protocol = testProtocolOIDC
+	scope.Spec.Description = testScopeDescription
+	scope.Spec.Attributes = map[string]string{"key": "val"}
+
+	existingAttrs := map[string]string{"key": "val", "removed.key": "stale"}
+
+	mockScopes.EXPECT().GetClientScopes(
+		context.Background(), testRealmName,
+	).Return([]keycloakapi.ClientScopeRepresentation{
+		{
+			Id:          ptr.To(testScopeID),
+			Name:        ptr.To(testScopeName),
+			Protocol:    ptr.To(testProtocolOIDC),
+			Description: ptr.To(testScopeDescription),
+			Attributes:  &existingAttrs,
+		},
+	}, nil, nil)
+
+	desc := testScopeDescription
+	protocol := testProtocolOIDC
+	attrs := map[string]string{"key": "val"}
+
+	mockScopes.EXPECT().UpdateClientScope(
+		context.Background(), testRealmName, testScopeID,
+		keycloakapi.ClientScopeRepresentation{
+			Name:        ptr.To(testScopeName),
+			Protocol:    &protocol,
+			Description: &desc,
+			Attributes:  &attrs,
 		},
 	).Return(nil, nil)
 

--- a/internal/controller/keycloakclientscope/chain/set_scope_type.go
+++ b/internal/controller/keycloakclientscope/chain/set_scope_type.go
@@ -3,6 +3,7 @@ package chain
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -30,39 +31,65 @@ func (h *SetScopeType) Serve(
 	scopeID := scope.Status.ID
 	scopeType := scope.GetType()
 
-	switch scopeType {
-	case keycloakApi.KeycloakClientScopeTypeDefault:
+	if scopeType != keycloakApi.KeycloakClientScopeTypeDefault &&
+		scopeType != keycloakApi.KeycloakClientScopeTypeOptional &&
+		scopeType != keycloakApi.KeycloakClientScopeTypeNone {
+		return fmt.Errorf("invalid client scope type: %s", scopeType)
+	}
+
+	inDefault, err := h.scopeInRealmList(ctx, realmName, scopeID, scopesClient.GetRealmDefaultClientScopes)
+	if err != nil {
+		return fmt.Errorf("failed to get realm default client scopes: %w", err)
+	}
+
+	inOptional, err := h.scopeInRealmList(ctx, realmName, scopeID, scopesClient.GetRealmOptionalClientScopes)
+	if err != nil {
+		return fmt.Errorf("failed to get realm optional client scopes: %w", err)
+	}
+
+	wantDefault := scopeType == keycloakApi.KeycloakClientScopeTypeDefault
+	wantOptional := scopeType == keycloakApi.KeycloakClientScopeTypeOptional
+
+	if inDefault && !wantDefault {
+		if _, err := scopesClient.RemoveRealmDefaultClientScope(ctx, realmName, scopeID); err != nil && !keycloakapi.IsNotFound(err) {
+			return fmt.Errorf("failed to remove scope from default list: %w", err)
+		}
+	}
+
+	if inOptional && !wantOptional {
 		if _, err := scopesClient.RemoveRealmOptionalClientScope(ctx, realmName, scopeID); err != nil && !keycloakapi.IsNotFound(err) {
 			return fmt.Errorf("failed to remove scope from optional list: %w", err)
 		}
+	}
 
+	if !inDefault && wantDefault {
 		if _, err := scopesClient.AddRealmDefaultClientScope(ctx, realmName, scopeID); err != nil {
 			return fmt.Errorf("failed to add scope to default list: %w", err)
 		}
+	}
 
-	case keycloakApi.KeycloakClientScopeTypeOptional:
-		if _, err := scopesClient.RemoveRealmDefaultClientScope(ctx, realmName, scopeID); err != nil && !keycloakapi.IsNotFound(err) {
-			return fmt.Errorf("failed to remove scope from default list: %w", err)
-		}
-
+	if !inOptional && wantOptional {
 		if _, err := scopesClient.AddRealmOptionalClientScope(ctx, realmName, scopeID); err != nil {
 			return fmt.Errorf("failed to add scope to optional list: %w", err)
 		}
-
-	case keycloakApi.KeycloakClientScopeTypeNone:
-		if _, err := scopesClient.RemoveRealmDefaultClientScope(ctx, realmName, scopeID); err != nil && !keycloakapi.IsNotFound(err) {
-			return fmt.Errorf("failed to remove scope from default list: %w", err)
-		}
-
-		if _, err := scopesClient.RemoveRealmOptionalClientScope(ctx, realmName, scopeID); err != nil && !keycloakapi.IsNotFound(err) {
-			return fmt.Errorf("failed to remove scope from optional list: %w", err)
-		}
-
-	default:
-		return fmt.Errorf("invalid client scope type: %s", scopeType)
 	}
 
 	log.Info("Client scope type has been set")
 
 	return nil
+}
+
+func (h *SetScopeType) scopeInRealmList(
+	ctx context.Context,
+	realmName, scopeID string,
+	list func(ctx context.Context, realm string) ([]keycloakapi.ClientScopeRepresentation, *keycloakapi.Response, error),
+) (bool, error) {
+	scopes, _, err := list(ctx, realmName)
+	if err != nil {
+		return false, err
+	}
+
+	return slices.ContainsFunc(scopes, func(s keycloakapi.ClientScopeRepresentation) bool {
+		return s.Id != nil && *s.Id == scopeID
+	}), nil
 }

--- a/internal/controller/keycloakclientscope/chain/set_scope_type_test.go
+++ b/internal/controller/keycloakclientscope/chain/set_scope_type_test.go
@@ -7,11 +7,31 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi/mocks"
 )
+
+func scopeList(ids ...string) []keycloakapi.ClientScopeRepresentation {
+	scopes := make([]keycloakapi.ClientScopeRepresentation, 0, len(ids))
+	for _, id := range ids {
+		scopes = append(scopes, keycloakapi.ClientScopeRepresentation{Id: ptr.To(id)})
+	}
+
+	return scopes
+}
+
+func expectRealmScopeLists(mockScopes *mocks.MockClientScopesClient, defaultIDs, optionalIDs []string) {
+	mockScopes.EXPECT().GetRealmDefaultClientScopes(
+		context.Background(), testRealmName,
+	).Return(scopeList(defaultIDs...), nil, nil)
+
+	mockScopes.EXPECT().GetRealmOptionalClientScopes(
+		context.Background(), testRealmName,
+	).Return(scopeList(optionalIDs...), nil, nil)
+}
 
 func TestSetScopeType_Serve_Default(t *testing.T) {
 	mockScopes := mocks.NewMockClientScopesClient(t)
@@ -20,6 +40,8 @@ func TestSetScopeType_Serve_Default(t *testing.T) {
 	scope := &keycloakApi.KeycloakClientScope{}
 	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeDefault
 	scope.Status.ID = testScopeID
+
+	expectRealmScopeLists(mockScopes, nil, []string{testScopeID})
 
 	mockScopes.EXPECT().RemoveRealmOptionalClientScope(
 		context.Background(), testRealmName, testScopeID,
@@ -34,6 +56,22 @@ func TestSetScopeType_Serve_Default(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSetScopeType_Serve_Default_AlreadyInSync(t *testing.T) {
+	mockScopes := mocks.NewMockClientScopesClient(t)
+	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
+
+	scope := &keycloakApi.KeycloakClientScope{}
+	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeDefault
+	scope.Status.ID = testScopeID
+
+	// Scope already in default list only: no write calls expected.
+	expectRealmScopeLists(mockScopes, []string{testScopeID}, nil)
+
+	h := NewSetScopeType(kClient)
+	err := h.Serve(context.Background(), scope, testRealmName)
+	require.NoError(t, err)
+}
+
 func TestSetScopeType_Serve_Optional(t *testing.T) {
 	mockScopes := mocks.NewMockClientScopesClient(t)
 	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
@@ -41,6 +79,8 @@ func TestSetScopeType_Serve_Optional(t *testing.T) {
 	scope := &keycloakApi.KeycloakClientScope{}
 	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeOptional
 	scope.Status.ID = testScopeID
+
+	expectRealmScopeLists(mockScopes, []string{testScopeID}, nil)
 
 	mockScopes.EXPECT().RemoveRealmDefaultClientScope(
 		context.Background(), testRealmName, testScopeID,
@@ -55,6 +95,21 @@ func TestSetScopeType_Serve_Optional(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSetScopeType_Serve_Optional_AlreadyInSync(t *testing.T) {
+	mockScopes := mocks.NewMockClientScopesClient(t)
+	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
+
+	scope := &keycloakApi.KeycloakClientScope{}
+	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeOptional
+	scope.Status.ID = testScopeID
+
+	expectRealmScopeLists(mockScopes, nil, []string{testScopeID})
+
+	h := NewSetScopeType(kClient)
+	err := h.Serve(context.Background(), scope, testRealmName)
+	require.NoError(t, err)
+}
+
 func TestSetScopeType_Serve_None(t *testing.T) {
 	mockScopes := mocks.NewMockClientScopesClient(t)
 	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
@@ -62,6 +117,8 @@ func TestSetScopeType_Serve_None(t *testing.T) {
 	scope := &keycloakApi.KeycloakClientScope{}
 	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeNone
 	scope.Status.ID = testScopeID
+
+	expectRealmScopeLists(mockScopes, []string{testScopeID}, []string{testScopeID})
 
 	mockScopes.EXPECT().RemoveRealmDefaultClientScope(
 		context.Background(), testRealmName, testScopeID,
@@ -76,6 +133,21 @@ func TestSetScopeType_Serve_None(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSetScopeType_Serve_None_AlreadyInSync(t *testing.T) {
+	mockScopes := mocks.NewMockClientScopesClient(t)
+	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
+
+	scope := &keycloakApi.KeycloakClientScope{}
+	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeNone
+	scope.Status.ID = testScopeID
+
+	expectRealmScopeLists(mockScopes, nil, nil)
+
+	h := NewSetScopeType(kClient)
+	err := h.Serve(context.Background(), scope, testRealmName)
+	require.NoError(t, err)
+}
+
 func TestSetScopeType_Serve_DefaultRemoveOptionalNotFound(t *testing.T) {
 	mockScopes := mocks.NewMockClientScopesClient(t)
 	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
@@ -83,6 +155,8 @@ func TestSetScopeType_Serve_DefaultRemoveOptionalNotFound(t *testing.T) {
 	scope := &keycloakApi.KeycloakClientScope{}
 	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeDefault
 	scope.Status.ID = testScopeID
+
+	expectRealmScopeLists(mockScopes, nil, []string{testScopeID})
 
 	mockScopes.EXPECT().RemoveRealmOptionalClientScope(
 		context.Background(), testRealmName, testScopeID,
@@ -105,9 +179,7 @@ func TestSetScopeType_Serve_AddDefaultError(t *testing.T) {
 	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeDefault
 	scope.Status.ID = testScopeID
 
-	mockScopes.EXPECT().RemoveRealmOptionalClientScope(
-		context.Background(), testRealmName, testScopeID,
-	).Return(nil, nil)
+	expectRealmScopeLists(mockScopes, nil, nil)
 
 	mockScopes.EXPECT().AddRealmDefaultClientScope(
 		context.Background(), testRealmName, testScopeID,
@@ -126,6 +198,8 @@ func TestSetScopeType_Serve_RemoveOptionalError(t *testing.T) {
 	scope := &keycloakApi.KeycloakClientScope{}
 	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeDefault
 	scope.Status.ID = testScopeID
+
+	expectRealmScopeLists(mockScopes, nil, []string{testScopeID})
 
 	mockScopes.EXPECT().RemoveRealmOptionalClientScope(
 		context.Background(), testRealmName, testScopeID,
@@ -146,6 +220,8 @@ func TestSetScopeType_Serve_DeprecatedDefaultField(t *testing.T) {
 	scope.Spec.Default = true
 	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeNone
 	scope.Status.ID = testScopeID
+
+	expectRealmScopeLists(mockScopes, nil, []string{testScopeID})
 
 	mockScopes.EXPECT().RemoveRealmOptionalClientScope(
 		context.Background(), testRealmName, testScopeID,
@@ -168,6 +244,8 @@ func TestSetScopeType_Serve_OptionalRemoveDefaultNotFound(t *testing.T) {
 	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeOptional
 	scope.Status.ID = testScopeID
 
+	expectRealmScopeLists(mockScopes, []string{testScopeID}, nil)
+
 	mockScopes.EXPECT().RemoveRealmDefaultClientScope(
 		context.Background(), testRealmName, testScopeID,
 	).Return(nil, keycloakapi.ErrNotFound)
@@ -189,6 +267,8 @@ func TestSetScopeType_Serve_OptionalRemoveDefaultError(t *testing.T) {
 	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeOptional
 	scope.Status.ID = testScopeID
 
+	expectRealmScopeLists(mockScopes, []string{testScopeID}, nil)
+
 	mockScopes.EXPECT().RemoveRealmDefaultClientScope(
 		context.Background(), testRealmName, testScopeID,
 	).Return(nil, errors.New("api error"))
@@ -207,9 +287,7 @@ func TestSetScopeType_Serve_OptionalAddOptionalError(t *testing.T) {
 	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeOptional
 	scope.Status.ID = testScopeID
 
-	mockScopes.EXPECT().RemoveRealmDefaultClientScope(
-		context.Background(), testRealmName, testScopeID,
-	).Return(nil, nil)
+	expectRealmScopeLists(mockScopes, nil, nil)
 
 	mockScopes.EXPECT().AddRealmOptionalClientScope(
 		context.Background(), testRealmName, testScopeID,
@@ -221,27 +299,6 @@ func TestSetScopeType_Serve_OptionalAddOptionalError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to add scope to optional list")
 }
 
-func TestSetScopeType_Serve_NoneRemoveDefaultNotFound(t *testing.T) {
-	mockScopes := mocks.NewMockClientScopesClient(t)
-	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
-
-	scope := &keycloakApi.KeycloakClientScope{}
-	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeNone
-	scope.Status.ID = testScopeID
-
-	mockScopes.EXPECT().RemoveRealmDefaultClientScope(
-		context.Background(), testRealmName, testScopeID,
-	).Return(nil, keycloakapi.ErrNotFound)
-
-	mockScopes.EXPECT().RemoveRealmOptionalClientScope(
-		context.Background(), testRealmName, testScopeID,
-	).Return(nil, nil)
-
-	h := NewSetScopeType(kClient)
-	err := h.Serve(context.Background(), scope, testRealmName)
-	require.NoError(t, err)
-}
-
 func TestSetScopeType_Serve_NoneRemoveDefaultError(t *testing.T) {
 	mockScopes := mocks.NewMockClientScopesClient(t)
 	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
@@ -249,6 +306,8 @@ func TestSetScopeType_Serve_NoneRemoveDefaultError(t *testing.T) {
 	scope := &keycloakApi.KeycloakClientScope{}
 	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeNone
 	scope.Status.ID = testScopeID
+
+	expectRealmScopeLists(mockScopes, []string{testScopeID}, nil)
 
 	mockScopes.EXPECT().RemoveRealmDefaultClientScope(
 		context.Background(), testRealmName, testScopeID,
@@ -260,27 +319,6 @@ func TestSetScopeType_Serve_NoneRemoveDefaultError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to remove scope from default list")
 }
 
-func TestSetScopeType_Serve_NoneRemoveOptionalNotFound(t *testing.T) {
-	mockScopes := mocks.NewMockClientScopesClient(t)
-	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
-
-	scope := &keycloakApi.KeycloakClientScope{}
-	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeNone
-	scope.Status.ID = testScopeID
-
-	mockScopes.EXPECT().RemoveRealmDefaultClientScope(
-		context.Background(), testRealmName, testScopeID,
-	).Return(nil, nil)
-
-	mockScopes.EXPECT().RemoveRealmOptionalClientScope(
-		context.Background(), testRealmName, testScopeID,
-	).Return(nil, keycloakapi.ErrNotFound)
-
-	h := NewSetScopeType(kClient)
-	err := h.Serve(context.Background(), scope, testRealmName)
-	require.NoError(t, err)
-}
-
 func TestSetScopeType_Serve_NoneRemoveOptionalError(t *testing.T) {
 	mockScopes := mocks.NewMockClientScopesClient(t)
 	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
@@ -289,9 +327,7 @@ func TestSetScopeType_Serve_NoneRemoveOptionalError(t *testing.T) {
 	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeNone
 	scope.Status.ID = testScopeID
 
-	mockScopes.EXPECT().RemoveRealmDefaultClientScope(
-		context.Background(), testRealmName, testScopeID,
-	).Return(nil, nil)
+	expectRealmScopeLists(mockScopes, nil, []string{testScopeID})
 
 	mockScopes.EXPECT().RemoveRealmOptionalClientScope(
 		context.Background(), testRealmName, testScopeID,
@@ -301,6 +337,46 @@ func TestSetScopeType_Serve_NoneRemoveOptionalError(t *testing.T) {
 	err := h.Serve(context.Background(), scope, testRealmName)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to remove scope from optional list")
+}
+
+func TestSetScopeType_Serve_GetDefaultScopesError(t *testing.T) {
+	mockScopes := mocks.NewMockClientScopesClient(t)
+	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
+
+	scope := &keycloakApi.KeycloakClientScope{}
+	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeDefault
+	scope.Status.ID = testScopeID
+
+	mockScopes.EXPECT().GetRealmDefaultClientScopes(
+		context.Background(), testRealmName,
+	).Return(nil, nil, errors.New("api error"))
+
+	h := NewSetScopeType(kClient)
+	err := h.Serve(context.Background(), scope, testRealmName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get realm default client scopes")
+}
+
+func TestSetScopeType_Serve_GetOptionalScopesError(t *testing.T) {
+	mockScopes := mocks.NewMockClientScopesClient(t)
+	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
+
+	scope := &keycloakApi.KeycloakClientScope{}
+	scope.Spec.Type = keycloakApi.KeycloakClientScopeTypeDefault
+	scope.Status.ID = testScopeID
+
+	mockScopes.EXPECT().GetRealmDefaultClientScopes(
+		context.Background(), testRealmName,
+	).Return(nil, nil, nil)
+
+	mockScopes.EXPECT().GetRealmOptionalClientScopes(
+		context.Background(), testRealmName,
+	).Return(nil, nil, errors.New("api error"))
+
+	h := NewSetScopeType(kClient)
+	err := h.Serve(context.Background(), scope, testRealmName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get realm optional client scopes")
 }
 
 func TestSetScopeType_Serve_InvalidType(t *testing.T) {

--- a/internal/controller/keycloakclientscope/chain/sync_protocol_mappers.go
+++ b/internal/controller/keycloakclientscope/chain/sync_protocol_mappers.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"maps"
 
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+	"github.com/epam/edp-keycloak-operator/pkg/maputil"
 )
 
 type SyncProtocolMappers struct {
@@ -35,27 +37,61 @@ func (h *SyncProtocolMappers) Serve(
 		return fmt.Errorf("failed to get existing protocol mappers: %w", err)
 	}
 
-	for _, mapper := range existingMappers {
+	existingByName := maputil.SliceToMapSelf(existingMappers, func(m keycloakapi.ProtocolMapperRepresentation) (string, bool) {
+		if m.Name == nil {
+			return "", false
+		}
+
+		return *m.Name, true
+	})
+
+	forceUpdate := specChanged(scope)
+
+	for _, specMapper := range scope.Spec.ProtocolMappers {
+		desired := convertProtocolMapper(specMapper)
+
+		existing, exists := existingByName[specMapper.Name]
+		if !exists {
+			if _, err := scopesClient.CreateClientScopeProtocolMapper(ctx, realmName, scopeID, desired); err != nil {
+				return fmt.Errorf("failed to create protocol mapper %s: %w", specMapper.Name, err)
+			}
+
+			continue
+		}
+
+		delete(existingByName, specMapper.Name)
+
+		if existing.Id == nil || (!forceUpdate && protocolMapperMatches(existing, desired)) {
+			continue
+		}
+
+		desired.Id = existing.Id
+
+		if _, err := scopesClient.UpdateClientScopeProtocolMapper(ctx, realmName, scopeID, *existing.Id, desired); err != nil {
+			return fmt.Errorf("failed to update protocol mapper %s: %w", specMapper.Name, err)
+		}
+	}
+
+	// Only mappers removed from the spec are deleted.
+	for name, mapper := range existingByName {
 		if mapper.Id == nil {
 			continue
 		}
 
 		if _, err := scopesClient.DeleteClientScopeProtocolMapper(ctx, realmName, scopeID, *mapper.Id); err != nil {
-			return fmt.Errorf("failed to delete protocol mapper %s: %w", *mapper.Id, err)
-		}
-	}
-
-	for _, specMapper := range scope.Spec.ProtocolMappers {
-		mapper := convertProtocolMapper(specMapper)
-
-		if _, err := scopesClient.CreateClientScopeProtocolMapper(ctx, realmName, scopeID, mapper); err != nil {
-			return fmt.Errorf("failed to create protocol mapper %s: %w", specMapper.Name, err)
+			return fmt.Errorf("failed to delete protocol mapper %s: %w", name, err)
 		}
 	}
 
 	log.Info("Protocol mappers have been synced")
 
 	return nil
+}
+
+func protocolMapperMatches(existing, desired keycloakapi.ProtocolMapperRepresentation) bool {
+	return ptr.Deref(existing.Protocol, "") == ptr.Deref(desired.Protocol, "") &&
+		ptr.Deref(existing.ProtocolMapper, "") == ptr.Deref(desired.ProtocolMapper, "") &&
+		containsConfig(ptr.Deref(existing.Config, nil), ptr.Deref(desired.Config, nil))
 }
 
 func convertProtocolMapper(m keycloakApi.ProtocolMapper) keycloakapi.ProtocolMapperRepresentation {

--- a/internal/controller/keycloakclientscope/chain/sync_protocol_mappers_test.go
+++ b/internal/controller/keycloakclientscope/chain/sync_protocol_mappers_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
@@ -14,20 +15,42 @@ import (
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi/mocks"
 )
 
-func TestSyncProtocolMappers_Serve_Success(t *testing.T) {
-	mockScopes := mocks.NewMockClientScopesClient(t)
-	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
+const (
+	testMapperID   = "mapper-id"
+	testMapperName = "groups"
+	testMapperType = "oidc-group-membership-mapper"
+)
 
+func groupsMapperScope(config map[string]string) *keycloakApi.KeycloakClientScope {
 	scope := &keycloakApi.KeycloakClientScope{}
 	scope.Status.ID = testScopeID
 	scope.Spec.ProtocolMappers = []keycloakApi.ProtocolMapper{
 		{
-			Name:           "groups",
+			Name:           testMapperName,
 			Protocol:       testProtocolOIDC,
-			ProtocolMapper: "oidc-group-membership-mapper",
-			Config:         map[string]string{"claim.name": "groups"},
+			ProtocolMapper: testMapperType,
+			Config:         config,
 		},
 	}
+
+	return scope
+}
+
+func groupsMapperRepr(config map[string]string) keycloakapi.ProtocolMapperRepresentation {
+	return keycloakapi.ProtocolMapperRepresentation{
+		Id:             ptr.To(testMapperID),
+		Name:           ptr.To(testMapperName),
+		Protocol:       ptr.To(testProtocolOIDC),
+		ProtocolMapper: ptr.To(testMapperType),
+		Config:         &config,
+	}
+}
+
+func TestSyncProtocolMappers_Serve_Success(t *testing.T) {
+	mockScopes := mocks.NewMockClientScopesClient(t)
+	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
+
+	scope := groupsMapperScope(map[string]string{"claim.name": "groups"})
 
 	// Existing mapper to delete
 	mockScopes.EXPECT().GetClientScopeProtocolMappers(
@@ -45,9 +68,9 @@ func TestSyncProtocolMappers_Serve_Success(t *testing.T) {
 	mockScopes.EXPECT().CreateClientScopeProtocolMapper(
 		context.Background(), testRealmName, testScopeID,
 		keycloakapi.ProtocolMapperRepresentation{
-			Name:           ptr.To("groups"),
+			Name:           ptr.To(testMapperName),
 			Protocol:       ptr.To(testProtocolOIDC),
-			ProtocolMapper: ptr.To("oidc-group-membership-mapper"),
+			ProtocolMapper: ptr.To(testMapperType),
 			Config:         &config,
 		},
 	).Return(nil, nil)
@@ -101,11 +124,11 @@ func TestSyncProtocolMappers_Serve_DeleteMapperError(t *testing.T) {
 	mockScopes.EXPECT().GetClientScopeProtocolMappers(
 		context.Background(), testRealmName, testScopeID,
 	).Return([]keycloakapi.ProtocolMapperRepresentation{
-		{Id: ptr.To("mapper-id"), Name: ptr.To("mapper")},
+		{Id: ptr.To(testMapperID), Name: ptr.To("mapper")},
 	}, nil, nil)
 
 	mockScopes.EXPECT().DeleteClientScopeProtocolMapper(
-		context.Background(), testRealmName, testScopeID, "mapper-id",
+		context.Background(), testRealmName, testScopeID, testMapperID,
 	).Return(nil, errors.New("delete error"))
 
 	h := NewSyncProtocolMappers(kClient)
@@ -131,6 +154,119 @@ func TestSyncProtocolMappers_Serve_NilMapperID(t *testing.T) {
 	h := NewSyncProtocolMappers(kClient)
 	err := h.Serve(context.Background(), scope, testRealmName)
 	require.NoError(t, err)
+}
+
+func TestSyncProtocolMappers_Serve_SkipWhenInSync(t *testing.T) {
+	mockScopes := mocks.NewMockClientScopesClient(t)
+	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
+
+	scope := groupsMapperScope(map[string]string{"claim.name": "groups"})
+
+	// Server-added default keys must not trigger an update.
+	// Existing state matches spec: no write calls expected.
+	mockScopes.EXPECT().GetClientScopeProtocolMappers(
+		context.Background(), testRealmName, testScopeID,
+	).Return([]keycloakapi.ProtocolMapperRepresentation{
+		groupsMapperRepr(map[string]string{"claim.name": "groups", "introspection.token.claim": "true"}),
+	}, nil, nil)
+
+	h := NewSyncProtocolMappers(kClient)
+	err := h.Serve(context.Background(), scope, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestSyncProtocolMappers_Serve_ForceUpdateOnSpecChange(t *testing.T) {
+	mockScopes := mocks.NewMockClientScopesClient(t)
+	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
+
+	// Generation ahead of ObservedGeneration: PUT must fire even though the
+	// declared keys match, so keys removed from the spec are dropped in Keycloak.
+	scope := groupsMapperScope(map[string]string{"claim.name": "groups"})
+	scope.Generation = 2
+	scope.Status.ObservedGeneration = 1
+
+	mockScopes.EXPECT().GetClientScopeProtocolMappers(
+		context.Background(), testRealmName, testScopeID,
+	).Return([]keycloakapi.ProtocolMapperRepresentation{
+		groupsMapperRepr(map[string]string{"claim.name": "groups", "removed.key": "stale"}),
+	}, nil, nil)
+
+	mockScopes.EXPECT().UpdateClientScopeProtocolMapper(
+		context.Background(), testRealmName, testScopeID, testMapperID,
+		groupsMapperRepr(map[string]string{"claim.name": "groups"}),
+	).Return(nil, nil)
+
+	h := NewSyncProtocolMappers(kClient)
+	err := h.Serve(context.Background(), scope, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestSyncProtocolMappers_Serve_EmptyValueKeyDetected(t *testing.T) {
+	mockScopes := mocks.NewMockClientScopesClient(t)
+	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
+
+	scope := groupsMapperScope(map[string]string{"empty.key": ""})
+
+	// Key absent server-side vs declared with "" value: must trigger an update.
+	mockScopes.EXPECT().GetClientScopeProtocolMappers(
+		context.Background(), testRealmName, testScopeID,
+	).Return([]keycloakapi.ProtocolMapperRepresentation{
+		groupsMapperRepr(map[string]string{}),
+	}, nil, nil)
+
+	mockScopes.EXPECT().UpdateClientScopeProtocolMapper(
+		context.Background(), testRealmName, testScopeID, testMapperID,
+		mock.Anything,
+	).Return(nil, nil)
+
+	h := NewSyncProtocolMappers(kClient)
+	err := h.Serve(context.Background(), scope, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestSyncProtocolMappers_Serve_UpdateChangedMapper(t *testing.T) {
+	mockScopes := mocks.NewMockClientScopesClient(t)
+	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
+
+	scope := groupsMapperScope(map[string]string{"claim.name": "groups", "full.path": "true"})
+
+	mockScopes.EXPECT().GetClientScopeProtocolMappers(
+		context.Background(), testRealmName, testScopeID,
+	).Return([]keycloakapi.ProtocolMapperRepresentation{
+		groupsMapperRepr(map[string]string{"claim.name": "groups", "full.path": "false"}),
+	}, nil, nil)
+
+	mockScopes.EXPECT().UpdateClientScopeProtocolMapper(
+		context.Background(), testRealmName, testScopeID, testMapperID,
+		groupsMapperRepr(map[string]string{"claim.name": "groups", "full.path": "true"}),
+	).Return(nil, nil)
+
+	h := NewSyncProtocolMappers(kClient)
+	err := h.Serve(context.Background(), scope, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestSyncProtocolMappers_Serve_UpdateMapperError(t *testing.T) {
+	mockScopes := mocks.NewMockClientScopesClient(t)
+	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
+
+	scope := groupsMapperScope(map[string]string{"claim.name": "changed"})
+
+	mockScopes.EXPECT().GetClientScopeProtocolMappers(
+		context.Background(), testRealmName, testScopeID,
+	).Return([]keycloakapi.ProtocolMapperRepresentation{
+		groupsMapperRepr(map[string]string{"claim.name": "groups"}),
+	}, nil, nil)
+
+	mockScopes.EXPECT().UpdateClientScopeProtocolMapper(
+		context.Background(), testRealmName, testScopeID, testMapperID,
+		mock.Anything,
+	).Return(nil, errors.New("update error"))
+
+	h := NewSyncProtocolMappers(kClient)
+	err := h.Serve(context.Background(), scope, testRealmName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update protocol mapper")
 }
 
 func TestSyncProtocolMappers_Serve_CreateMapperError(t *testing.T) {

--- a/internal/controller/keycloakclientscope/keycloakclientscope_controller.go
+++ b/internal/controller/keycloakclientscope/keycloakclientscope_controller.go
@@ -167,6 +167,7 @@ func (r *Reconcile) handleReconciliation(ctx context.Context, instance *keycloak
 	}
 
 	instance.Status.Value = common.StatusOK
+	instance.Status.ObservedGeneration = instance.Generation
 
 	if err := r.updateClientScopeStatus(ctx, instance, oldStatus); err != nil {
 		return reconcile.Result{}, err


### PR DESCRIPTION


Every reconcile unconditionally updated the scope, deleted and recreated all protocol mappers, and removed/re-added the realm default/optional scope assignment, flooding admin events and churning mapper IDs every 10 minutes even with no CR changes.

- CreateOrUpdateScope: update only when name/protocol/description/attributes differ
- SyncProtocolMappers: diff by mapper name - update in place, create missing, delete only mappers removed from the spec (same pattern as KeycloakClient put_protocol_mappers)
- SetScopeType: check realm default/optional list membership before remove/add, restoring the needToUpdateType guard lost in the keycloakv2 client migration

Config/attribute comparison checks only spec-declared keys because Keycloak adds default keys server-side (e.g. introspection.token.claim). To still propagate key removals through the PUT-based full-replace endpoints, status gains observedGeneration: a spec edit (generation bump) forces the write; in-sync checks apply only to already-reconciled generations.

