### PR TITLE
fix(KeycloakRealmComponent,KeycloakOrganization): skip Keycloak writes when state already matches spec

### DIFF
--- a/api/v1/keycloakcomponent_types.go
+++ b/api/v1/keycloakcomponent_types.go
@@ -43,6 +43,14 @@ type KeycloakComponentStatus struct {
 
 	// +optional
 	Value string `json:"value,omitempty"`
+
+	// ObservedGeneration is the generation last successfully reconciled to Keycloak.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// ConfigSecretsHash is a hash of resolved secret-ref config values from the last successful reconcile.
+	// +optional
+	ConfigSecretsHash string `json:"configSecretsHash,omitempty"`
 }
 
 // ParentComponent defines the parent component of KeycloakRealmComponent.

--- a/api/v1alpha1/organization_types.go
+++ b/api/v1alpha1/organization_types.go
@@ -70,6 +70,10 @@ type KeycloakOrganizationStatus struct {
 	// Error is the error message if the reconciliation failed.
 	// +optional
 	Error string `json:"error,omitempty"`
+
+	// ObservedGeneration is the generation last successfully reconciled to Keycloak.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 func (in *KeycloakOrganizationStatus) SetOK() {

--- a/config/crd/bases/v1.edp.epam.com_keycloakorganizations.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakorganizations.yaml
@@ -138,6 +138,11 @@ spec:
               error:
                 description: Error is the error message if the reconciliation failed.
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the generation last successfully
+                  reconciled to Keycloak.
+                format: int64
+                type: integer
               organizationId:
                 description: OrganizationID is the unique identifier of the organization
                   in Keycloak.

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealmcomponents.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealmcomponents.yaml
@@ -115,8 +115,17 @@ spec:
           status:
             description: KeycloakComponentStatus defines the observed state of KeycloakRealmComponent.
             properties:
+              configSecretsHash:
+                description: ConfigSecretsHash is a hash of resolved secret-ref config
+                  values from the last successful reconcile.
+                type: string
               id:
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the generation last successfully
+                  reconciled to Keycloak.
+                format: int64
+                type: integer
               value:
                 type: string
             type: object

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakorganizations.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakorganizations.yaml
@@ -138,6 +138,11 @@ spec:
               error:
                 description: Error is the error message if the reconciliation failed.
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the generation last successfully
+                  reconciled to Keycloak.
+                format: int64
+                type: integer
               organizationId:
                 description: OrganizationID is the unique identifier of the organization
                   in Keycloak.

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealmcomponents.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealmcomponents.yaml
@@ -115,8 +115,17 @@ spec:
           status:
             description: KeycloakComponentStatus defines the observed state of KeycloakRealmComponent.
             properties:
+              configSecretsHash:
+                description: ConfigSecretsHash is a hash of resolved secret-ref config
+                  values from the last successful reconcile.
+                type: string
               id:
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the generation last successfully
+                  reconciled to Keycloak.
+                format: int64
+                type: integer
               value:
                 type: string
             type: object

--- a/docs/api.md
+++ b/docs/api.md
@@ -2644,6 +2644,15 @@ KeycloakOrganizationStatus defines the observed state of Organization.
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>observedGeneration</b></td>
+        <td>integer</td>
+        <td>
+          ObservedGeneration is the generation last successfully reconciled to Keycloak.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>organizationId</b></td>
         <td>string</td>
         <td>
@@ -5000,10 +5009,26 @@ KeycloakComponentStatus defines the observed state of KeycloakRealmComponent.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>configSecretsHash</b></td>
+        <td>string</td>
+        <td>
+          ConfigSecretsHash is a hash of resolved secret-ref config values from the last successful reconcile.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>id</b></td>
         <td>string</td>
         <td>
           <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>observedGeneration</b></td>
+        <td>integer</td>
+        <td>
+          ObservedGeneration is the generation last successfully reconciled to Keycloak.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/internal/controller/keycloakorganization/chain/create_organization.go
+++ b/internal/controller/keycloakorganization/chain/create_organization.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"slices"
 
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1alpha1"
+	"github.com/epam/edp-keycloak-operator/internal/controller/helper"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+	"github.com/epam/edp-keycloak-operator/pkg/maputil"
 )
 
 type CreateOrganization struct {
@@ -38,13 +41,20 @@ func (h *CreateOrganization) ServeRequest(ctx context.Context, organization *key
 	if err == nil && existingOrg != nil {
 		// Organization exists, update it
 		orgRepresentation.Id = existingOrg.Id
-		if _, updateErr := h.keycloakClient.UpdateOrganization(ctx, realmName, ptr.Deref(existingOrg.Id, ""), orgRepresentation); updateErr != nil {
-			return fmt.Errorf("unable to update organization: %w", updateErr)
-		}
-
 		organization.Status.OrganizationID = ptr.Deref(existingOrg.Id, "")
 
-		log.Info("Organization updated successfully", "organizationId", organization.Status.OrganizationID)
+		needsUpdate, matchErr := h.orgNeedsUpdate(ctx, realmName, existingOrg, organization)
+		if matchErr != nil {
+			return matchErr
+		}
+
+		if needsUpdate {
+			if _, updateErr := h.keycloakClient.UpdateOrganization(ctx, realmName, ptr.Deref(existingOrg.Id, ""), orgRepresentation); updateErr != nil {
+				return fmt.Errorf("unable to update organization: %w", updateErr)
+			}
+
+			log.Info("Organization updated successfully", "organizationId", organization.Status.OrganizationID)
+		}
 
 		return nil
 	}
@@ -95,4 +105,68 @@ func specToOrganizationRepresentation(org *keycloakApi.KeycloakOrganization) key
 	}
 
 	return rep
+}
+
+// orgNeedsUpdate reports whether organization must be written to Keycloak. A spec edit
+// (generation bump) always forces the write. Otherwise the brief fields already available from
+// existing (the list representation backing GetOrganizationByAlias) are compared first; only
+// when those match and the spec declares attributes does it fetch the full representation to
+// compare attributes, since the list endpoint omits them.
+func (h *CreateOrganization) orgNeedsUpdate(
+	ctx context.Context,
+	realmName string,
+	existing *keycloakapi.OrganizationRepresentation,
+	organization *keycloakApi.KeycloakOrganization,
+) (bool, error) {
+	if helper.SpecChanged(organization.Generation, organization.Status.ObservedGeneration) {
+		return true, nil
+	}
+
+	if !briefOrgMatchesSpec(existing, organization) {
+		return true, nil
+	}
+
+	if len(organization.Spec.Attributes) == 0 {
+		return false, nil
+	}
+
+	orgID := ptr.Deref(existing.Id, "")
+
+	// The list endpoint returns a brief representation without attributes; only the by-ID GET
+	// includes them.
+	full, _, err := h.keycloakClient.GetOrganization(ctx, realmName, orgID)
+	if err != nil {
+		return false, fmt.Errorf("failed to get organization %s by id: %w", orgID, err)
+	}
+
+	return !maputil.ContainsSubsetMulti(ptr.Deref(full.Attributes, nil), organization.Spec.Attributes), nil
+}
+
+// briefOrgMatchesSpec reports whether the fields present in the brief (list) representation
+// already match the desired spec. Enabled, Groups and Members are server-populated;
+// IdentityProviders is reconciled separately by ProcessIdentityProviders.
+func briefOrgMatchesSpec(existing *keycloakapi.OrganizationRepresentation, org *keycloakApi.KeycloakOrganization) bool {
+	if ptr.Deref(existing.Name, "") != org.Spec.Name ||
+		ptr.Deref(existing.Alias, "") != org.Spec.Alias ||
+		ptr.Deref(existing.Description, "") != org.Spec.Description ||
+		ptr.Deref(existing.RedirectUrl, "") != org.Spec.RedirectURL {
+		return false
+	}
+
+	existingDomains := ptr.Deref(existing.Domains, nil)
+	existingDomainNames := make([]string, 0, len(existingDomains))
+
+	for _, d := range existingDomains {
+		existingDomainNames = append(existingDomainNames, ptr.Deref(d.Name, ""))
+	}
+
+	// Keycloak dedups domains server-side: dedup the spec list too so accidental spec
+	// duplicates don't permanently look like drift.
+	specDomains := slices.Clone(org.Spec.Domains)
+	slices.Sort(specDomains)
+	specDomains = slices.Compact(specDomains)
+
+	slices.Sort(existingDomainNames)
+
+	return slices.Equal(existingDomainNames, specDomains)
 }

--- a/internal/controller/keycloakorganization/chain/create_organization_test.go
+++ b/internal/controller/keycloakorganization/chain/create_organization_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1alpha1"
@@ -83,14 +84,13 @@ func TestCreateOrganization_ServeRequest(t *testing.T) {
 			keycloakClient: func(t *testing.T) keycloakapi.OrganizationsClient {
 				client := keycloakapimocks.NewMockOrganizationsClient(t)
 
-				// First call: GetOrganizationByAlias returns existing organization
+				// Fetched organization has none of the spec's fields set: drift forces the update.
 				client.On("GetOrganizationByAlias", mock.Anything, "test-realm", "existing-org").
 					Return(&keycloakapi.OrganizationRepresentation{
 						Id:    ptr.To("existing-org-456"),
 						Alias: ptr.To("existing-org"),
 					}, (*keycloakapi.Response)(nil), nil).Once()
 
-				// Second call: UpdateOrganization succeeds
 				client.On("UpdateOrganization", mock.Anything, "test-realm", "existing-org-456", mock.MatchedBy(func(org keycloakapi.OrganizationRepresentation) bool {
 					return ptr.Deref(org.Name, "") == "Updated Organization" &&
 						ptr.Deref(org.Alias, "") == "existing-org" &&
@@ -103,6 +103,328 @@ func TestCreateOrganization_ServeRequest(t *testing.T) {
 			},
 			wantErr:       require.NoError,
 			expectedOrgID: "existing-org-456",
+		},
+		{
+			name: "no update when existing organization matches spec",
+			organization: &keycloakApi.KeycloakOrganization{
+				ObjectMeta: metav1.ObjectMeta{Generation: 3},
+				Spec: keycloakApi.KeycloakOrganizationSpec{
+					Name:        "In Sync Org",
+					Alias:       "in-sync-org",
+					Description: "In sync description",
+					RedirectURL: "https://in-sync.com/redirect",
+					Domains:     []string{"a.com", "b.com"},
+					Attributes: map[string][]string{
+						"dept": {"eng", "qa"},
+					},
+				},
+				Status: keycloakApi.KeycloakOrganizationStatus{
+					ObservedGeneration: 3,
+				},
+			},
+			realmName: "test-realm",
+			keycloakClient: func(t *testing.T) keycloakapi.OrganizationsClient {
+				client := keycloakapimocks.NewMockOrganizationsClient(t)
+
+				// GetOrganizationByAlias is backed by the list endpoint: it never returns
+				// Attributes. Domains are shuffled and Enabled/Members are server-populated
+				// fields the spec never sets: none of that should trigger an update.
+				client.On("GetOrganizationByAlias", mock.Anything, "test-realm", "in-sync-org").
+					Return(&keycloakapi.OrganizationRepresentation{
+						Id:          ptr.To("in-sync-id"),
+						Name:        ptr.To("In Sync Org"),
+						Alias:       ptr.To("in-sync-org"),
+						Description: ptr.To("In sync description"),
+						RedirectUrl: ptr.To("https://in-sync.com/redirect"),
+						Enabled:     ptr.To(true),
+						Domains: &[]keycloakapi.OrganizationDomainRepresentation{
+							{Name: ptr.To("b.com"), Verified: ptr.To(true)},
+							{Name: ptr.To("a.com")},
+						},
+						Members: &[]keycloakapi.MemberRepresentation{{}},
+					}, (*keycloakapi.Response)(nil), nil).Once()
+
+				// Brief fields already match, and the spec declares attributes: the full
+				// representation is fetched by ID to compare them, with values shuffled.
+				client.On("GetOrganization", mock.Anything, "test-realm", "in-sync-id").
+					Return(&keycloakapi.OrganizationRepresentation{
+						Id:    ptr.To("in-sync-id"),
+						Alias: ptr.To("in-sync-org"),
+						Attributes: &map[string][]string{
+							"dept": {"qa", "eng"},
+						},
+					}, (*keycloakapi.Response)(nil), nil).Once()
+
+				return client
+			},
+			wantErr:       require.NoError,
+			expectedOrgID: "in-sync-id",
+		},
+		{
+			name: "brief field drift forces update without fetching the full representation",
+			organization: &keycloakApi.KeycloakOrganization{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec: keycloakApi.KeycloakOrganizationSpec{
+					Name:        "Brief Drift Org",
+					Alias:       "brief-drift-org",
+					Description: "New description",
+					Domains:     []string{"a.com"},
+					Attributes: map[string][]string{
+						"dept": {"eng"},
+					},
+				},
+				Status: keycloakApi.KeycloakOrganizationStatus{
+					ObservedGeneration: 1,
+				},
+			},
+			realmName: "test-realm",
+			keycloakClient: func(t *testing.T) keycloakapi.OrganizationsClient {
+				client := keycloakapimocks.NewMockOrganizationsClient(t)
+
+				// Description differs: the update fires from the brief comparison alone.
+				// GetOrganization (by ID) is not stubbed; an unexpected call fails the test.
+				client.On("GetOrganizationByAlias", mock.Anything, "test-realm", "brief-drift-org").
+					Return(&keycloakapi.OrganizationRepresentation{
+						Id:          ptr.To("brief-drift-id"),
+						Name:        ptr.To("Brief Drift Org"),
+						Alias:       ptr.To("brief-drift-org"),
+						Description: ptr.To("Old description"),
+						Domains: &[]keycloakapi.OrganizationDomainRepresentation{
+							{Name: ptr.To("a.com")},
+						},
+					}, (*keycloakapi.Response)(nil), nil).Once()
+
+				client.On("UpdateOrganization", mock.Anything, "test-realm", "brief-drift-id", mock.Anything).
+					Return((*keycloakapi.Response)(nil), nil).Once()
+
+				return client
+			},
+			wantErr:       require.NoError,
+			expectedOrgID: "brief-drift-id",
+		},
+		{
+			name: "spec without attributes needs no full representation fetch",
+			organization: &keycloakApi.KeycloakOrganization{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec: keycloakApi.KeycloakOrganizationSpec{
+					Name:    "No Attrs Org",
+					Alias:   "no-attrs-org",
+					Domains: []string{"a.com"},
+				},
+				Status: keycloakApi.KeycloakOrganizationStatus{
+					ObservedGeneration: 1,
+				},
+			},
+			realmName: "test-realm",
+			keycloakClient: func(t *testing.T) keycloakapi.OrganizationsClient {
+				client := keycloakapimocks.NewMockOrganizationsClient(t)
+
+				// Brief fields already match and the spec declares no attributes: neither
+				// GetOrganization (by ID) nor UpdateOrganization should be called.
+				client.On("GetOrganizationByAlias", mock.Anything, "test-realm", "no-attrs-org").
+					Return(&keycloakapi.OrganizationRepresentation{
+						Id:    ptr.To("no-attrs-id"),
+						Name:  ptr.To("No Attrs Org"),
+						Alias: ptr.To("no-attrs-org"),
+						Domains: &[]keycloakapi.OrganizationDomainRepresentation{
+							{Name: ptr.To("a.com")},
+						},
+					}, (*keycloakapi.Response)(nil), nil).Once()
+
+				return client
+			},
+			wantErr:       require.NoError,
+			expectedOrgID: "no-attrs-id",
+		},
+		{
+			name: "GetOrganization by id error is propagated",
+			organization: &keycloakApi.KeycloakOrganization{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec: keycloakApi.KeycloakOrganizationSpec{
+					Name:    "By Id Error Org",
+					Alias:   "by-id-error-org",
+					Domains: []string{"a.com"},
+					Attributes: map[string][]string{
+						"dept": {"eng"},
+					},
+				},
+				Status: keycloakApi.KeycloakOrganizationStatus{
+					ObservedGeneration: 1,
+				},
+			},
+			realmName: "test-realm",
+			keycloakClient: func(t *testing.T) keycloakapi.OrganizationsClient {
+				client := keycloakapimocks.NewMockOrganizationsClient(t)
+
+				client.On("GetOrganizationByAlias", mock.Anything, "test-realm", "by-id-error-org").
+					Return(&keycloakapi.OrganizationRepresentation{
+						Id:    ptr.To("by-id-error-id"),
+						Name:  ptr.To("By Id Error Org"),
+						Alias: ptr.To("by-id-error-org"),
+						Domains: &[]keycloakapi.OrganizationDomainRepresentation{
+							{Name: ptr.To("a.com")},
+						},
+					}, (*keycloakapi.Response)(nil), nil).Once()
+
+				client.On("GetOrganization", mock.Anything, "test-realm", "by-id-error-id").
+					Return((*keycloakapi.OrganizationRepresentation)(nil), (*keycloakapi.Response)(nil), errors.New("network error")).Once()
+
+				return client
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "generation bump forces update even when in sync",
+			organization: &keycloakApi.KeycloakOrganization{
+				ObjectMeta: metav1.ObjectMeta{Generation: 4},
+				Spec: keycloakApi.KeycloakOrganizationSpec{
+					Name:    "In Sync Org",
+					Alias:   "in-sync-org-gen",
+					Domains: []string{"a.com"},
+				},
+				Status: keycloakApi.KeycloakOrganizationStatus{
+					ObservedGeneration: 3,
+				},
+			},
+			realmName: "test-realm",
+			keycloakClient: func(t *testing.T) keycloakapi.OrganizationsClient {
+				client := keycloakapimocks.NewMockOrganizationsClient(t)
+
+				client.On("GetOrganizationByAlias", mock.Anything, "test-realm", "in-sync-org-gen").
+					Return(&keycloakapi.OrganizationRepresentation{
+						Id:    ptr.To("gen-bump-id"),
+						Name:  ptr.To("In Sync Org"),
+						Alias: ptr.To("in-sync-org-gen"),
+						Domains: &[]keycloakapi.OrganizationDomainRepresentation{
+							{Name: ptr.To("a.com")},
+						},
+					}, (*keycloakapi.Response)(nil), nil).Once()
+
+				client.On("UpdateOrganization", mock.Anything, "test-realm", "gen-bump-id", mock.Anything).
+					Return((*keycloakapi.Response)(nil), nil).Once()
+
+				return client
+			},
+			wantErr:       require.NoError,
+			expectedOrgID: "gen-bump-id",
+		},
+		{
+			name: "domain removed from spec forces update",
+			organization: &keycloakApi.KeycloakOrganization{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec: keycloakApi.KeycloakOrganizationSpec{
+					Name:    "Domain Drop Org",
+					Alias:   "domain-drop-org",
+					Domains: []string{"a.com"},
+				},
+				Status: keycloakApi.KeycloakOrganizationStatus{
+					ObservedGeneration: 1,
+				},
+			},
+			realmName: "test-realm",
+			keycloakClient: func(t *testing.T) keycloakapi.OrganizationsClient {
+				client := keycloakapimocks.NewMockOrganizationsClient(t)
+
+				client.On("GetOrganizationByAlias", mock.Anything, "test-realm", "domain-drop-org").
+					Return(&keycloakapi.OrganizationRepresentation{
+						Id:    ptr.To("domain-drop-id"),
+						Name:  ptr.To("Domain Drop Org"),
+						Alias: ptr.To("domain-drop-org"),
+						Domains: &[]keycloakapi.OrganizationDomainRepresentation{
+							{Name: ptr.To("a.com")},
+							{Name: ptr.To("b.com")},
+						},
+					}, (*keycloakapi.Response)(nil), nil).Once()
+
+				client.On("UpdateOrganization", mock.Anything, "test-realm", "domain-drop-id", mock.Anything).
+					Return((*keycloakapi.Response)(nil), nil).Once()
+
+				return client
+			},
+			wantErr:       require.NoError,
+			expectedOrgID: "domain-drop-id",
+		},
+		{
+			name: "duplicated domain in spec is in sync with the deduped existing domain",
+			organization: &keycloakApi.KeycloakOrganization{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec: keycloakApi.KeycloakOrganizationSpec{
+					Name:    "Dup Domain Org",
+					Alias:   "dup-domain-org",
+					Domains: []string{"a.com", "a.com"},
+				},
+				Status: keycloakApi.KeycloakOrganizationStatus{
+					ObservedGeneration: 1,
+				},
+			},
+			realmName: "test-realm",
+			keycloakClient: func(t *testing.T) keycloakapi.OrganizationsClient {
+				client := keycloakapimocks.NewMockOrganizationsClient(t)
+
+				// Keycloak dedups domains server-side: only one "a.com" comes back.
+				client.On("GetOrganizationByAlias", mock.Anything, "test-realm", "dup-domain-org").
+					Return(&keycloakapi.OrganizationRepresentation{
+						Id:    ptr.To("dup-domain-id"),
+						Name:  ptr.To("Dup Domain Org"),
+						Alias: ptr.To("dup-domain-org"),
+						Domains: &[]keycloakapi.OrganizationDomainRepresentation{
+							{Name: ptr.To("a.com")},
+						},
+					}, (*keycloakapi.Response)(nil), nil).Once()
+
+				return client
+			},
+			wantErr:       require.NoError,
+			expectedOrgID: "dup-domain-id",
+		},
+		{
+			name: "attribute drift discovered via the by-id fetch forces update",
+			organization: &keycloakApi.KeycloakOrganization{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec: keycloakApi.KeycloakOrganizationSpec{
+					Name:    "Attr Change Org",
+					Alias:   "attr-change-org",
+					Domains: []string{"a.com"},
+					Attributes: map[string][]string{
+						"dept": {"eng"},
+					},
+				},
+				Status: keycloakApi.KeycloakOrganizationStatus{
+					ObservedGeneration: 1,
+				},
+			},
+			realmName: "test-realm",
+			keycloakClient: func(t *testing.T) keycloakapi.OrganizationsClient {
+				client := keycloakapimocks.NewMockOrganizationsClient(t)
+
+				// Brief fields match, so the full representation is fetched by ID; its
+				// attributes differ from the spec.
+				client.On("GetOrganizationByAlias", mock.Anything, "test-realm", "attr-change-org").
+					Return(&keycloakapi.OrganizationRepresentation{
+						Id:    ptr.To("attr-change-id"),
+						Name:  ptr.To("Attr Change Org"),
+						Alias: ptr.To("attr-change-org"),
+						Domains: &[]keycloakapi.OrganizationDomainRepresentation{
+							{Name: ptr.To("a.com")},
+						},
+					}, (*keycloakapi.Response)(nil), nil).Once()
+
+				client.On("GetOrganization", mock.Anything, "test-realm", "attr-change-id").
+					Return(&keycloakapi.OrganizationRepresentation{
+						Id:    ptr.To("attr-change-id"),
+						Alias: ptr.To("attr-change-org"),
+						Attributes: &map[string][]string{
+							"dept": {"qa"},
+						},
+					}, (*keycloakapi.Response)(nil), nil).Once()
+
+				client.On("UpdateOrganization", mock.Anything, "test-realm", "attr-change-id", mock.Anything).
+					Return((*keycloakapi.Response)(nil), nil).Once()
+
+				return client
+			},
+			wantErr:       require.NoError,
+			expectedOrgID: "attr-change-id",
 		},
 		{
 			name: "error when GetOrganizationByAlias fails with non-not-found error",

--- a/internal/controller/keycloakorganization/keycloakorganization_controller.go
+++ b/internal/controller/keycloakorganization/keycloakorganization_controller.go
@@ -166,6 +166,7 @@ func (r *ReconcileOrganization) handleReconciliation(ctx context.Context, organi
 	}
 
 	organization.Status.SetOK()
+	organization.Status.ObservedGeneration = organization.Generation
 
 	if err := r.updateOrganizationStatus(ctx, organization, *oldStatus); err != nil {
 		return reconcile.Result{}, err

--- a/internal/controller/keycloakrealmcomponent/chain/create_or_update_component.go
+++ b/internal/controller/keycloakrealmcomponent/chain/create_or_update_component.go
@@ -3,13 +3,18 @@ package chain
 import (
 	"context"
 	"fmt"
+	"slices"
 
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/epam/edp-keycloak-operator/internal/controller/helper"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
-	"k8s.io/apimachinery/pkg/types"
+	"github.com/epam/edp-keycloak-operator/pkg/maputil"
+	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 )
 
 // CreateOrUpdateComponent creates or updates a realm component in Keycloak.
@@ -40,6 +45,7 @@ func (h *CreateOrUpdateComponent) Serve(
 	log.Info("Creating or updating realm component")
 
 	spec := component.Spec
+	rawCfg := spec.Config
 
 	config := make(keycloakapi.MultivaluedHashMapStringString, len(spec.Config))
 
@@ -52,6 +58,8 @@ func (h *CreateOrUpdateComponent) Serve(
 	if err := h.secretRefClient.MapComponentConfigSecretsRefs(ctx, config, component.Namespace); err != nil {
 		return fmt.Errorf("unable to map config secrets: %w", err)
 	}
+
+	newHash := secretref.ConfigSecretsHash(rawCfg, config)
 
 	parentID, err := h.resolveParentID(ctx, component, realmName)
 	if err != nil {
@@ -83,22 +91,66 @@ func (h *CreateOrUpdateComponent) Serve(
 		component.Status.ID = keycloakapi.GetResourceIDFromResponse(resp)
 
 		log.Info("Realm component created")
+	} else {
+		if existing.Id != nil {
+			component.Status.ID = *existing.Id
+			repr.Id = existing.Id
+		}
 
-		return nil
+		needsUpdate := helper.SpecChanged(component.Generation, component.Status.ObservedGeneration) ||
+			newHash != component.Status.ConfigSecretsHash ||
+			!componentMatchesSpec(existing, repr, rawCfg)
+
+		if needsUpdate {
+			if _, err := h.kClient.RealmComponents.UpdateComponent(ctx, realmName, component.Status.ID, repr); err != nil {
+				return fmt.Errorf("failed to update realm component: %w", err)
+			}
+
+			log.Info("Realm component updated")
+		}
 	}
 
-	if existing.Id != nil {
-		component.Status.ID = *existing.Id
-		repr.Id = existing.Id
-	}
-
-	if _, err := h.kClient.RealmComponents.UpdateComponent(ctx, realmName, component.Status.ID, repr); err != nil {
-		return fmt.Errorf("failed to update realm component: %w", err)
-	}
-
-	log.Info("Realm component updated")
+	// Stamped even when the update is skipped; if the controller's status write fails, the
+	// generation check forces the next reconcile to re-run.
+	component.Status.ConfigSecretsHash = newHash
 
 	return nil
+}
+
+// componentMatchesSpec reports whether the fetched component already matches the desired
+// representation. Config keys are excluded from comparison when Keycloak masks them: either
+// the raw spec value is a secret ref, or the fetched value is already the mask sentinel.
+// ParentId is compared only when the operator manages it (desired.ParentId set): Keycloak
+// auto-fills it with the realm's internal ID for components created without a parentRef.
+func componentMatchesSpec(
+	existing *keycloakapi.ComponentRepresentation,
+	desired keycloakapi.ComponentRepresentation,
+	rawCfg map[string][]string,
+) bool {
+	if ptr.Deref(existing.Name, "") != ptr.Deref(desired.Name, "") ||
+		ptr.Deref(existing.ProviderId, "") != ptr.Deref(desired.ProviderId, "") ||
+		ptr.Deref(existing.ProviderType, "") != ptr.Deref(desired.ProviderType, "") {
+		return false
+	}
+
+	if desired.ParentId != nil && ptr.Deref(existing.ParentId, "") != *desired.ParentId {
+		return false
+	}
+
+	existingConfig := ptr.Deref(existing.Config, nil)
+	desiredConfig := ptr.Deref(desired.Config, nil)
+
+	comparableConfig := make(map[string][]string, len(desiredConfig))
+
+	for k, v := range desiredConfig {
+		if secretref.HasAnySecretRef(rawCfg[k]) || slices.Contains(existingConfig[k], keycloakapi.MaskedSecretValue) {
+			continue
+		}
+
+		comparableConfig[k] = v
+	}
+
+	return maputil.ContainsSubsetMulti(existingConfig, comparableConfig)
 }
 
 func (h *CreateOrUpdateComponent) resolveParentID(

--- a/internal/controller/keycloakrealmcomponent/chain/create_or_update_component_test.go
+++ b/internal/controller/keycloakrealmcomponent/chain/create_or_update_component_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,6 +17,7 @@ import (
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi/mocks"
+	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 )
 
 const (
@@ -33,6 +35,20 @@ type fakeSecretRefClient struct {
 
 func (f *fakeSecretRefClient) MapComponentConfigSecretsRefs(_ context.Context, _ map[string][]string, _ string) error {
 	return f.err
+}
+
+// mutatingSecretRefClient simulates secret-ref resolution by rewriting config values in place,
+// mirroring the real SecretRef client's mutate-in-place contract.
+type mutatingSecretRefClient struct {
+	mutate func(config map[string][]string)
+}
+
+func (f *mutatingSecretRefClient) MapComponentConfigSecretsRefs(_ context.Context, config map[string][]string, _ string) error {
+	if f.mutate != nil {
+		f.mutate(config)
+	}
+
+	return nil
 }
 
 func newScheme(t *testing.T) *runtime.Scheme {
@@ -96,11 +112,15 @@ func TestCreateOrUpdateComponent_Serve_UpdateExisting(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
 
 	component := baseComponent()
+	// Pre-seed the hash so it can't itself be the reason the update fires: the test isolates
+	// the providerId drift.
+	component.Status.ConfigSecretsHash = secretref.ConfigSecretsHash(component.Spec.Config, component.Spec.Config)
 
+	// Fetched providerId differs from spec: drift forces the update.
 	existing := &keycloakapi.ComponentRepresentation{
 		Id:           ptr.To(testComponentID),
 		Name:         ptr.To(testComponentName),
-		ProviderId:   ptr.To(testProviderID),
+		ProviderId:   ptr.To("stale-provider"),
 		ProviderType: ptr.To(testProviderType),
 	}
 
@@ -122,6 +142,208 @@ func TestCreateOrUpdateComponent_Serve_UpdateExisting(t *testing.T) {
 	err := h.Serve(context.Background(), component, testRealmName)
 	require.NoError(t, err)
 	assert.Equal(t, testComponentID, component.Status.ID)
+}
+
+func TestCreateOrUpdateComponent_Serve_TopLevelParentIdAutoFillDoesNotForceUpdate(t *testing.T) {
+	mockComponents := mocks.NewMockRealmComponentsClient(t)
+	kClient := &keycloakapi.KeycloakClient{RealmComponents: mockComponents}
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+
+	component := baseComponent()
+	component.Status.ConfigSecretsHash = secretref.ConfigSecretsHash(component.Spec.Config, component.Spec.Config)
+
+	// No spec.ParentRef, but Keycloak auto-fills ParentId with the realm's internal ID for
+	// top-level components: this must not be mistaken for spec drift.
+	existing := &keycloakapi.ComponentRepresentation{
+		Id:           ptr.To(testComponentID),
+		Name:         ptr.To(testComponentName),
+		ProviderId:   ptr.To(testProviderID),
+		ProviderType: ptr.To(testProviderType),
+		ParentId:     ptr.To("realm-internal-id"),
+	}
+
+	mockComponents.EXPECT().
+		FindComponentByName(context.Background(), testRealmName, testComponentName).
+		Return(existing, nil)
+
+	h := NewCreateOrUpdateComponent(fakeClient, kClient, &fakeSecretRefClient{})
+	err := h.Serve(context.Background(), component, testRealmName)
+	require.NoError(t, err)
+	assert.Equal(t, testComponentID, component.Status.ID)
+}
+
+func TestCreateOrUpdateComponent_Serve_SkipUpdateWhenInSync(t *testing.T) {
+	mockComponents := mocks.NewMockRealmComponentsClient(t)
+	kClient := &keycloakapi.KeycloakClient{RealmComponents: mockComponents}
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+
+	component := baseComponent()
+	component.Generation = 5
+	component.Status.ObservedGeneration = 5
+	component.Spec.Config = map[string][]string{"key1": {"val1", "val2"}}
+	component.Status.ConfigSecretsHash = secretref.ConfigSecretsHash(component.Spec.Config, component.Spec.Config)
+
+	// Fetched config value order differs from spec: order-insensitive comparison still matches.
+	existing := &keycloakapi.ComponentRepresentation{
+		Id:           ptr.To(testComponentID),
+		Name:         ptr.To(testComponentName),
+		ProviderId:   ptr.To(testProviderID),
+		ProviderType: ptr.To(testProviderType),
+		Config: ptr.To(keycloakapi.MultivaluedHashMapStringString{
+			"key1": {"val2", "val1"},
+		}),
+	}
+
+	mockComponents.EXPECT().
+		FindComponentByName(context.Background(), testRealmName, testComponentName).
+		Return(existing, nil)
+
+	h := NewCreateOrUpdateComponent(fakeClient, kClient, &fakeSecretRefClient{})
+	err := h.Serve(context.Background(), component, testRealmName)
+	require.NoError(t, err)
+	assert.Equal(t, testComponentID, component.Status.ID)
+}
+
+func TestCreateOrUpdateComponent_Serve_ForceUpdateOnGenerationBump(t *testing.T) {
+	mockComponents := mocks.NewMockRealmComponentsClient(t)
+	kClient := &keycloakapi.KeycloakClient{RealmComponents: mockComponents}
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+
+	component := baseComponent()
+	component.Generation = 6
+	component.Status.ObservedGeneration = 5
+	component.Spec.Config = map[string][]string{"key1": {"val1", "val2"}}
+	component.Status.ConfigSecretsHash = secretref.ConfigSecretsHash(component.Spec.Config, component.Spec.Config)
+
+	existing := &keycloakapi.ComponentRepresentation{
+		Id:           ptr.To(testComponentID),
+		Name:         ptr.To(testComponentName),
+		ProviderId:   ptr.To(testProviderID),
+		ProviderType: ptr.To(testProviderType),
+		Config: ptr.To(keycloakapi.MultivaluedHashMapStringString{
+			"key1": {"val1", "val2"},
+		}),
+	}
+
+	mockComponents.EXPECT().
+		FindComponentByName(context.Background(), testRealmName, testComponentName).
+		Return(existing, nil)
+
+	mockComponents.EXPECT().
+		UpdateComponent(context.Background(), testRealmName, testComponentID, mock.Anything).
+		Return(nil, nil)
+
+	h := NewCreateOrUpdateComponent(fakeClient, kClient, &fakeSecretRefClient{})
+	err := h.Serve(context.Background(), component, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestCreateOrUpdateComponent_Serve_SecretRefConfigKeySkipped(t *testing.T) {
+	mockComponents := mocks.NewMockRealmComponentsClient(t)
+	kClient := &keycloakapi.KeycloakClient{RealmComponents: mockComponents}
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+
+	component := baseComponent()
+	component.Generation = 2
+	component.Status.ObservedGeneration = 2
+	component.Spec.Config = map[string][]string{"bindCredential": {"$secret:key"}}
+	component.Status.ConfigSecretsHash = secretref.ConfigSecretsHash(
+		map[string][]string{"bindCredential": {"$secret:key"}},
+		map[string][]string{"bindCredential": {"resolved-value"}},
+	)
+
+	// Keycloak masks the secret-typed value on GET regardless of the resolved value.
+	existing := &keycloakapi.ComponentRepresentation{
+		Id:           ptr.To(testComponentID),
+		Name:         ptr.To(testComponentName),
+		ProviderId:   ptr.To(testProviderID),
+		ProviderType: ptr.To(testProviderType),
+		Config: ptr.To(keycloakapi.MultivaluedHashMapStringString{
+			"bindCredential": {keycloakapi.MaskedSecretValue},
+		}),
+	}
+
+	mockComponents.EXPECT().
+		FindComponentByName(context.Background(), testRealmName, testComponentName).
+		Return(existing, nil)
+
+	secretRefClient := &mutatingSecretRefClient{mutate: func(config map[string][]string) {
+		config["bindCredential"] = []string{"resolved-value"}
+	}}
+
+	h := NewCreateOrUpdateComponent(fakeClient, kClient, secretRefClient)
+	err := h.Serve(context.Background(), component, testRealmName)
+	require.NoError(t, err)
+}
+
+func TestCreateOrUpdateComponent_Serve_HashDriftForcesUpdate(t *testing.T) {
+	mockComponents := mocks.NewMockRealmComponentsClient(t)
+	kClient := &keycloakapi.KeycloakClient{RealmComponents: mockComponents}
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+
+	component := baseComponent()
+	component.Generation = 2
+	component.Status.ObservedGeneration = 2
+	component.Spec.Config = map[string][]string{"bindCredential": {"$secret:key"}}
+	component.Status.ConfigSecretsHash = "stale-hash"
+
+	existing := &keycloakapi.ComponentRepresentation{
+		Id:           ptr.To(testComponentID),
+		Name:         ptr.To(testComponentName),
+		ProviderId:   ptr.To(testProviderID),
+		ProviderType: ptr.To(testProviderType),
+		Config: ptr.To(keycloakapi.MultivaluedHashMapStringString{
+			"bindCredential": {keycloakapi.MaskedSecretValue},
+		}),
+	}
+
+	mockComponents.EXPECT().
+		FindComponentByName(context.Background(), testRealmName, testComponentName).
+		Return(existing, nil)
+
+	mockComponents.EXPECT().
+		UpdateComponent(context.Background(), testRealmName, testComponentID, mock.Anything).
+		Return(nil, nil)
+
+	secretRefClient := &mutatingSecretRefClient{mutate: func(config map[string][]string) {
+		config["bindCredential"] = []string{"resolved-value"}
+	}}
+
+	h := NewCreateOrUpdateComponent(fakeClient, kClient, secretRefClient)
+	err := h.Serve(context.Background(), component, testRealmName)
+	require.NoError(t, err)
+	assert.NotEqual(t, "stale-hash", component.Status.ConfigSecretsHash)
+}
+
+func TestCreateOrUpdateComponent_Serve_MaskedFetchedValueSkipped(t *testing.T) {
+	mockComponents := mocks.NewMockRealmComponentsClient(t)
+	kClient := &keycloakapi.KeycloakClient{RealmComponents: mockComponents}
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+
+	component := baseComponent()
+	component.Generation = 3
+	component.Status.ObservedGeneration = 3
+	component.Spec.Config = map[string][]string{"bindCredential": {"plain-secret-value"}}
+	component.Status.ConfigSecretsHash = secretref.ConfigSecretsHash(component.Spec.Config, component.Spec.Config)
+
+	// A plain-literal (non secret-ref) value is still masked by Keycloak on GET.
+	existing := &keycloakapi.ComponentRepresentation{
+		Id:           ptr.To(testComponentID),
+		Name:         ptr.To(testComponentName),
+		ProviderId:   ptr.To(testProviderID),
+		ProviderType: ptr.To(testProviderType),
+		Config: ptr.To(keycloakapi.MultivaluedHashMapStringString{
+			"bindCredential": {keycloakapi.MaskedSecretValue},
+		}),
+	}
+
+	mockComponents.EXPECT().
+		FindComponentByName(context.Background(), testRealmName, testComponentName).
+		Return(existing, nil)
+
+	h := NewCreateOrUpdateComponent(fakeClient, kClient, &fakeSecretRefClient{})
+	err := h.Serve(context.Background(), component, testRealmName)
+	require.NoError(t, err)
 }
 
 func TestCreateOrUpdateComponent_Serve_FindByNameError(t *testing.T) {
@@ -173,11 +395,15 @@ func TestCreateOrUpdateComponent_Serve_UpdateError(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
 
 	component := baseComponent()
+	// Pre-seed the hash so it can't itself be the reason the update fires: the test isolates
+	// the providerId drift.
+	component.Status.ConfigSecretsHash = secretref.ConfigSecretsHash(component.Spec.Config, component.Spec.Config)
 
+	// Fetched providerId differs from spec: drift forces the update.
 	existing := &keycloakapi.ComponentRepresentation{
 		Id:           ptr.To(testComponentID),
 		Name:         ptr.To(testComponentName),
-		ProviderId:   ptr.To(testProviderID),
+		ProviderId:   ptr.To("stale-provider"),
 		ProviderType: ptr.To(testProviderType),
 	}
 

--- a/internal/controller/keycloakrealmcomponent/keycloakrealmcomponent_controller.go
+++ b/internal/controller/keycloakrealmcomponent/keycloakrealmcomponent_controller.go
@@ -201,6 +201,7 @@ func (r *RealmComponentReconciler) handleReconciliation(
 	}
 
 	instance.Status.Value = common.StatusOK
+	instance.Status.ObservedGeneration = instance.Generation
 
 	if err := r.updateStatus(ctx, instance, oldStatus); err != nil {
 		return reconcile.Result{}, err

--- a/internal/controller/keycloakrealmidentityprovider/chain/put_idp.go
+++ b/internal/controller/keycloakrealmidentityprovider/chain/put_idp.go
@@ -2,11 +2,8 @@ package chain
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"maps"
-	"slices"
 
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -45,7 +42,7 @@ func (h *PutIDP) Serve(ctx context.Context, keycloakRealmIDP *keycloakApi.Keyclo
 	}
 
 	idpRep := specToIdentityProviderRepresentation(&keycloakRealmIDP.Spec, config)
-	newHash := computeConfigSecretsHash(rawSpecConfig, config)
+	newHash := secretref.ConfigSecretsHashSingle(rawSpecConfig, config)
 
 	existingIDP, _, err := h.idpClient.GetIdentityProvider(ctx, realmName, keycloakRealmIDP.Spec.Alias)
 	if err != nil && !keycloakapi.IsNotFound(err) {
@@ -95,10 +92,6 @@ func specToIdentityProviderRepresentation(spec *keycloakApi.KeycloakRealmIdentit
 	}
 }
 
-// maskedSecretValue is what Keycloak returns on GET for secret-typed config properties,
-// regardless of how the value was originally supplied.
-const maskedSecretValue = "**********"
-
 // idpMatchesSpec reports whether the fetched IDP already matches the desired representation.
 // Config keys are excluded from comparison when Keycloak masks them: either the raw spec value
 // is a secret ref, or the fetched value is already the mask sentinel (e.g. a plain-literal secret).
@@ -128,7 +121,7 @@ func idpMatchesSpec(
 	comparableConfig := make(map[string]string, len(desiredConfig))
 
 	for k, v := range desiredConfig {
-		if secretref.HasSecretRef(rawSpecConfig[k]) || existingConfig[k] == maskedSecretValue {
+		if secretref.HasSecretRef(rawSpecConfig[k]) || existingConfig[k] == keycloakapi.MaskedSecretValue {
 			continue
 		}
 
@@ -136,24 +129,4 @@ func idpMatchesSpec(
 	}
 
 	return maputil.ContainsSubset(existingConfig, comparableConfig)
-}
-
-// computeConfigSecretsHash hashes the resolved values of secret-ref config keys so that
-// rotating the referenced k8s Secret (which does not bump the CR generation) still forces
-// a write. No secret material is stored, only the digest.
-func computeConfigSecretsHash(rawSpecConfig, resolvedConfig map[string]string) string {
-	h := sha256.New()
-
-	for _, k := range slices.Sorted(maps.Keys(rawSpecConfig)) {
-		if !secretref.HasSecretRef(rawSpecConfig[k]) {
-			continue
-		}
-
-		// Length-prefixed to avoid delimiter ambiguity between adjacent key/value pairs.
-		// hash.Hash.Write never returns an error.
-		v := resolvedConfig[k]
-		_, _ = fmt.Fprintf(h, "%d:%s%d:%s", len(k), k, len(v), v)
-	}
-
-	return hex.EncodeToString(h.Sum(nil))
 }

--- a/internal/controller/keycloakrealmidentityprovider/chain/put_idp_test.go
+++ b/internal/controller/keycloakrealmidentityprovider/chain/put_idp_test.go
@@ -15,6 +15,7 @@ import (
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	keycloakapimocks "github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi/mocks"
+	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 	secretrefmocks "github.com/epam/edp-keycloak-operator/pkg/secretref/mocks"
 )
 
@@ -66,11 +67,11 @@ func noSecretRefMock(t *testing.T) refClient {
 func TestPutIDP_Serve(t *testing.T) {
 	t.Parallel()
 
-	inSyncHash := computeConfigSecretsHash(
+	inSyncHash := secretref.ConfigSecretsHashSingle(
 		map[string]string{"clientId": "test-client"},
 		map[string]string{"clientId": "test-client"},
 	)
-	maskedSecretRefHash := computeConfigSecretsHash(
+	maskedSecretRefHash := secretref.ConfigSecretsHashSingle(
 		map[string]string{"clientId": "test-client", "clientSecret": "$secret:key"},
 		map[string]string{"clientId": "test-client", "clientSecret": "resolved-secret-value"},
 	)
@@ -237,7 +238,7 @@ func TestPutIDP_Serve(t *testing.T) {
 				}(),
 				Status: keycloakApi.KeycloakRealmIdentityProviderStatus{
 					ObservedGeneration: 3,
-					ConfigSecretsHash: computeConfigSecretsHash(
+					ConfigSecretsHash: secretref.ConfigSecretsHashSingle(
 						map[string]string{"clientId": "test-client", "clientSecret": "supersecret123"},
 						map[string]string{"clientId": "test-client", "clientSecret": "supersecret123"},
 					),
@@ -247,7 +248,7 @@ func TestPutIDP_Serve(t *testing.T) {
 				existing := inSyncIDPRepresentation()
 				existing.Config = &map[string]string{
 					"clientId":     "test-client",
-					"clientSecret": maskedSecretValue,
+					"clientSecret": keycloakapi.MaskedSecretValue,
 				}
 
 				m := keycloakapimocks.NewMockIdentityProvidersClient(t)

--- a/pkg/client/keycloakapi/constants.go
+++ b/pkg/client/keycloakapi/constants.go
@@ -36,4 +36,7 @@ const (
 	ClientAuthClientJWT       = "client-jwt"
 	ClientAuthClientSecretJWT = "client-secret-jwt"
 	ClientAuthX509Certificate = "client-x509"
+
+	// MaskedSecretValue is the sentinel Keycloak returns for secret-typed config values on GET.
+	MaskedSecretValue = "**********"
 )

--- a/pkg/client/keycloakapi/contracts.go
+++ b/pkg/client/keycloakapi/contracts.go
@@ -475,7 +475,11 @@ type OrganizationsClient interface {
 		params *GetOrganizationsParams,
 	) ([]OrganizationRepresentation, *Response, error)
 	// GetOrganizationByAlias looks up an organization by its alias. Returns ErrNotFound if no match.
+	// The result comes from the list endpoint and omits Attributes; use GetOrganization for the
+	// full representation.
 	GetOrganizationByAlias(ctx context.Context, realm, alias string) (*OrganizationRepresentation, *Response, error)
+	// GetOrganization retrieves the full organization representation, including Attributes, by its Keycloak UUID.
+	GetOrganization(ctx context.Context, realm, orgID string) (*OrganizationRepresentation, *Response, error)
 	// CreateOrganization creates a new organization in the given realm.
 	CreateOrganization(ctx context.Context, realm string, org OrganizationRepresentation) (*Response, error)
 	// UpdateOrganization updates an existing organization.

--- a/pkg/client/keycloakapi/mocks/organizations_client_generated.mock.go
+++ b/pkg/client/keycloakapi/mocks/organizations_client_generated.mock.go
@@ -266,6 +266,88 @@ func (_c *MockOrganizationsClient_DeleteOrganization_Call) RunAndReturn(run func
 	return _c
 }
 
+// GetOrganization provides a mock function for the type MockOrganizationsClient
+func (_mock *MockOrganizationsClient) GetOrganization(ctx context.Context, realm string, orgID string) (*keycloakapi.OrganizationRepresentation, *keycloakapi.Response, error) {
+	ret := _mock.Called(ctx, realm, orgID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOrganization")
+	}
+
+	var r0 *keycloakapi.OrganizationRepresentation
+	var r1 *keycloakapi.Response
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*keycloakapi.OrganizationRepresentation, *keycloakapi.Response, error)); ok {
+		return returnFunc(ctx, realm, orgID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *keycloakapi.OrganizationRepresentation); ok {
+		r0 = returnFunc(ctx, realm, orgID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*keycloakapi.OrganizationRepresentation)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *keycloakapi.Response); ok {
+		r1 = returnFunc(ctx, realm, orgID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*keycloakapi.Response)
+		}
+	}
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string, string) error); ok {
+		r2 = returnFunc(ctx, realm, orgID)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockOrganizationsClient_GetOrganization_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganization'
+type MockOrganizationsClient_GetOrganization_Call struct {
+	*mock.Call
+}
+
+// GetOrganization is a helper method to define mock.On call
+//   - ctx context.Context
+//   - realm string
+//   - orgID string
+func (_e *MockOrganizationsClient_Expecter) GetOrganization(ctx interface{}, realm interface{}, orgID interface{}) *MockOrganizationsClient_GetOrganization_Call {
+	return &MockOrganizationsClient_GetOrganization_Call{Call: _e.mock.On("GetOrganization", ctx, realm, orgID)}
+}
+
+func (_c *MockOrganizationsClient_GetOrganization_Call) Run(run func(ctx context.Context, realm string, orgID string)) *MockOrganizationsClient_GetOrganization_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOrganizationsClient_GetOrganization_Call) Return(v *keycloakapi.OrganizationRepresentation, response *keycloakapi.Response, err error) *MockOrganizationsClient_GetOrganization_Call {
+	_c.Call.Return(v, response, err)
+	return _c
+}
+
+func (_c *MockOrganizationsClient_GetOrganization_Call) RunAndReturn(run func(ctx context.Context, realm string, orgID string) (*keycloakapi.OrganizationRepresentation, *keycloakapi.Response, error)) *MockOrganizationsClient_GetOrganization_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetOrganizationByAlias provides a mock function for the type MockOrganizationsClient
 func (_mock *MockOrganizationsClient) GetOrganizationByAlias(ctx context.Context, realm string, alias string) (*keycloakapi.OrganizationRepresentation, *keycloakapi.Response, error) {
 	ret := _mock.Called(ctx, realm, alias)

--- a/pkg/client/keycloakapi/organizations.go
+++ b/pkg/client/keycloakapi/organizations.go
@@ -76,6 +76,28 @@ func (c *organizationsClient) GetOrganizationByAlias(
 	}
 }
 
+func (c *organizationsClient) GetOrganization(
+	ctx context.Context,
+	realm, orgID string,
+) (*OrganizationRepresentation, *Response, error) {
+	res, err := c.client.GetAdminRealmsRealmOrganizationsOrgIdWithResponse(ctx, realm, orgID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if res == nil {
+		return nil, nil, ErrNilResponse
+	}
+
+	response := &Response{HTTPResponse: res.HTTPResponse, Body: res.Body}
+
+	if err := checkResponseError(res.HTTPResponse, res.Body); err != nil {
+		return nil, response, err
+	}
+
+	return res.JSON200, response, nil
+}
+
 func (c *organizationsClient) CreateOrganization(
 	ctx context.Context,
 	realm string,

--- a/pkg/maputil/maputil.go
+++ b/pkg/maputil/maputil.go
@@ -1,5 +1,7 @@
 package maputil
 
+import "slices"
+
 // SliceToMap builds a map from a slice.
 // key returns the map key and whether the item should be included (ok=false skips the item).
 // val returns the map value.
@@ -26,6 +28,27 @@ func ContainsSubset(m, subset map[string]string) bool {
 	for k, v := range subset {
 		mv, ok := m[k]
 		if !ok || mv != v {
+			return false
+		}
+	}
+
+	return true
+}
+
+// ContainsSubsetMulti reports whether every key in subset is present in m with the
+// same value set; value order is ignored.
+func ContainsSubsetMulti(m, subset map[string][]string) bool {
+	for k, v := range subset {
+		mv, ok := m[k]
+		if !ok {
+			return false
+		}
+
+		if len(v) != len(mv) {
+			return false
+		}
+
+		if !slices.Equal(slices.Sorted(slices.Values(v)), slices.Sorted(slices.Values(mv))) {
 			return false
 		}
 	}

--- a/pkg/maputil/maputil_test.go
+++ b/pkg/maputil/maputil_test.go
@@ -200,3 +200,83 @@ func TestContainsSubset(t *testing.T) {
 		})
 	}
 }
+
+func TestContainsSubsetMulti(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		m        map[string][]string
+		subset   map[string][]string
+		expected bool
+	}{
+		{
+			name:     "empty subset always true",
+			m:        map[string][]string{"a": {"1", "2"}},
+			subset:   map[string][]string{},
+			expected: true,
+		},
+		{
+			name:     "empty subset matches empty map",
+			m:        map[string][]string{},
+			subset:   map[string][]string{},
+			expected: true,
+		},
+		{
+			name:     "equal value sets",
+			m:        map[string][]string{"a": {"1", "2"}},
+			subset:   map[string][]string{"a": {"1", "2"}},
+			expected: true,
+		},
+		{
+			name:     "order-shuffled values still equal",
+			m:        map[string][]string{"a": {"2", "1", "3"}},
+			subset:   map[string][]string{"a": {"3", "1", "2"}},
+			expected: true,
+		},
+		{
+			name:     "value differs",
+			m:        map[string][]string{"a": {"1", "2"}},
+			subset:   map[string][]string{"a": {"1", "3"}},
+			expected: false,
+		},
+		{
+			name:     "value count differs",
+			m:        map[string][]string{"a": {"1", "2"}},
+			subset:   map[string][]string{"a": {"1", "2", "3"}},
+			expected: false,
+		},
+		{
+			name:     "absent key vs empty slice",
+			m:        map[string][]string{},
+			subset:   map[string][]string{"a": {}},
+			expected: false,
+		},
+		{
+			name:     "present key with empty slice matches empty slice",
+			m:        map[string][]string{"a": {}},
+			subset:   map[string][]string{"a": {}},
+			expected: true,
+		},
+		{
+			name:     "extra keys in m are allowed",
+			m:        map[string][]string{"a": {"1"}, "b": {"2"}},
+			subset:   map[string][]string{"a": {"1"}},
+			expected: true,
+		},
+		{
+			name:     "subset key missing from map",
+			m:        map[string][]string{"a": {"1"}},
+			subset:   map[string][]string{"a": {"1"}, "b": {"2"}},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, ContainsSubsetMulti(tc.m, tc.subset))
+		})
+	}
+}

--- a/pkg/secretref/config_secrets_hash_test.go
+++ b/pkg/secretref/config_secrets_hash_test.go
@@ -1,0 +1,129 @@
+package secretref
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasAnySecretRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		values   []string
+		expected bool
+	}{
+		{name: "nil slice", values: nil, expected: false},
+		{name: "empty slice", values: []string{}, expected: false},
+		{name: "no secret ref", values: []string{"plain", "also-plain"}, expected: false},
+		{name: "secret ref among plain values", values: []string{"plain", "$secret:key"}, expected: true},
+		{name: "all secret refs", values: []string{"$a:b", "$c:d"}, expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, HasAnySecretRef(tt.values))
+		})
+	}
+}
+
+func TestConfigSecretsHash_EmptyInputIsConstant(t *testing.T) {
+	t.Parallel()
+
+	emptyDigest := hex.EncodeToString(sha256.New().Sum(nil))
+
+	assert.Equal(t, emptyDigest, ConfigSecretsHash(nil, nil))
+	assert.Equal(t, emptyDigest, ConfigSecretsHash(map[string][]string{}, map[string][]string{}))
+}
+
+func TestConfigSecretsHash_IgnoresKeysWithoutAnySecretRef(t *testing.T) {
+	t.Parallel()
+
+	rawCfg := map[string][]string{
+		"plainKey":  {"literal-value"},
+		"secretKey": {"$secret:key"},
+	}
+
+	base := ConfigSecretsHash(rawCfg, map[string][]string{
+		"plainKey":  {"literal-value"},
+		"secretKey": {"resolved-1"},
+	})
+
+	// Changing the resolved value of a key with no secret ref must not affect the hash.
+	sameAfterPlainChange := ConfigSecretsHash(rawCfg, map[string][]string{
+		"plainKey":  {"changed-but-irrelevant"},
+		"secretKey": {"resolved-1"},
+	})
+	assert.Equal(t, base, sameAfterPlainChange)
+
+	// Changing the resolved value of the secret-ref key must affect the hash.
+	differsAfterSecretChange := ConfigSecretsHash(rawCfg, map[string][]string{
+		"plainKey":  {"literal-value"},
+		"secretKey": {"resolved-2"},
+	})
+	assert.NotEqual(t, base, differsAfterSecretChange)
+}
+
+func TestConfigSecretsHash_ValueOrderIsSignificant(t *testing.T) {
+	t.Parallel()
+
+	rawCfg := map[string][]string{"k": {"$s:1", "$s:2"}}
+
+	forward := ConfigSecretsHash(rawCfg, map[string][]string{"k": {"x", "y"}})
+	reversed := ConfigSecretsHash(rawCfg, map[string][]string{"k": {"y", "x"}})
+
+	assert.NotEqual(t, forward, reversed)
+}
+
+func TestConfigSecretsHash_CountPrefixDisambiguatesValueGrouping(t *testing.T) {
+	t.Parallel()
+
+	rawCfg := map[string][]string{"k": {"$s:1", "$s:2"}}
+
+	// Same concatenated characters ("ab"), grouped as one value vs two: the explicit
+	// per-key value count keeps these from hashing identically.
+	oneValue := ConfigSecretsHash(rawCfg, map[string][]string{"k": {"ab"}})
+	twoValues := ConfigSecretsHash(rawCfg, map[string][]string{"k": {"a", "b"}})
+
+	assert.NotEqual(t, oneValue, twoValues)
+}
+
+func TestConfigSecretsHash_SingleAndMultiValueLists(t *testing.T) {
+	t.Parallel()
+
+	// idp wraps a single string value as a one-element slice; component config is natively
+	// multi-valued. Both shapes go through the same function and hash deterministically.
+	singleValue := ConfigSecretsHash(
+		map[string][]string{"clientSecret": {"$secret:key"}},
+		map[string][]string{"clientSecret": {"resolved-value"}},
+	)
+	assert.NotEmpty(t, singleValue)
+	assert.Equal(t, singleValue, ConfigSecretsHash(
+		map[string][]string{"clientSecret": {"$secret:key"}},
+		map[string][]string{"clientSecret": {"resolved-value"}},
+	))
+
+	multiValue := ConfigSecretsHash(
+		map[string][]string{"bindCredential": {"$secret:a", "$secret:b"}},
+		map[string][]string{"bindCredential": {"resolved-a", "resolved-b"}},
+	)
+	assert.NotEmpty(t, multiValue)
+	assert.NotEqual(t, singleValue, multiValue)
+}
+
+func TestConfigSecretsHashSingle_MatchesWrappedConfigSecretsHash(t *testing.T) {
+	t.Parallel()
+
+	rawCfg := map[string]string{"clientId": "test-client", "clientSecret": "$secret:key"}
+	resolvedCfg := map[string]string{"clientId": "test-client", "clientSecret": "resolved-value"}
+
+	wrappedRaw := map[string][]string{"clientId": {"test-client"}, "clientSecret": {"$secret:key"}}
+	wrappedResolved := map[string][]string{"clientId": {"test-client"}, "clientSecret": {"resolved-value"}}
+
+	assert.Equal(t, ConfigSecretsHash(wrappedRaw, wrappedResolved), ConfigSecretsHashSingle(rawCfg, resolvedCfg))
+}

--- a/pkg/secretref/secretref.go
+++ b/pkg/secretref/secretref.go
@@ -2,7 +2,11 @@ package secretref
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -109,7 +113,52 @@ func HasSecretRef(val string) bool {
 	return strings.HasPrefix(val, secretRefPrefix)
 }
 
+// HasAnySecretRef reports whether any value in values is a secret reference.
+func HasAnySecretRef(values []string) bool {
+	return slices.ContainsFunc(values, HasSecretRef)
+}
+
 // GenerateSecretRef generates secret reference.
 func GenerateSecretRef(secretName, secretFiled string) string {
 	return fmt.Sprintf("%s%s:%s", secretRefPrefix, secretName, secretFiled)
+}
+
+// ConfigSecretsHash hashes the resolved values of secret-ref config keys so that rotating the
+// referenced k8s Secret (which does not bump the CR generation) still forces a write. No secret
+// material is stored, only the digest.
+func ConfigSecretsHash(rawCfg, resolvedCfg map[string][]string) string {
+	h := sha256.New()
+
+	for _, k := range slices.Sorted(maps.Keys(rawCfg)) {
+		if !HasAnySecretRef(rawCfg[k]) {
+			continue
+		}
+
+		values := resolvedCfg[k]
+
+		// Length- and count-prefixed to avoid delimiter ambiguity between adjacent key/value
+		// entries. hash.Hash.Write never returns an error.
+		_, _ = fmt.Fprintf(h, "%d:%s%d:", len(k), k, len(values))
+
+		for _, v := range values {
+			_, _ = fmt.Fprintf(h, "%d:%s", len(v), v)
+		}
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ConfigSecretsHashSingle is ConfigSecretsHash for single-value config maps: each value is
+// wrapped as a one-element slice.
+func ConfigSecretsHashSingle(rawCfg, resolvedCfg map[string]string) string {
+	wrap := func(config map[string]string) map[string][]string {
+		wrapped := make(map[string][]string, len(config))
+		for k, v := range config {
+			wrapped[k] = []string{v}
+		}
+
+		return wrapped
+	}
+
+	return ConfigSecretsHash(wrap(rawCfg), wrap(resolvedCfg))
 }


### PR DESCRIPTION


Both controllers updated Keycloak unconditionally every reconcile on fixed 10-minute timers.

- CreateOrUpdateComponent: update only on drift; config keys backed by secret refs are excluded from the comparison (Keycloak omits or masks secret-typed values on GET); secret rotation propagates via status.configSecretsHash; parentId is compared only when the operator manages it (Keycloak auto-fills it with the realm ID otherwise)
- CreateOrganization: update only on drift; brief fields compared from the list lookup, attributes fetched via the new GetOrganization by-ID wrapper only when needed (the list endpoint omits attributes); domains compared as a deduplicated name set so removals propagate and server-side dedup converges
- both statuses gain observedGeneration; spec edits force writes so removed config keys and attributes propagate
- shared helpers: maputil.ContainsSubsetMulti (order-insensitive multi-valued subset), secretref.ConfigSecretsHash/ConfigSecretsHashSingle/ HasAnySecretRef, keycloakapi.MaskedSecretValue; the IdP chain now uses them (private copies removed)

Same defect class and fix pattern as KeycloakClientScope (e38631e), KeycloakAuthFlow (05a8a74) and KeycloakRealmIdentityProvider (c1623c8).

