### PR TITLE
fix(KeycloakAuthFlow): skip Keycloak writes when state already matches spec

### DIFF
--- a/api/v1/keycloakauthflow_types.go
+++ b/api/v1/keycloakauthflow_types.go
@@ -93,6 +93,10 @@ type KeycloakAuthFlowStatus struct {
 	// ID is the Keycloak internal ID of the auth flow.
 	// +optional
 	ID string `json:"id,omitempty"`
+
+	// ObservedGeneration is the generation last successfully reconciled to Keycloak.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/v1.edp.epam.com_keycloakauthflows.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakauthflows.yaml
@@ -141,6 +141,11 @@ spec:
               id:
                 description: ID is the Keycloak internal ID of the auth flow.
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the generation last successfully
+                  reconciled to Keycloak.
+                format: int64
+                type: integer
               value:
                 type: string
             type: object

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakauthflows.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakauthflows.yaml
@@ -141,6 +141,11 @@ spec:
               id:
                 description: ID is the Keycloak internal ID of the auth flow.
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the generation last successfully
+                  reconciled to Keycloak.
+                format: int64
+                type: integer
               value:
                 type: string
             type: object

--- a/docs/api.md
+++ b/docs/api.md
@@ -2990,6 +2990,15 @@ KeycloakAuthFlowStatus defines the observed state of KeycloakAuthFlow.
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>observedGeneration</b></td>
+        <td>integer</td>
+        <td>
+          ObservedGeneration is the generation last successfully reconciled to Keycloak.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>value</b></td>
         <td>string</td>
         <td>

--- a/internal/controller/keycloakauthflow/chain/compare.go
+++ b/internal/controller/keycloakauthflow/chain/compare.go
@@ -1,0 +1,24 @@
+package chain
+
+import (
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+)
+
+// Update endpoints PUT the full representation: a spec edit must force the
+// write so keys removed from the spec are dropped in Keycloak.
+func specChanged(flow *keycloakApi.KeycloakAuthFlow) bool {
+	return flow.Generation != flow.Status.ObservedGeneration
+}
+
+// Keycloak may inject default config keys server-side;
+// exact comparison would never converge.
+func containsConfig(existing, desired map[string]string) bool {
+	for k, v := range desired {
+		existingValue, ok := existing[k]
+		if !ok || existingValue != v {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/controller/keycloakauthflow/chain/create_or_update_auth_flow.go
+++ b/internal/controller/keycloakauthflow/chain/create_or_update_auth_flow.go
@@ -49,12 +49,14 @@ func (h *CreateOrUpdateAuthFlow) serveTopLevelFlow(ctx context.Context, flow *ke
 				return fmt.Errorf("auth flow %q has no ID", flow.Spec.Alias)
 			}
 
-			log.Info("Top-level auth flow already exists, updating", "alias", flow.Spec.Alias)
-
 			flow.Status.ID = *flows[i].Id
 
-			if _, err = h.kClient.AuthFlows.UpdateAuthFlow(ctx, realmName, *flows[i].Id, authFlowRepFromSpec(flow.Spec)); err != nil {
-				return fmt.Errorf("failed to update auth flow: %w", err)
+			if !authFlowMatchesSpec(&flows[i], flow.Spec) {
+				log.Info("Top-level auth flow already exists, updating", "alias", flow.Spec.Alias)
+
+				if _, err = h.kClient.AuthFlows.UpdateAuthFlow(ctx, realmName, *flows[i].Id, authFlowRepFromSpec(flow.Spec)); err != nil {
+					return fmt.Errorf("failed to update auth flow: %w", err)
+				}
 			}
 
 			return h.validateChildFlows(ctx, flow, realmName)
@@ -170,6 +172,15 @@ func (h *CreateOrUpdateAuthFlow) validateChildFlows(ctx context.Context, flow *k
 	}
 
 	return nil
+}
+
+// authFlowMatchesSpec reports whether existing already carries the fields authFlowRepFromSpec would write.
+func authFlowMatchesSpec(existing *keycloakapi.AuthFlowRepresentation, spec keycloakApi.KeycloakAuthFlowSpec) bool {
+	return ptr.Deref(existing.Alias, "") == spec.Alias &&
+		ptr.Deref(existing.Description, "") == spec.Description &&
+		ptr.Deref(existing.ProviderId, "") == spec.ProviderID &&
+		ptr.Deref(existing.BuiltIn, false) == spec.BuiltIn &&
+		ptr.Deref(existing.TopLevel, false) == spec.TopLevel
 }
 
 func authFlowRepFromSpec(spec keycloakApi.KeycloakAuthFlowSpec) keycloakapi.AuthFlowRepresentation {

--- a/internal/controller/keycloakauthflow/chain/create_or_update_auth_flow_test.go
+++ b/internal/controller/keycloakauthflow/chain/create_or_update_auth_flow_test.go
@@ -20,6 +20,7 @@ const (
 	testParentFlow = "parent-flow"
 	testChildAlias = "child-flow"
 	testProviderID = "basic-flow"
+	testFlowDesc   = "desc"
 )
 
 func TestCreateOrUpdateAuthFlow_TopLevel_Create(t *testing.T) {
@@ -28,7 +29,7 @@ func TestCreateOrUpdateAuthFlow_TopLevel_Create(t *testing.T) {
 
 	flow := &keycloakApi.KeycloakAuthFlow{}
 	flow.Spec.Alias = testFlowAlias
-	flow.Spec.Description = "desc"
+	flow.Spec.Description = testFlowDesc
 	flow.Spec.ProviderID = testProviderID
 	flow.Spec.TopLevel = true
 
@@ -41,7 +42,7 @@ func TestCreateOrUpdateAuthFlow_TopLevel_Create(t *testing.T) {
 		context.Background(), testRealmName,
 		keycloakapi.AuthFlowRepresentation{
 			Alias:       ptr.To(testFlowAlias),
-			Description: ptr.To("desc"),
+			Description: ptr.To(testFlowDesc),
 			ProviderId:  ptr.To(testProviderID),
 			BuiltIn:     ptr.To(false),
 			TopLevel:    ptr.To(true),
@@ -55,7 +56,39 @@ func TestCreateOrUpdateAuthFlow_TopLevel_Create(t *testing.T) {
 	assert.Equal(t, testFlowID, flow.Status.ID)
 }
 
-func TestCreateOrUpdateAuthFlow_TopLevel_AlreadyExists(t *testing.T) {
+// existingTopLevelFlowRep builds the fetched representation of the sample top-level flow.
+func existingTopLevelFlowRep(description string) keycloakapi.AuthFlowRepresentation {
+	return keycloakapi.AuthFlowRepresentation{
+		Alias:       ptr.To(testFlowAlias),
+		Id:          ptr.To(testFlowID),
+		Description: ptr.To(description),
+		ProviderId:  ptr.To(testProviderID),
+		BuiltIn:     ptr.To(false),
+		TopLevel:    ptr.To(true),
+	}
+}
+
+func TestCreateOrUpdateAuthFlow_TopLevel_InSync(t *testing.T) {
+	mockFlows := mocks.NewMockAuthFlowsClient(t)
+	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
+
+	flow := &keycloakApi.KeycloakAuthFlow{}
+	flow.Spec.Alias = testFlowAlias
+	flow.Spec.Description = testFlowDesc
+	flow.Spec.ProviderID = testProviderID
+	flow.Spec.TopLevel = true
+
+	// Flow already exists and already matches spec — UpdateAuthFlow must NOT be called
+	mockFlows.EXPECT().GetAuthFlows(context.Background(), testRealmName).
+		Return([]keycloakapi.AuthFlowRepresentation{existingTopLevelFlowRep(testFlowDesc)}, nil, nil)
+
+	h := NewCreateOrUpdateAuthFlow(kc)
+	err := h.Serve(context.Background(), flow, testRealmName)
+	require.NoError(t, err)
+	assert.Equal(t, testFlowID, flow.Status.ID)
+}
+
+func TestCreateOrUpdateAuthFlow_TopLevel_DiffersFromSpec(t *testing.T) {
 	mockFlows := mocks.NewMockAuthFlowsClient(t)
 	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
 
@@ -65,11 +98,9 @@ func TestCreateOrUpdateAuthFlow_TopLevel_AlreadyExists(t *testing.T) {
 	flow.Spec.ProviderID = testProviderID
 	flow.Spec.TopLevel = true
 
-	// Flow already exists
+	// Flow already exists but description differs
 	mockFlows.EXPECT().GetAuthFlows(context.Background(), testRealmName).
-		Return([]keycloakapi.AuthFlowRepresentation{
-			{Alias: ptr.To(testFlowAlias), Id: ptr.To(testFlowID)},
-		}, nil, nil)
+		Return([]keycloakapi.AuthFlowRepresentation{existingTopLevelFlowRep("stale-desc")}, nil, nil)
 
 	// UpdateAuthFlow must be called with updated fields; CreateAuthFlow must NOT be called
 	mockFlows.EXPECT().UpdateAuthFlow(
@@ -82,6 +113,27 @@ func TestCreateOrUpdateAuthFlow_TopLevel_AlreadyExists(t *testing.T) {
 			TopLevel:    ptr.To(true),
 		},
 	).Return(nil, nil)
+
+	h := NewCreateOrUpdateAuthFlow(kc)
+	err := h.Serve(context.Background(), flow, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestCreateOrUpdateAuthFlow_TopLevel_InSyncIgnoresGeneration(t *testing.T) {
+	mockFlows := mocks.NewMockAuthFlowsClient(t)
+	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
+
+	flow := &keycloakApi.KeycloakAuthFlow{}
+	flow.Generation = 2
+	flow.Status.ObservedGeneration = 1
+	flow.Spec.Alias = testFlowAlias
+	flow.Spec.Description = testFlowDesc
+	flow.Spec.ProviderID = testProviderID
+	flow.Spec.TopLevel = true
+
+	// Flow scalar fields are exact diffs: matching state needs no write even on generation drift.
+	mockFlows.EXPECT().GetAuthFlows(context.Background(), testRealmName).
+		Return([]keycloakapi.AuthFlowRepresentation{existingTopLevelFlowRep(testFlowDesc)}, nil, nil)
 
 	h := NewCreateOrUpdateAuthFlow(kc)
 	err := h.Serve(context.Background(), flow, testRealmName)
@@ -165,20 +217,9 @@ func TestCreateOrUpdateAuthFlow_ValidateChildFlows_NotAllCreated(t *testing.T) {
 		{AuthenticatorFlow: true, Alias: "sub-flow"},
 	}
 
-	// Flow exists (with ID so UpdateAuthFlow is called)
+	// Existing flow matches spec → no UpdateAuthFlow
 	mockFlows.EXPECT().GetAuthFlows(context.Background(), testRealmName).
 		Return([]keycloakapi.AuthFlowRepresentation{{Alias: ptr.To(testFlowAlias), Id: ptr.To(testFlowID)}}, nil, nil)
-
-	mockFlows.EXPECT().UpdateAuthFlow(
-		context.Background(), testRealmName, testFlowID,
-		keycloakapi.AuthFlowRepresentation{
-			Alias:       ptr.To(testFlowAlias),
-			Description: ptr.To(""),
-			ProviderId:  ptr.To(""),
-			BuiltIn:     ptr.To(false),
-			TopLevel:    ptr.To(false),
-		},
-	).Return(nil, nil)
 
 	// validateChildFlows: GetFlowExecutions returns non-flow execution only → 0 child flows
 	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
@@ -202,19 +243,9 @@ func TestCreateOrUpdateAuthFlow_ValidateChildFlows_AllCreated(t *testing.T) {
 		{AuthenticatorFlow: true, Alias: "sub-flow"},
 	}
 
+	// Existing flow matches spec → no UpdateAuthFlow
 	mockFlows.EXPECT().GetAuthFlows(context.Background(), testRealmName).
 		Return([]keycloakapi.AuthFlowRepresentation{{Alias: ptr.To(testFlowAlias), Id: ptr.To(testFlowID)}}, nil, nil)
-
-	mockFlows.EXPECT().UpdateAuthFlow(
-		context.Background(), testRealmName, testFlowID,
-		keycloakapi.AuthFlowRepresentation{
-			Alias:       ptr.To(testFlowAlias),
-			Description: ptr.To(""),
-			ProviderId:  ptr.To(""),
-			BuiltIn:     ptr.To(false),
-			TopLevel:    ptr.To(false),
-		},
-	).Return(nil, nil)
 
 	// validateChildFlows: one AuthenticationFlow=true, Level=0 execution → 1 child
 	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).

--- a/internal/controller/keycloakauthflow/chain/sync_auth_flow_executions.go
+++ b/internal/controller/keycloakauthflow/chain/sync_auth_flow_executions.go
@@ -1,10 +1,12 @@
 package chain
 
 import (
+	"cmp"
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
@@ -12,7 +14,8 @@ import (
 )
 
 // SyncAuthFlowExecutions syncs authentication executions for an auth flow.
-// It clears all existing non-flow executions and recreates them from the spec.
+// Non-flow executions have no name in Keycloak; they are paired with spec entries by
+// authenticator (duplicates paired by priority order within the group) and only diffs are written.
 // This ports the execution-sync logic from the legacy gocloak adapter.
 type SyncAuthFlowExecutions struct {
 	kClient *keycloakapi.KeycloakClient
@@ -22,28 +25,228 @@ func NewSyncAuthFlowExecutions(kClient *keycloakapi.KeycloakClient) *SyncAuthFlo
 	return &SyncAuthFlowExecutions{kClient: kClient}
 }
 
+// executionPair matches an existing Keycloak execution to its spec counterpart.
+type executionPair struct {
+	existing keycloakapi.AuthenticationExecutionInfoRepresentation
+	desired  keycloakApi.AuthenticationExecution
+}
+
 func (h *SyncAuthFlowExecutions) Serve(ctx context.Context, flow *keycloakApi.KeycloakAuthFlow, realmName string) error {
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Syncing auth flow executions", "alias", flow.Spec.Alias)
 
-	if err := h.clearNonFlowExecutions(ctx, flow.Spec.Alias, realmName); err != nil {
-		return fmt.Errorf("failed to clear flow executions: %w", err)
+	execs, _, err := h.kClient.AuthFlows.GetFlowExecutions(ctx, realmName, flow.Spec.Alias)
+	if err != nil {
+		return fmt.Errorf("failed to get flow executions: %w", err)
 	}
 
-	// Collect only non-flow executions from spec (flow-type executions are managed
-	// by separate child KeycloakAuthFlow resources).
-	var execsToAdd []keycloakApi.AuthenticationExecution
+	if err := h.syncNonFlowExecutions(ctx, flow, realmName, execs); err != nil {
+		return err
+	}
+
+	// Non-flow writes above never touch flow-type siblings, so the fetched list stays valid.
+	return h.adjustChildFlowsPriority(ctx, flow, realmName, execs)
+}
+
+func (h *SyncAuthFlowExecutions) syncNonFlowExecutions(
+	ctx context.Context,
+	flow *keycloakApi.KeycloakAuthFlow,
+	realmName string,
+	execs []keycloakapi.AuthenticationExecutionInfoRepresentation,
+) error {
+	existing := make([]keycloakapi.AuthenticationExecutionInfoRepresentation, 0, len(execs))
+
+	for i := range execs {
+		e := &execs[i]
+
+		isFlowExec := e.AuthenticationFlow != nil && *e.AuthenticationFlow
+		isTopLevel := e.Level != nil && *e.Level == 0
+
+		if isFlowExec || !isTopLevel {
+			continue
+		}
+
+		existing = append(existing, *e)
+	}
+
+	var desired []keycloakApi.AuthenticationExecution
 
 	for _, e := range flow.Spec.AuthenticationExecutions {
 		if !e.AuthenticatorFlow {
-			execsToAdd = append(execsToAdd, e)
+			desired = append(desired, e)
 		}
 	}
 
-	if len(execsToAdd) == 0 {
-		log.Info("No non-flow executions to sync")
+	pairs, unmatchedExisting, unmatchedDesired := pairExecutionsByAuthenticator(existing, desired)
 
-		return h.adjustChildFlowsPriority(ctx, flow, realmName)
+	forceUpdate := specChanged(flow)
+
+	for _, p := range pairs {
+		if err := h.syncPairedExecution(ctx, flow.Spec.Alias, realmName, p, forceUpdate); err != nil {
+			return err
+		}
+	}
+
+	// Deletes go first so an added execution never transiently shares a priority slot.
+	for i := range unmatchedExisting {
+		if err := h.deleteExecution(ctx, realmName, &unmatchedExisting[i]); err != nil {
+			return err
+		}
+	}
+
+	return h.addExecutions(ctx, flow, realmName, unmatchedDesired)
+}
+
+// pairExecutionsByAuthenticator matches existing Keycloak executions to spec entries by
+// authenticator. The spec may list the same authenticator more than once; each side's group
+// is sorted by priority and paired index-wise.
+func pairExecutionsByAuthenticator(
+	existing []keycloakapi.AuthenticationExecutionInfoRepresentation,
+	desired []keycloakApi.AuthenticationExecution,
+) (pairs []executionPair, unmatchedExisting []keycloakapi.AuthenticationExecutionInfoRepresentation, unmatchedDesired []keycloakApi.AuthenticationExecution) {
+	existingByAuth := make(map[string][]keycloakapi.AuthenticationExecutionInfoRepresentation)
+
+	for _, e := range existing {
+		key := ptr.Deref(e.ProviderId, "")
+		existingByAuth[key] = append(existingByAuth[key], e)
+	}
+
+	desiredByAuth := make(map[string][]keycloakApi.AuthenticationExecution)
+	for _, e := range desired {
+		desiredByAuth[e.Authenticator] = append(desiredByAuth[e.Authenticator], e)
+	}
+
+	for auth, existGroup := range existingByAuth {
+		// Stable sorts keep pairing deterministic when priorities tie.
+		slices.SortStableFunc(existGroup, func(a, b keycloakapi.AuthenticationExecutionInfoRepresentation) int {
+			return cmp.Compare(ptr.Deref(a.Priority, 0), ptr.Deref(b.Priority, 0))
+		})
+
+		desireGroup := desiredByAuth[auth]
+		slices.SortStableFunc(desireGroup, func(a, b keycloakApi.AuthenticationExecution) int {
+			return cmp.Compare(a.Priority, b.Priority)
+		})
+
+		paired := min(len(existGroup), len(desireGroup))
+
+		for i := 0; i < paired; i++ {
+			pairs = append(pairs, executionPair{existing: existGroup[i], desired: desireGroup[i]})
+		}
+
+		unmatchedExisting = append(unmatchedExisting, existGroup[paired:]...)
+		unmatchedDesired = append(unmatchedDesired, desireGroup[paired:]...)
+
+		delete(desiredByAuth, auth)
+	}
+
+	for _, desireGroup := range desiredByAuth {
+		unmatchedDesired = append(unmatchedDesired, desireGroup...)
+	}
+
+	return pairs, unmatchedExisting, unmatchedDesired
+}
+
+// syncPairedExecution updates an existing execution in place when its requirement or priority
+// drifts from spec, then reconciles its authenticator config. Executions are never
+// deleted and recreated to keep their Keycloak ID (and position) stable.
+func (h *SyncAuthFlowExecutions) syncPairedExecution(
+	ctx context.Context, flowAlias, realmName string, p executionPair, forceUpdate bool,
+) error {
+	existing := p.existing
+	desired := p.desired
+
+	// Requirement and priority are exact scalar diffs; no force needed to converge.
+	requirementDiffers := ptr.Deref(existing.Requirement, "") != desired.Requirement
+	priorityDiffers := ptr.Deref(existing.Priority, 0) != int32(desired.Priority)
+
+	if requirementDiffers || priorityDiffers {
+		existing.Requirement = ptr.To(desired.Requirement)
+		existing.Priority = ptr.To(int32(desired.Priority))
+
+		if _, err := h.kClient.AuthFlows.UpdateFlowExecution(ctx, realmName, flowAlias, existing); err != nil {
+			return fmt.Errorf("failed to update execution %q: %w", desired.Authenticator, err)
+		}
+	}
+
+	return h.syncExecutionConfig(ctx, realmName, existing, desired, forceUpdate)
+}
+
+// syncExecutionConfig reconciles the authenticator config of a paired execution: creates it
+// when only the spec has one, deletes it when only Keycloak has one, and updates it in place
+// when both have one but the alias or values drifted.
+func (h *SyncAuthFlowExecutions) syncExecutionConfig(
+	ctx context.Context,
+	realmName string,
+	existing keycloakapi.AuthenticationExecutionInfoRepresentation,
+	desired keycloakApi.AuthenticationExecution,
+	forceUpdate bool,
+) error {
+	existingConfigID := existing.AuthenticationConfig
+	desiredConfig := desired.AuthenticatorConfig
+
+	switch {
+	case desiredConfig == nil && existingConfigID == nil:
+		return nil
+	case desiredConfig != nil && existingConfigID == nil:
+		execID := ptr.Deref(existing.Id, "")
+		if execID == "" {
+			return fmt.Errorf("execution %q has no ID; cannot create config", desired.Authenticator)
+		}
+
+		return h.createExecutionConfig(ctx, realmName, execID, desiredConfig)
+	case desiredConfig == nil && existingConfigID != nil:
+		if _, err := h.kClient.AuthFlows.DeleteAuthenticatorConfig(ctx, realmName, *existingConfigID); err != nil && !keycloakapi.IsNotFound(err) {
+			return fmt.Errorf("failed to delete authenticator config %q: %w", *existingConfigID, err)
+		}
+
+		return nil
+	default:
+		return h.updateExecutionConfigIfNeeded(ctx, realmName, ptr.Deref(existing.Id, ""), *existingConfigID, desiredConfig, forceUpdate)
+	}
+}
+
+func (h *SyncAuthFlowExecutions) updateExecutionConfigIfNeeded(
+	ctx context.Context,
+	realmName, execID, configID string,
+	desiredConfig *keycloakApi.AuthenticatorConfig,
+	forceUpdate bool,
+) error {
+	if !forceUpdate {
+		existingCfg, _, err := h.kClient.AuthFlows.GetAuthenticatorConfig(ctx, realmName, configID)
+		if err != nil && !keycloakapi.IsNotFound(err) {
+			return fmt.Errorf("failed to get authenticator config %q: %w", configID, err)
+		}
+
+		if existingCfg != nil &&
+			ptr.Deref(existingCfg.Alias, "") == desiredConfig.Alias &&
+			containsConfig(ptr.Deref(existingCfg.Config, nil), desiredConfig.Config) {
+			return nil
+		}
+	}
+
+	_, err := h.kClient.AuthFlows.UpdateAuthenticatorConfig(ctx, realmName, configID, keycloakapi.AuthenticatorConfigRepresentation{
+		Id:     &configID,
+		Alias:  &desiredConfig.Alias,
+		Config: &desiredConfig.Config,
+	})
+	if err == nil {
+		return nil
+	}
+
+	if !keycloakapi.IsNotFound(err) {
+		return fmt.Errorf("failed to update authenticator config %q: %w", configID, err)
+	}
+
+	// Dangling config reference: the execution points at a config that no longer exists.
+	return h.createExecutionConfig(ctx, realmName, execID, desiredConfig)
+}
+
+// addExecutions posts spec entries that had no matching existing execution.
+func (h *SyncAuthFlowExecutions) addExecutions(
+	ctx context.Context, flow *keycloakApi.KeycloakAuthFlow, realmName string, execsToAdd []keycloakApi.AuthenticationExecution,
+) error {
+	if len(execsToAdd) == 0 {
+		return nil
 	}
 
 	// The flow's internal Keycloak ID is set by the preceding CreateOrUpdateAuthFlow chain step.
@@ -53,8 +256,8 @@ func (h *SyncAuthFlowExecutions) Serve(ctx context.Context, flow *keycloakApi.Ke
 	}
 
 	// Sort by priority before adding (mirrors legacy adapter behaviour).
-	sort.Slice(execsToAdd, func(i, j int) bool {
-		return execsToAdd[i].Priority < execsToAdd[j].Priority
+	slices.SortStableFunc(execsToAdd, func(a, b keycloakApi.AuthenticationExecution) int {
+		return cmp.Compare(a.Priority, b.Priority)
 	})
 
 	for i := range execsToAdd {
@@ -72,38 +275,26 @@ func (h *SyncAuthFlowExecutions) Serve(ctx context.Context, flow *keycloakApi.Ke
 		}
 	}
 
-	return h.adjustChildFlowsPriority(ctx, flow, realmName)
+	return nil
 }
 
-// clearNonFlowExecutions deletes all top-level non-flow executions from the flow.
-func (h *SyncAuthFlowExecutions) clearNonFlowExecutions(ctx context.Context, flowAlias, realmName string) error {
-	execs, _, err := h.kClient.AuthFlows.GetFlowExecutions(ctx, realmName, flowAlias)
-	if err != nil {
-		return fmt.Errorf("failed to get flow executions: %w", err)
+// deleteExecution removes an execution that left the spec, along with its authenticator config.
+func (h *SyncAuthFlowExecutions) deleteExecution(
+	ctx context.Context, realmName string, e *keycloakapi.AuthenticationExecutionInfoRepresentation,
+) error {
+	if e.AuthenticationConfig != nil {
+		if _, err := h.kClient.AuthFlows.DeleteAuthenticatorConfig(ctx, realmName, *e.AuthenticationConfig); err != nil && !keycloakapi.IsNotFound(err) {
+			return fmt.Errorf("failed to delete authenticator config %q: %w", *e.AuthenticationConfig, err)
+		}
 	}
 
-	for i := range execs {
-		e := &execs[i]
+	execID := ptr.Deref(e.Id, "")
+	if execID == "" {
+		return nil
+	}
 
-		isFlowExec := e.AuthenticationFlow != nil && *e.AuthenticationFlow
-		isTopLevel := e.Level != nil && *e.Level == 0
-
-		if isFlowExec || !isTopLevel {
-			continue
-		}
-
-		execID := ""
-		if e.Id != nil {
-			execID = *e.Id
-		}
-
-		if execID == "" {
-			continue
-		}
-
-		if _, err := h.kClient.AuthFlows.DeleteExecution(ctx, realmName, execID); err != nil {
-			return fmt.Errorf("failed to delete execution %q: %w", execID, err)
-		}
+	if _, err := h.kClient.AuthFlows.DeleteExecution(ctx, realmName, execID); err != nil {
+		return fmt.Errorf("failed to delete execution %q: %w", execID, err)
 	}
 
 	return nil
@@ -154,7 +345,12 @@ func (h *SyncAuthFlowExecutions) createExecutionConfig(
 
 // adjustChildFlowsPriority updates priority (and requirement) of flow-type executions
 // to match the spec. Ports adjustChildFlowsPriority from the legacy adapter.
-func (h *SyncAuthFlowExecutions) adjustChildFlowsPriority(ctx context.Context, flow *keycloakApi.KeycloakAuthFlow, realmName string) error {
+func (h *SyncAuthFlowExecutions) adjustChildFlowsPriority(
+	ctx context.Context,
+	flow *keycloakApi.KeycloakAuthFlow,
+	realmName string,
+	execs []keycloakapi.AuthenticationExecutionInfoRepresentation,
+) error {
 	// Build a map of alias -> spec execution for flow-type entries.
 	childFlowSpecs := make(map[string]keycloakApi.AuthenticationExecution)
 
@@ -166,11 +362,6 @@ func (h *SyncAuthFlowExecutions) adjustChildFlowsPriority(ctx context.Context, f
 
 	if len(childFlowSpecs) == 0 {
 		return nil
-	}
-
-	execs, _, err := h.kClient.AuthFlows.GetFlowExecutions(ctx, realmName, flow.Spec.Alias)
-	if err != nil {
-		return fmt.Errorf("failed to get flow executions for priority adjustment: %w", err)
 	}
 
 	for i := range execs {

--- a/internal/controller/keycloakauthflow/chain/sync_auth_flow_executions_test.go
+++ b/internal/controller/keycloakauthflow/chain/sync_auth_flow_executions_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
@@ -27,6 +28,35 @@ func locationResponse(id string) *keycloakapi.Response {
 	}
 }
 
+// setIdpRedirectorSpec fills the spec with one configured identity-provider-redirector execution.
+func setIdpRedirectorSpec(flow *keycloakApi.KeycloakAuthFlow) {
+	flow.Spec.Alias = testFlowAlias
+	flow.Spec.AuthenticationExecutions = []keycloakApi.AuthenticationExecution{
+		{
+			Authenticator: "identity-provider-redirector",
+			Requirement:   "ALTERNATIVE",
+			Priority:      10,
+			AuthenticatorConfig: &keycloakApi.AuthenticatorConfig{
+				Alias:  "idp-config",
+				Config: map[string]string{"defaultProvider": "github"},
+			},
+		},
+	}
+}
+
+// nonFlowExec builds a top-level, non-flow execution as returned by GetFlowExecutions.
+func nonFlowExec(id, providerID, requirement string, priority int32, configID *string) keycloakapi.AuthenticationExecutionInfoRepresentation {
+	return keycloakapi.AuthenticationExecutionInfoRepresentation{
+		Id:                   ptr.To(id),
+		ProviderId:           ptr.To(providerID),
+		AuthenticationFlow:   ptr.To(false),
+		Level:                ptr.To(int32(0)),
+		Requirement:          ptr.To(requirement),
+		Priority:             ptr.To(priority),
+		AuthenticationConfig: configID,
+	}
+}
+
 func TestSyncAuthFlowExecutions_Serve_NoExistingNoSpec(t *testing.T) {
 	mockFlows := mocks.NewMockAuthFlowsClient(t)
 	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
@@ -34,32 +64,8 @@ func TestSyncAuthFlowExecutions_Serve_NoExistingNoSpec(t *testing.T) {
 	flow := &keycloakApi.KeycloakAuthFlow{}
 	flow.Spec.Alias = testFlowAlias
 
-	// clearNonFlowExecutions: nothing to delete
 	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
 		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{}, nil, nil)
-
-	// adjustChildFlowsPriority: no child flow specs → returns immediately
-
-	h := NewSyncAuthFlowExecutions(kc)
-	err := h.Serve(context.Background(), flow, testRealmName)
-	require.NoError(t, err)
-}
-
-func TestSyncAuthFlowExecutions_Serve_ClearExistingNonFlowExec(t *testing.T) {
-	mockFlows := mocks.NewMockAuthFlowsClient(t)
-	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
-
-	flow := &keycloakApi.KeycloakAuthFlow{}
-	flow.Spec.Alias = testFlowAlias
-
-	// clearNonFlowExecutions: one non-flow top-level exec to delete
-	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
-		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{
-			{Id: ptr.To("old-exec"), AuthenticationFlow: ptr.To(false), Level: ptr.To(int32(0))},
-		}, nil, nil)
-
-	mockFlows.EXPECT().DeleteExecution(context.Background(), testRealmName, "old-exec").
-		Return(nil, nil)
 
 	h := NewSyncAuthFlowExecutions(kc)
 	err := h.Serve(context.Background(), flow, testRealmName)
@@ -72,14 +78,199 @@ func TestSyncAuthFlowExecutions_Serve_SkipFlowTypeExec(t *testing.T) {
 
 	flow := &keycloakApi.KeycloakAuthFlow{}
 	flow.Spec.Alias = testFlowAlias
+	flow.Spec.AuthenticationExecutions = []keycloakApi.AuthenticationExecution{
+		{Alias: "sub-flow", AuthenticatorFlow: true},
+	}
 
-	// clearNonFlowExecutions: one flow-type exec — must NOT be deleted
+	// Flow-type exec is filtered from the non-flow sync; spec entry already matches → no update
 	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
 		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{
-			{Id: ptr.To("flow-exec"), AuthenticationFlow: ptr.To(true), Level: ptr.To(int32(0))},
+			{Id: ptr.To("flow-exec"), DisplayName: ptr.To("sub-flow"), AuthenticationFlow: ptr.To(true), Level: ptr.To(int32(0)), Priority: ptr.To(int32(0))},
+		}, nil, nil).Once()
+
+	h := NewSyncAuthFlowExecutions(kc)
+	err := h.Serve(context.Background(), flow, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestSyncAuthFlowExecutions_Serve_InSync(t *testing.T) {
+	mockFlows := mocks.NewMockAuthFlowsClient(t)
+	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
+
+	flow := &keycloakApi.KeycloakAuthFlow{}
+	flow.Spec.Alias = testFlowAlias
+	flow.Spec.AuthenticationExecutions = []keycloakApi.AuthenticationExecution{
+		{Authenticator: "basic-auth", Requirement: "REQUIRED", Priority: 10},
+	}
+
+	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
+		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{
+			nonFlowExec("exec-1", "basic-auth", "REQUIRED", 10, nil),
 		}, nil, nil)
 
-	// DeleteExecution must NOT be called
+	h := NewSyncAuthFlowExecutions(kc)
+	err := h.Serve(context.Background(), flow, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestSyncAuthFlowExecutions_Serve_RequirementDrift(t *testing.T) {
+	mockFlows := mocks.NewMockAuthFlowsClient(t)
+	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
+
+	flow := &keycloakApi.KeycloakAuthFlow{}
+	flow.Spec.Alias = testFlowAlias
+	flow.Spec.AuthenticationExecutions = []keycloakApi.AuthenticationExecution{
+		{Authenticator: "basic-auth", Requirement: "REQUIRED", Priority: 10},
+	}
+
+	existing := nonFlowExec("exec-1", "basic-auth", "DISABLED", 10, nil)
+
+	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
+		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{existing}, nil, nil)
+
+	updated := existing
+	updated.Requirement = ptr.To("REQUIRED")
+	updated.Priority = ptr.To(int32(10))
+
+	mockFlows.EXPECT().UpdateFlowExecution(context.Background(), testRealmName, testFlowAlias, updated).
+		Return(nil, nil)
+
+	h := NewSyncAuthFlowExecutions(kc)
+	err := h.Serve(context.Background(), flow, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestSyncAuthFlowExecutions_Serve_PriorityDrift(t *testing.T) {
+	mockFlows := mocks.NewMockAuthFlowsClient(t)
+	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
+
+	flow := &keycloakApi.KeycloakAuthFlow{}
+	flow.Spec.Alias = testFlowAlias
+	flow.Spec.AuthenticationExecutions = []keycloakApi.AuthenticationExecution{
+		{Authenticator: "basic-auth", Requirement: "REQUIRED", Priority: 30},
+	}
+
+	existing := nonFlowExec("exec-1", "basic-auth", "REQUIRED", 10, nil)
+
+	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
+		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{existing}, nil, nil)
+
+	updated := existing
+	updated.Priority = ptr.To(int32(30))
+
+	mockFlows.EXPECT().UpdateFlowExecution(context.Background(), testRealmName, testFlowAlias, updated).
+		Return(nil, nil)
+
+	h := NewSyncAuthFlowExecutions(kc)
+	err := h.Serve(context.Background(), flow, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestSyncAuthFlowExecutions_Serve_ConfigDrift(t *testing.T) {
+	mockFlows := mocks.NewMockAuthFlowsClient(t)
+	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
+
+	const configID = "cfg-1"
+
+	flow := &keycloakApi.KeycloakAuthFlow{}
+	setIdpRedirectorSpec(flow)
+
+	existing := nonFlowExec("exec-1", "identity-provider-redirector", "ALTERNATIVE", 10, ptr.To(configID))
+
+	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
+		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{existing}, nil, nil)
+
+	existingConfig := map[string]string{"defaultProvider": "gitlab"}
+	mockFlows.EXPECT().GetAuthenticatorConfig(context.Background(), testRealmName, configID).
+		Return(&keycloakapi.AuthenticatorConfigRepresentation{
+			Id:     ptr.To(configID),
+			Alias:  ptr.To("idp-config"),
+			Config: &existingConfig,
+		}, nil, nil)
+
+	desiredConfig := map[string]string{"defaultProvider": "github"}
+	mockFlows.EXPECT().UpdateAuthenticatorConfig(context.Background(), testRealmName, configID,
+		keycloakapi.AuthenticatorConfigRepresentation{
+			Id:     ptr.To(configID),
+			Alias:  ptr.To("idp-config"),
+			Config: &desiredConfig,
+		},
+	).Return(nil, nil)
+
+	h := NewSyncAuthFlowExecutions(kc)
+	err := h.Serve(context.Background(), flow, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestSyncAuthFlowExecutions_Serve_ConfigRemovedFromSpec(t *testing.T) {
+	mockFlows := mocks.NewMockAuthFlowsClient(t)
+	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
+
+	const configID = "cfg-2"
+
+	flow := &keycloakApi.KeycloakAuthFlow{}
+	flow.Spec.Alias = testFlowAlias
+	flow.Spec.AuthenticationExecutions = []keycloakApi.AuthenticationExecution{
+		{Authenticator: "basic-auth", Requirement: "REQUIRED", Priority: 10},
+	}
+
+	existing := nonFlowExec("exec-1", "basic-auth", "REQUIRED", 10, ptr.To(configID))
+
+	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
+		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{existing}, nil, nil)
+
+	mockFlows.EXPECT().DeleteAuthenticatorConfig(context.Background(), testRealmName, configID).
+		Return(nil, nil)
+
+	h := NewSyncAuthFlowExecutions(kc)
+	err := h.Serve(context.Background(), flow, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestSyncAuthFlowExecutions_Serve_ExecutionRemovedFromSpec(t *testing.T) {
+	mockFlows := mocks.NewMockAuthFlowsClient(t)
+	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
+
+	const configID = "cfg-3"
+
+	flow := &keycloakApi.KeycloakAuthFlow{}
+	flow.Spec.Alias = testFlowAlias
+
+	existing := nonFlowExec("exec-removed", "old-auth", "REQUIRED", 10, ptr.To(configID))
+
+	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
+		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{existing}, nil, nil)
+
+	mockFlows.EXPECT().DeleteAuthenticatorConfig(context.Background(), testRealmName, configID).
+		Return(nil, nil)
+
+	mockFlows.EXPECT().DeleteExecution(context.Background(), testRealmName, "exec-removed").
+		Return(nil, nil)
+
+	h := NewSyncAuthFlowExecutions(kc)
+	err := h.Serve(context.Background(), flow, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestSyncAuthFlowExecutions_Serve_ExecutionRemovedFromSpec_ConfigDeleteNotFound(t *testing.T) {
+	mockFlows := mocks.NewMockAuthFlowsClient(t)
+	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
+
+	const configID = "cfg-4"
+
+	flow := &keycloakApi.KeycloakAuthFlow{}
+	flow.Spec.Alias = testFlowAlias
+
+	existing := nonFlowExec("exec-removed", "old-auth", "REQUIRED", 10, ptr.To(configID))
+
+	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
+		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{existing}, nil, nil)
+
+	mockFlows.EXPECT().DeleteAuthenticatorConfig(context.Background(), testRealmName, configID).
+		Return(nil, keycloakapi.ErrNotFound)
+
+	mockFlows.EXPECT().DeleteExecution(context.Background(), testRealmName, "exec-removed").
+		Return(nil, nil)
 
 	h := NewSyncAuthFlowExecutions(kc)
 	err := h.Serve(context.Background(), flow, testRealmName)
@@ -97,11 +288,9 @@ func TestSyncAuthFlowExecutions_Serve_AddExecution(t *testing.T) {
 		{Authenticator: "basic-auth", AuthenticatorFlow: false},
 	}
 
-	// clearNonFlowExecutions: empty
 	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
 		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{}, nil, nil)
 
-	// addExecution
 	mockFlows.EXPECT().AddExecutionToFlow(
 		context.Background(), testRealmName,
 		keycloakapi.AuthenticationExecutionRepresentation{
@@ -111,8 +300,6 @@ func TestSyncAuthFlowExecutions_Serve_AddExecution(t *testing.T) {
 			Priority:      ptr.To(int32(0)),
 		},
 	).Return(locationResponse(testExecID), nil)
-
-	// adjustChildFlowsPriority: no AuthenticatorFlow=true entries → returns immediately
 
 	h := NewSyncAuthFlowExecutions(kc)
 	err := h.Serve(context.Background(), flow, testRealmName)
@@ -164,6 +351,125 @@ func TestSyncAuthFlowExecutions_Serve_AddExecutionWithConfig(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSyncAuthFlowExecutions_Serve_AddExecutionPropagatesPriority(t *testing.T) {
+	mockFlows := mocks.NewMockAuthFlowsClient(t)
+	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
+
+	flow := &keycloakApi.KeycloakAuthFlow{}
+	flow.Spec.Alias = testFlowAlias
+	flow.Status.ID = testFlowID
+	flow.Spec.AuthenticationExecutions = []keycloakApi.AuthenticationExecution{
+		{Authenticator: "basic-auth", AuthenticatorFlow: false, Priority: 5, Requirement: "REQUIRED"},
+	}
+
+	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
+		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{}, nil, nil)
+
+	mockFlows.EXPECT().AddExecutionToFlow(
+		context.Background(), testRealmName,
+		keycloakapi.AuthenticationExecutionRepresentation{
+			Authenticator: ptr.To("basic-auth"),
+			ParentFlow:    ptr.To(testFlowID),
+			Requirement:   ptr.To("REQUIRED"),
+			Priority:      ptr.To(int32(5)),
+		},
+	).Return(locationResponse(testExecID), nil)
+
+	h := NewSyncAuthFlowExecutions(kc)
+	err := h.Serve(context.Background(), flow, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestSyncAuthFlowExecutions_Serve_ForceUpdateOnGenerationChange(t *testing.T) {
+	mockFlows := mocks.NewMockAuthFlowsClient(t)
+	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
+
+	const configID = "cfg-5"
+
+	flow := &keycloakApi.KeycloakAuthFlow{}
+	flow.Generation = 2
+	flow.Status.ObservedGeneration = 1
+	setIdpRedirectorSpec(flow)
+
+	existing := nonFlowExec("exec-1", "identity-provider-redirector", "ALTERNATIVE", 10, ptr.To(configID))
+
+	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
+		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{existing}, nil, nil)
+
+	// Requirement and priority match spec: exact scalar diffs need no forced write.
+	desiredConfig := map[string]string{"defaultProvider": "github"}
+
+	// Forced by generation drift: config updated without a prior read.
+	mockFlows.EXPECT().UpdateAuthenticatorConfig(context.Background(), testRealmName, configID,
+		keycloakapi.AuthenticatorConfigRepresentation{
+			Id:     ptr.To(configID),
+			Alias:  ptr.To("idp-config"),
+			Config: &desiredConfig,
+		},
+	).Return(nil, nil)
+
+	h := NewSyncAuthFlowExecutions(kc)
+	err := h.Serve(context.Background(), flow, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestSyncAuthFlowExecutions_Serve_DanglingConfigRecreated(t *testing.T) {
+	mockFlows := mocks.NewMockAuthFlowsClient(t)
+	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
+
+	const configID = "cfg-gone"
+
+	flow := &keycloakApi.KeycloakAuthFlow{}
+	setIdpRedirectorSpec(flow)
+
+	existing := nonFlowExec("exec-1", "identity-provider-redirector", "ALTERNATIVE", 10, ptr.To(configID))
+
+	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
+		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{existing}, nil, nil)
+
+	// Execution references a config that no longer exists: read 404s, update 404s, config is recreated.
+	mockFlows.EXPECT().GetAuthenticatorConfig(context.Background(), testRealmName, configID).
+		Return(nil, nil, keycloakapi.ErrNotFound)
+
+	mockFlows.EXPECT().UpdateAuthenticatorConfig(context.Background(), testRealmName, configID, mock.Anything).
+		Return(nil, keycloakapi.ErrNotFound)
+
+	desiredConfig := map[string]string{"defaultProvider": "github"}
+
+	mockFlows.EXPECT().CreateExecutionConfig(context.Background(), testRealmName, "exec-1",
+		keycloakapi.AuthenticatorConfigRepresentation{
+			Alias:  ptr.To("idp-config"),
+			Config: &desiredConfig,
+		},
+	).Return(nil, nil)
+
+	h := NewSyncAuthFlowExecutions(kc)
+	err := h.Serve(context.Background(), flow, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestSyncAuthFlowExecutions_Serve_DuplicateAuthenticatorInSync(t *testing.T) {
+	mockFlows := mocks.NewMockAuthFlowsClient(t)
+	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
+
+	flow := &keycloakApi.KeycloakAuthFlow{}
+	flow.Spec.Alias = testFlowAlias
+	flow.Spec.AuthenticationExecutions = []keycloakApi.AuthenticationExecution{
+		{Authenticator: "otp-form", Requirement: "REQUIRED", Priority: 10},
+		{Authenticator: "otp-form", Requirement: "ALTERNATIVE", Priority: 20},
+	}
+
+	existing1 := nonFlowExec("exec-1", "otp-form", "REQUIRED", 10, nil)
+	existing2 := nonFlowExec("exec-2", "otp-form", "ALTERNATIVE", 20, nil)
+
+	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
+		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{existing1, existing2}, nil, nil)
+
+	h := NewSyncAuthFlowExecutions(kc)
+	err := h.Serve(context.Background(), flow, testRealmName)
+	require.NoError(t, err)
+}
+
 func TestSyncAuthFlowExecutions_Serve_AdjustChildFlowPriority(t *testing.T) {
 	mockFlows := mocks.NewMockAuthFlowsClient(t)
 	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
@@ -174,7 +480,7 @@ func TestSyncAuthFlowExecutions_Serve_AdjustChildFlowPriority(t *testing.T) {
 		{Alias: "sub-flow", AuthenticatorFlow: true, Priority: 10, Requirement: "REQUIRED"},
 	}
 
-	// clearNonFlowExecutions: one flow exec (not deleted)
+	// Single fetch serves both the non-flow sync and the child-flow priority adjustment.
 	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
 		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{
 			{
@@ -186,7 +492,6 @@ func TestSyncAuthFlowExecutions_Serve_AdjustChildFlowPriority(t *testing.T) {
 			},
 		}, nil, nil).Once()
 
-	// adjustChildFlowsPriority re-fetches executions
 	updatedExec := keycloakapi.AuthenticationExecutionInfoRepresentation{
 		DisplayName:        ptr.To("sub-flow"),
 		AuthenticationFlow: ptr.To(true),
@@ -194,17 +499,6 @@ func TestSyncAuthFlowExecutions_Serve_AdjustChildFlowPriority(t *testing.T) {
 		Priority:           ptr.To(int32(10)),
 		Requirement:        ptr.To("REQUIRED"),
 	}
-
-	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
-		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{
-			{
-				DisplayName:        ptr.To("sub-flow"),
-				AuthenticationFlow: ptr.To(true),
-				Level:              ptr.To(int32(0)),
-				Priority:           ptr.To(int32(20)),
-				Requirement:        ptr.To("DISABLED"),
-			},
-		}, nil, nil).Once()
 
 	mockFlows.EXPECT().UpdateFlowExecution(context.Background(), testRealmName, testFlowAlias, updatedExec).
 		Return(nil, nil)
@@ -227,7 +521,7 @@ func TestSyncAuthFlowExecutions_Serve_GetFlowExecutionsError(t *testing.T) {
 	h := NewSyncAuthFlowExecutions(kc)
 	err := h.Serve(context.Background(), flow, testRealmName)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to clear flow executions")
+	assert.Contains(t, err.Error(), "failed to get flow executions")
 }
 
 func TestSyncAuthFlowExecutions_Serve_DeleteExecutionError(t *testing.T) {
@@ -239,7 +533,7 @@ func TestSyncAuthFlowExecutions_Serve_DeleteExecutionError(t *testing.T) {
 
 	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
 		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{
-			{Id: ptr.To("bad-exec"), AuthenticationFlow: ptr.To(false), Level: ptr.To(int32(0))},
+			nonFlowExec("bad-exec", "basic-auth", "REQUIRED", 0, nil),
 		}, nil, nil)
 
 	mockFlows.EXPECT().DeleteExecution(context.Background(), testRealmName, "bad-exec").
@@ -299,33 +593,4 @@ func TestSyncAuthFlowExecutions_Serve_EmptyFlowID(t *testing.T) {
 	err := h.Serve(context.Background(), flow, testRealmName)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "flow ID is empty")
-}
-
-func TestSyncAuthFlowExecutions_Serve_AddExecutionPropagatesPriority(t *testing.T) {
-	mockFlows := mocks.NewMockAuthFlowsClient(t)
-	kc := &keycloakapi.KeycloakClient{AuthFlows: mockFlows}
-
-	flow := &keycloakApi.KeycloakAuthFlow{}
-	flow.Spec.Alias = testFlowAlias
-	flow.Status.ID = testFlowID
-	flow.Spec.AuthenticationExecutions = []keycloakApi.AuthenticationExecution{
-		{Authenticator: "basic-auth", AuthenticatorFlow: false, Priority: 5, Requirement: "REQUIRED"},
-	}
-
-	mockFlows.EXPECT().GetFlowExecutions(context.Background(), testRealmName, testFlowAlias).
-		Return([]keycloakapi.AuthenticationExecutionInfoRepresentation{}, nil, nil)
-
-	mockFlows.EXPECT().AddExecutionToFlow(
-		context.Background(), testRealmName,
-		keycloakapi.AuthenticationExecutionRepresentation{
-			Authenticator: ptr.To("basic-auth"),
-			ParentFlow:    ptr.To(testFlowID),
-			Requirement:   ptr.To("REQUIRED"),
-			Priority:      ptr.To(int32(5)),
-		},
-	).Return(locationResponse(testExecID), nil)
-
-	h := NewSyncAuthFlowExecutions(kc)
-	err := h.Serve(context.Background(), flow, testRealmName)
-	require.NoError(t, err)
 }

--- a/internal/controller/keycloakauthflow/keycloakauthflow_controller.go
+++ b/internal/controller/keycloakauthflow/keycloakauthflow_controller.go
@@ -167,6 +167,7 @@ func (r *Reconcile) handleReconciliation(ctx context.Context, instance *keycloak
 	}
 
 	instance.Status.Value = common.StatusOK
+	instance.Status.ObservedGeneration = instance.Generation
 
 	if err := r.updateKeycloakAuthFlowStatus(ctx, instance, oldStatus); err != nil {
 		return reconcile.Result{}, err


### PR DESCRIPTION


Every reconcile deleted all top-level non-flow executions and recreated them from spec (new IDs each cycle, transient auth gaps) and called UpdateAuthFlow unconditionally, every 10 minutes even with no CR changes.

- SyncAuthFlowExecutions: diff non-flow executions - pair by authenticator (duplicates by priority order), update requirement/priority in place via UpdateFlowExecution, create only missing, delete only spec-removed (config first); reconcile authenticator configs in place via UpdateAuthenticatorConfig, recreate on dangling config references
- CreateOrUpdateAuthFlow: skip UpdateAuthFlow when the existing flow already matches spec
- status gains observedGeneration; a spec edit forces the authenticator config write because its comparison checks only spec-declared keys; scalar fields converge through exact diffs without forcing
- fetch flow executions once per reconcile (was fetched twice)

Same defect class and fix pattern as KeycloakClientScope (e38631e).

