### PR TITLE
fix(KeycloakRealm,ClusterKeycloakRealm): skip Keycloak writes when state already matches spec

### DIFF
--- a/api/common/realm.go
+++ b/api/common/realm.go
@@ -315,6 +315,7 @@ type RealmEventConfig struct {
 	// EnabledEventTypes is a list of event types to enable.
 	// +optional
 	// +nullable
+	// +listType=set
 	EnabledEventTypes []string `json:"enabledEventTypes,omitempty"`
 
 	// EventsEnabled indicates whether to enable events.
@@ -330,6 +331,7 @@ type RealmEventConfig struct {
 	// EventsListeners is a list of event listeners to enable.
 	// +optional
 	// +nullable
+	// +listType=set
 	EventsListeners []string `json:"eventsListeners,omitempty"`
 }
 

--- a/api/v1/keycloakrealm_types.go
+++ b/api/v1/keycloakrealm_types.go
@@ -247,6 +247,14 @@ type KeycloakRealmStatus struct {
 
 	// +optional
 	Value string `json:"value,omitempty"`
+
+	// ObservedGeneration is the generation last successfully reconciled to Keycloak.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// ConfigSecretsHash is a hash of resolved secret-ref config values from the last successful reconcile.
+	// +optional
+	ConfigSecretsHash string `json:"configSecretsHash,omitempty"`
 }
 
 func (in *KeycloakRealm) GetFailureCount() int64 {

--- a/api/v1/keycloakrealm_types.go
+++ b/api/v1/keycloakrealm_types.go
@@ -164,6 +164,7 @@ type RealmLocalization struct {
 
 	// SupportedLocales lists locale tags offered to users (BCP 47).
 	// +optional
+	// +listType=set
 	SupportedLocales []string `json:"supportedLocales,omitempty"`
 
 	// DefaultLocale is the realm default locale tag.

--- a/api/v1alpha1/clusterkeycloakrealm_types.go
+++ b/api/v1alpha1/clusterkeycloakrealm_types.go
@@ -142,6 +142,7 @@ type RealmLocalization struct {
 
 	// SupportedLocales lists locale tags offered to users (BCP 47).
 	// +optional
+	// +listType=set
 	SupportedLocales []string `json:"supportedLocales,omitempty"`
 
 	// DefaultLocale is the realm default locale tag.

--- a/api/v1alpha1/clusterkeycloakrealm_types.go
+++ b/api/v1alpha1/clusterkeycloakrealm_types.go
@@ -163,6 +163,14 @@ type ClusterKeycloakRealmStatus struct {
 
 	// +optional
 	Value string `json:"value,omitempty"`
+
+	// ObservedGeneration is the generation last successfully reconciled to Keycloak.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// ConfigSecretsHash is a hash of resolved secret-ref config values from the last successful reconcile.
+	// +optional
+	ConfigSecretsHash string `json:"configSecretsHash,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/config/crd/bases/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -766,7 +766,16 @@ spec:
             properties:
               available:
                 type: boolean
+              configSecretsHash:
+                description: ConfigSecretsHash is a hash of resolved secret-ref config
+                  values from the last successful reconcile.
+                type: string
               failureCount:
+                format: int64
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the generation last successfully
+                  reconciled to Keycloak.
                 format: int64
                 type: integer
               value:

--- a/config/crd/bases/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/config/crd/bases/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -187,6 +187,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: set
                 type: object
               login:
                 description: Login settings for the realm.
@@ -285,6 +286,7 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                    x-kubernetes-list-type: set
                   eventsEnabled:
                     description: EventsEnabled indicates whether to enable events.
                     nullable: true
@@ -300,6 +302,7 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                    x-kubernetes-list-type: set
                 type: object
               realmName:
                 description: RealmName specifies the name of the realm.

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
@@ -810,7 +810,16 @@ spec:
             properties:
               available:
                 type: boolean
+              configSecretsHash:
+                description: ConfigSecretsHash is a hash of resolved secret-ref config
+                  values from the last successful reconcile.
+                type: string
               failureCount:
+                format: int64
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the generation last successfully
+                  reconciled to Keycloak.
                 format: int64
                 type: integer
               value:

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
@@ -201,6 +201,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: set
                 type: object
               login:
                 description: Login settings for the realm.
@@ -299,6 +300,7 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                    x-kubernetes-list-type: set
                   eventsEnabled:
                     description: EventsEnabled indicates whether to enable events.
                     nullable: true
@@ -314,6 +316,7 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                    x-kubernetes-list-type: set
                 type: object
               realmName:
                 description: RealmName specifies the name of the realm.

--- a/deploy-templates/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -766,7 +766,16 @@ spec:
             properties:
               available:
                 type: boolean
+              configSecretsHash:
+                description: ConfigSecretsHash is a hash of resolved secret-ref config
+                  values from the last successful reconcile.
+                type: string
               failureCount:
+                format: int64
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the generation last successfully
+                  reconciled to Keycloak.
                 format: int64
                 type: integer
               value:

--- a/deploy-templates/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -187,6 +187,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: set
                 type: object
               login:
                 description: Login settings for the realm.
@@ -285,6 +286,7 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                    x-kubernetes-list-type: set
                   eventsEnabled:
                     description: EventsEnabled indicates whether to enable events.
                     nullable: true
@@ -300,6 +302,7 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                    x-kubernetes-list-type: set
                 type: object
               realmName:
                 description: RealmName specifies the name of the realm.

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
@@ -810,7 +810,16 @@ spec:
             properties:
               available:
                 type: boolean
+              configSecretsHash:
+                description: ConfigSecretsHash is a hash of resolved secret-ref config
+                  values from the last successful reconcile.
+                type: string
               failureCount:
+                format: int64
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the generation last successfully
+                  reconciled to Keycloak.
                 format: int64
                 type: integer
               value:

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
@@ -201,6 +201,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: set
                 type: object
               login:
                 description: Login settings for the realm.
@@ -299,6 +300,7 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                    x-kubernetes-list-type: set
                   eventsEnabled:
                     description: EventsEnabled indicates whether to enable events.
                     nullable: true
@@ -314,6 +316,7 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                    x-kubernetes-list-type: set
                 type: object
               realmName:
                 description: RealmName specifies the name of the realm.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1698,10 +1698,26 @@ ClusterKeycloakRealmStatus defines the observed state of ClusterKeycloakRealm.
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>configSecretsHash</b></td>
+        <td>string</td>
+        <td>
+          ConfigSecretsHash is a hash of resolved secret-ref config values from the last successful reconcile.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>failureCount</b></td>
         <td>integer</td>
         <td>
           <br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>observedGeneration</b></td>
+        <td>integer</td>
+        <td>
+          ObservedGeneration is the generation last successfully reconciled to Keycloak.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -7991,10 +8007,26 @@ KeycloakRealmStatus defines the observed state of KeycloakRealm.
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>configSecretsHash</b></td>
+        <td>string</td>
+        <td>
+          ConfigSecretsHash is a hash of resolved secret-ref config values from the last successful reconcile.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>failureCount</b></td>
         <td>integer</td>
         <td>
           <br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>observedGeneration</b></td>
+        <td>integer</td>
+        <td>
+          ObservedGeneration is the generation last successfully reconciled to Keycloak.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>

--- a/internal/controller/clusterkeycloakrealm/chain/configure_email.go
+++ b/internal/controller/clusterkeycloakrealm/chain/configure_email.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1alpha1"
+	"github.com/epam/edp-keycloak-operator/internal/controller/helper"
 	keycloakrealmchain "github.com/epam/edp-keycloak-operator/internal/controller/keycloakrealm/chain"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 )
@@ -29,16 +30,21 @@ func (s ConfigureEmail) ServeRequest(ctx context.Context, realm *keycloakApi.Clu
 	l := ctrl.LoggerFrom(ctx)
 	l.Info("Configuring email for realm")
 
-	if err := keycloakrealmchain.ConfigureRealmEmail(
+	newHash, err := keycloakrealmchain.ConfigureRealmEmail(
 		ctx,
 		realm.Spec.RealmName,
 		realm.Spec.Smtp,
 		s.operatorNs,
 		kClient.Realms,
 		s.client,
-	); err != nil {
+		realm.Status.ConfigSecretsHash,
+		helper.SpecChanged(realm.Generation, realm.Status.ObservedGeneration),
+	)
+	if err != nil {
 		return fmt.Errorf("failed to configure email: %w", err)
 	}
+
+	realm.Status.ConfigSecretsHash = newHash
 
 	l.Info("Email has been configured")
 

--- a/internal/controller/clusterkeycloakrealm/chain/configure_email_test.go
+++ b/internal/controller/clusterkeycloakrealm/chain/configure_email_test.go
@@ -19,6 +19,7 @@ import (
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1alpha1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	v2mocks "github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi/mocks"
+	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 )
 
 func TestConfigureEmail_ServeRequest(t *testing.T) {
@@ -115,6 +116,152 @@ func TestConfigureEmail_ServeRequest(t *testing.T) {
 					kClient,
 				),
 			)
+		})
+	}
+}
+
+// TestConfigureEmail_ServeRequest_Idempotency exercises the ConfigSecretsHash/ObservedGeneration
+// plumbing this wrapper passes to the shared keycloakrealmchain.ConfigureRealmEmail.
+func TestConfigureEmail_ServeRequest_Idempotency(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	const namespace = "default"
+
+	smtpSpec := &common.SMTP{
+		Template: common.EmailTemplate{From: "from@mail.com"},
+		Connection: common.EmailConnection{
+			Host: "smtp-host",
+			Port: 25,
+			Authentication: &common.EmailAuthentication{
+				Username: common.SourceRefOrVal{Value: "username"},
+				Password: common.SourceRef{
+					SecretKeyRef: &common.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
+						Key:                  "secret",
+					},
+				},
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: namespace},
+			Data:       map[string][]byte{"secret": []byte("password")},
+		},
+	).Build()
+
+	inSyncSmtpServer := map[string]string{
+		"from":               "from@mail.com",
+		"fromDisplayName":    "",
+		"replyTo":            "",
+		"replyToDisplayName": "",
+		"envelopeFrom":       "",
+		"host":               "smtp-host",
+		"port":               "25",
+		"ssl":                "false",
+		"starttls":           "false",
+		"auth":               "true",
+		"user":               "username",
+		"password":           keycloakapi.MaskedSecretValue,
+	}
+
+	resolvedHash := secretref.ValuesHash(map[string][]string{"password": {"password"}})
+
+	tests := []struct {
+		name        string
+		realm       *keycloakApi.ClusterKeycloakRealm
+		realmClient func(t *testing.T) keycloakapi.RealmClient
+	}{
+		{
+			// smtpServer already matches spec, hash matches, generation unchanged, so
+			// UpdateRealm is intentionally not stubbed here.
+			name: "in sync and hash matches — no write",
+			realm: &keycloakApi.ClusterKeycloakRealm{
+				ObjectMeta: metav1.ObjectMeta{Name: "realm", Generation: 1},
+				Spec:       keycloakApi.ClusterKeycloakRealmSpec{RealmName: "realm", Smtp: smtpSpec},
+				Status: keycloakApi.ClusterKeycloakRealmStatus{
+					ObservedGeneration: 1,
+					ConfigSecretsHash:  resolvedHash,
+				},
+			},
+			realmClient: func(t *testing.T) keycloakapi.RealmClient {
+				m := v2mocks.NewMockRealmClient(t)
+				m.EXPECT().GetRealm(mock.Anything, "realm").
+					Return(&keycloakapi.RealmRepresentation{SmtpServer: &inSyncSmtpServer}, nil, nil)
+
+				return m
+			},
+		},
+		{
+			name: "empty stored hash (upgrade path) — write forced",
+			realm: &keycloakApi.ClusterKeycloakRealm{
+				ObjectMeta: metav1.ObjectMeta{Name: "realm", Generation: 1},
+				Spec:       keycloakApi.ClusterKeycloakRealmSpec{RealmName: "realm", Smtp: smtpSpec},
+				Status:     keycloakApi.ClusterKeycloakRealmStatus{ObservedGeneration: 1},
+			},
+			realmClient: func(t *testing.T) keycloakapi.RealmClient {
+				m := v2mocks.NewMockRealmClient(t)
+				m.EXPECT().GetRealm(mock.Anything, "realm").
+					Return(&keycloakapi.RealmRepresentation{SmtpServer: &inSyncSmtpServer}, nil, nil)
+				m.EXPECT().UpdateRealm(mock.Anything, "realm", mock.Anything).Return(nil, nil)
+
+				return m
+			},
+		},
+		{
+			name: "generation changed — write forced even though in sync",
+			realm: &keycloakApi.ClusterKeycloakRealm{
+				ObjectMeta: metav1.ObjectMeta{Name: "realm", Generation: 2},
+				Spec:       keycloakApi.ClusterKeycloakRealmSpec{RealmName: "realm", Smtp: smtpSpec},
+				Status: keycloakApi.ClusterKeycloakRealmStatus{
+					ObservedGeneration: 1,
+					ConfigSecretsHash:  resolvedHash,
+				},
+			},
+			realmClient: func(t *testing.T) keycloakapi.RealmClient {
+				m := v2mocks.NewMockRealmClient(t)
+				m.EXPECT().GetRealm(mock.Anything, "realm").
+					Return(&keycloakapi.RealmRepresentation{SmtpServer: &inSyncSmtpServer}, nil, nil)
+				m.EXPECT().UpdateRealm(mock.Anything, "realm", mock.Anything).Return(nil, nil)
+
+				return m
+			},
+		},
+		{
+			name: "password rotated — hash mismatch forces write despite matching non-password fields",
+			realm: &keycloakApi.ClusterKeycloakRealm{
+				ObjectMeta: metav1.ObjectMeta{Name: "realm", Generation: 1},
+				Spec:       keycloakApi.ClusterKeycloakRealmSpec{RealmName: "realm", Smtp: smtpSpec},
+				Status: keycloakApi.ClusterKeycloakRealmStatus{
+					ObservedGeneration: 1,
+					ConfigSecretsHash:  secretref.ValuesHash(map[string][]string{"password": {"old-password"}}),
+				},
+			},
+			realmClient: func(t *testing.T) keycloakapi.RealmClient {
+				m := v2mocks.NewMockRealmClient(t)
+				m.EXPECT().GetRealm(mock.Anything, "realm").
+					Return(&keycloakapi.RealmRepresentation{SmtpServer: &inSyncSmtpServer}, nil, nil)
+				m.EXPECT().UpdateRealm(mock.Anything, "realm", mock.Anything).Return(nil, nil)
+
+				return m
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := NewConfigureEmail(k8sClient, namespace)
+			kClient := &keycloakapi.KeycloakClient{Realms: tt.realmClient(t)}
+
+			err := s.ServeRequest(ctrl.LoggerInto(context.Background(), logr.Discard()), tt.realm, kClient)
+			require.NoError(t, err)
+			require.Equal(t, resolvedHash, tt.realm.Status.ConfigSecretsHash)
 		})
 	}
 }

--- a/internal/controller/clusterkeycloakrealm/chain/put_realm_settings_test.go
+++ b/internal/controller/clusterkeycloakrealm/chain/put_realm_settings_test.go
@@ -27,7 +27,9 @@ func TestPutRealmSettings_ServeRequest(t *testing.T) {
 		expectedError   string
 	}{
 		{
-			name: "successful realm settings update with minimal configuration",
+			// Empty spec overlaid on an empty current realm produces no diff, so
+			// UpdateRealm is intentionally not stubbed here.
+			name: "successful realm settings update with minimal configuration, no diff, no write",
 			realm: &v1alpha1.ClusterKeycloakRealm{
 				Spec: v1alpha1.ClusterKeycloakRealmSpec{
 					RealmName: "test-realm",
@@ -36,8 +38,6 @@ func TestPutRealmSettings_ServeRequest(t *testing.T) {
 			setupMocks: func(m *v2mocks.MockRealmClient) {
 				m.EXPECT().GetRealm(mock.Anything, "test-realm").
 					Return(&keycloakapi.RealmRepresentation{}, nil, nil)
-				m.EXPECT().UpdateRealm(mock.Anything, "test-realm", mock.Anything).
-					Return(nil, nil)
 			},
 			setupEventsMock: func(_ *v2mocks.MockEventsClient) {},
 		},
@@ -130,7 +130,8 @@ func TestPutRealmSettings_ServeRequest(t *testing.T) {
 			name: "error when UpdateRealm fails",
 			realm: &v1alpha1.ClusterKeycloakRealm{
 				Spec: v1alpha1.ClusterKeycloakRealmSpec{
-					RealmName: "test-realm",
+					RealmName:   "test-realm",
+					DisplayName: ptr.To("New Name"),
 				},
 			},
 			setupMocks: func(m *v2mocks.MockRealmClient) {

--- a/internal/controller/clusterkeycloakrealm/chain/user_profile_test.go
+++ b/internal/controller/clusterkeycloakrealm/chain/user_profile_test.go
@@ -81,6 +81,46 @@ func TestUserProfile_ServeRequest(t *testing.T) {
 			},
 			wantErr: require.NoError,
 		},
+		{
+			// GetUsersProfile returns exactly what the merge would produce, so
+			// UpdateUsersProfile is intentionally not stubbed here.
+			name: "user profile already in sync — no update",
+			realm: &keycloakApi.ClusterKeycloakRealm{
+				Spec: keycloakApi.ClusterKeycloakRealmSpec{
+					RealmName: "realm",
+					UserProfileConfig: &common.UserProfileConfig{
+						UnmanagedAttributePolicy: "ADMIN_VIEW",
+						Attributes: []common.UserProfileAttribute{
+							{
+								DisplayName: "Attribute 1",
+								Name:        "attr1",
+							},
+						},
+					},
+				},
+			},
+			kClient: func(t *testing.T) *keycloakapi.KeycloakClient {
+				mockUsers := keycloakapimocks.NewMockUsersClient(t)
+
+				mockUsers.On("GetUsersProfile", mock.Anything, "realm").
+					Return(&keycloakapi.UserProfileConfig{
+						UnmanagedAttributePolicy: ptr.To(keycloakapi.UnmanagedAttributePolicy("ADMIN_VIEW")),
+						Attributes: &[]keycloakapi.UserProfileAttribute{
+							{
+								DisplayName: ptr.To("Attribute 1"),
+								Name:        ptr.To("attr1"),
+								Multivalued: ptr.To(false),
+								Annotations: &map[string]any{},
+								Validations: &map[string]map[string]any{},
+							},
+						},
+						Groups: &[]keycloakapi.UserProfileGroup{},
+					}, nil, nil)
+
+				return &keycloakapi.KeycloakClient{Users: mockUsers}
+			},
+			wantErr: require.NoError,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/controller/clusterkeycloakrealm/clusterkeycloakrealm_controller.go
+++ b/internal/controller/clusterkeycloakrealm/clusterkeycloakrealm_controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -95,6 +96,10 @@ func (r *ClusterKeycloakRealmReconciler) Reconcile(ctx context.Context, req ctrl
 		return reconcile.Result{}, nil
 	}
 
+	// Captured before the chain runs: the chain mutates Status.ConfigSecretsHash in place,
+	// and updateSuccessStatus's DeepEqual guard must compare against the persisted status.
+	oldStatus := clusterRealm.Status
+
 	if err := chain.MakeChain(r.client, r.operatorNamespace).ServeRequest(ctx, clusterRealm, kClient); err != nil {
 		clusterRealm.Status.Available = false
 		clusterRealm.Status.Value = err.Error()
@@ -109,7 +114,7 @@ func (r *ClusterKeycloakRealmReconciler) Reconcile(ctx context.Context, req ctrl
 		}, fmt.Errorf("error during ClusterRealm chain: %w", err)
 	}
 
-	if err := r.updateSuccessStatus(ctx, clusterRealm); err != nil {
+	if err := r.updateSuccessStatus(ctx, clusterRealm, oldStatus); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -118,14 +123,19 @@ func (r *ClusterKeycloakRealmReconciler) Reconcile(ctx context.Context, req ctrl
 	}, nil
 }
 
-func (r *ClusterKeycloakRealmReconciler) updateSuccessStatus(ctx context.Context, clusterRealm *keycloakAlpha.ClusterKeycloakRealm) error {
-	if clusterRealm.Status.Available {
-		return nil
-	}
-
+func (r *ClusterKeycloakRealmReconciler) updateSuccessStatus(
+	ctx context.Context,
+	clusterRealm *keycloakAlpha.ClusterKeycloakRealm,
+	oldStatus keycloakAlpha.ClusterKeycloakRealmStatus,
+) error {
 	clusterRealm.Status.Available = true
 	clusterRealm.Status.Value = common.StatusOK
 	clusterRealm.Status.FailureCount = 0
+	clusterRealm.Status.ObservedGeneration = clusterRealm.Generation
+
+	if equality.Semantic.DeepEqual(&clusterRealm.Status, &oldStatus) {
+		return nil
+	}
 
 	if err := r.client.Status().Update(ctx, clusterRealm); err != nil {
 		return fmt.Errorf("unable to update cluster realm status: %w", err)

--- a/internal/controller/keycloakrealm/chain/chain_test.go
+++ b/internal/controller/keycloakrealm/chain/chain_test.go
@@ -52,11 +52,10 @@ func TestCreateDefChain(t *testing.T) {
 	// PutRealm: realm already exists
 	mockRealm.EXPECT().GetRealm(testifymock.Anything, kr.Spec.RealmName).
 		Return(&keycloakapi.RealmRepresentation{}, nil, nil).Once()
-	// RealmSettings: GetRealm + UpdateRealm
+	// RealmSettings: GetRealm only — empty spec overlaid on an empty current realm
+	// produces no diff, so UpdateRealm is not called.
 	mockRealm.EXPECT().GetRealm(testifymock.Anything, kr.Spec.RealmName).
 		Return(&keycloakapi.RealmRepresentation{}, nil, nil).Once()
-	mockRealm.EXPECT().UpdateRealm(testifymock.Anything, kr.Spec.RealmName, testifymock.Anything).
-		Return(nil, nil)
 
 	_ = realmName // kept for local variable consistency
 	chain := CreateDefChain(client, s)

--- a/internal/controller/keycloakrealm/chain/configure_email.go
+++ b/internal/controller/keycloakrealm/chain/configure_email.go
@@ -3,6 +3,7 @@ package chain
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -10,8 +11,10 @@ import (
 
 	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/epam/edp-keycloak-operator/internal/controller/helper"
 	"github.com/epam/edp-keycloak-operator/internal/controller/keycloakrealm/chain/handler"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+	"github.com/epam/edp-keycloak-operator/pkg/maputil"
 	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 )
 
@@ -28,22 +31,31 @@ func (s ConfigureEmail) ServeRequest(ctx context.Context, realm *keycloakApi.Key
 	l := ctrl.LoggerFrom(ctx)
 	l.Info("Configuring email for realm")
 
-	if err := ConfigureRealmEmail(
+	newHash, err := ConfigureRealmEmail(
 		ctx,
 		realm.Spec.RealmName,
 		realm.Spec.Smtp,
 		realm.Namespace,
 		kClient.Realms,
 		s.client,
-	); err != nil {
+		realm.Status.ConfigSecretsHash,
+		helper.SpecChanged(realm.Generation, realm.Status.ObservedGeneration),
+	)
+	if err != nil {
 		return err
 	}
+
+	realm.Status.ConfigSecretsHash = newHash
 
 	l.Info("Email has been configured")
 
 	return nextServeOrNil(ctx, s.next, realm, kClient)
 }
 
+// ConfigureRealmEmail applies emailSpec to the realm's SMTP server config and returns the
+// resolved-secret hash. GetRealm always runs to obtain the comparison baseline; the UpdateRealm
+// write is skipped when forceWrite is false, storedHash matches the newly resolved hash, and
+// the fetched SMTP config already matches spec.
 func ConfigureRealmEmail(
 	ctx context.Context,
 	realmName string,
@@ -51,28 +63,64 @@ func ConfigureRealmEmail(
 	secretsNamespace string,
 	realmClient keycloakapi.RealmClient,
 	k8sClient client.Client,
-) error {
+	storedHash string,
+	forceWrite bool,
+) (string, error) {
 	if emailSpec == nil {
-		return nil
+		return "", nil
 	}
 
 	current, _, err := realmClient.GetRealm(ctx, realmName)
 	if err != nil {
-		return fmt.Errorf("unable to get realm %v: %w", realmName, err)
+		return "", fmt.Errorf("unable to get realm %v: %w", realmName, err)
 	}
 
 	emailMap, err := convertEmailSpecToMap(ctx, emailSpec, secretsNamespace, k8sClient)
 	if err != nil {
-		return err
+		return "", err
+	}
+
+	// Rotating the password's k8s Secret bumps no CR generation; the hash of the resolved
+	// value forces the write instead.
+	passwordValues := map[string][]string{}
+	if emailSpec.Connection.Authentication != nil {
+		passwordValues["password"] = []string{emailMap["password"]}
+	}
+
+	newHash := secretref.ValuesHash(passwordValues)
+
+	if !forceWrite && storedHash == newHash && smtpMatchesSpec(current.SmtpServer, emailMap) {
+		return newHash, nil
 	}
 
 	current.SmtpServer = &emailMap
 
 	if _, err = realmClient.UpdateRealm(ctx, realmName, *current); err != nil {
-		return fmt.Errorf("unable to update realm %v: %w", realmName, err)
+		return "", fmt.Errorf("unable to update realm %v: %w", realmName, err)
 	}
 
-	return nil
+	return newHash, nil
+}
+
+// smtpMatchesSpec reports whether the fetched SMTP config already matches the desired one.
+// The "password" value is excluded from the comparison since Keycloak masks it on GET; key
+// sets must match exactly so keys removed from the spec still trigger a write.
+func smtpMatchesSpec(existing *map[string]string, desired map[string]string) bool {
+	if existing == nil || len(*existing) != len(desired) {
+		return false
+	}
+
+	_, existingHasPassword := (*existing)["password"]
+	_, desiredHasPassword := desired["password"]
+
+	if existingHasPassword != desiredHasPassword {
+		return false
+	}
+
+	want := maps.Clone(desired)
+	delete(want, "password")
+
+	return maputil.ContainsSubset(*existing, want)
 }
 
 func convertEmailSpecToMap(

--- a/internal/controller/keycloakrealm/chain/configure_email_test.go
+++ b/internal/controller/keycloakrealm/chain/configure_email_test.go
@@ -20,6 +20,7 @@ import (
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	v2mocks "github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi/mocks"
+	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 )
 
 func TestConfigureEmail_ServeRequest(t *testing.T) {
@@ -211,6 +212,156 @@ func TestConfigureEmail_ServeRequest(t *testing.T) {
 					kClient,
 				),
 			)
+		})
+	}
+}
+
+func TestConfigureRealmEmail(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	const namespace = "default"
+
+	emailSpec := &common.SMTP{
+		Template: common.EmailTemplate{From: "from@mail.com"},
+		Connection: common.EmailConnection{
+			Host: "smtp-host",
+			Port: 25,
+			Authentication: &common.EmailAuthentication{
+				Username: common.SourceRefOrVal{Value: "username"},
+				Password: common.SourceRef{
+					SecretKeyRef: &common.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
+						Key:                  "secret",
+					},
+				},
+			},
+		},
+	}
+
+	newK8sClient := func(t *testing.T, password string) client.Client {
+		t.Helper()
+
+		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: namespace},
+				Data:       map[string][]byte{"secret": []byte(password)},
+			},
+		).Build()
+	}
+
+	inSyncSmtpServer := map[string]string{
+		"from":               "from@mail.com",
+		"fromDisplayName":    "",
+		"replyTo":            "",
+		"replyToDisplayName": "",
+		"envelopeFrom":       "",
+		"host":               "smtp-host",
+		"port":               "25",
+		"ssl":                "false",
+		"starttls":           "false",
+		"auth":               "true",
+		"user":               "username",
+		"password":           keycloakapi.MaskedSecretValue,
+	}
+
+	resolvedHash := secretref.ValuesHash(map[string][]string{"password": {"password"}})
+
+	tests := []struct {
+		name        string
+		storedHash  string
+		forceWrite  bool
+		k8sClient   client.Client
+		realmClient func(t *testing.T) keycloakapi.RealmClient
+		wantHash    string
+		wantErr     require.ErrorAssertionFunc
+	}{
+		{
+			// smtpServer already matches spec and the hash matches, so UpdateRealm is
+			// intentionally not stubbed here.
+			name:       "in sync and hash matches — no write",
+			storedHash: resolvedHash,
+			forceWrite: false,
+			k8sClient:  newK8sClient(t, "password"),
+			realmClient: func(t *testing.T) keycloakapi.RealmClient {
+				m := v2mocks.NewMockRealmClient(t)
+				m.EXPECT().GetRealm(mock.Anything, "realm").
+					Return(&keycloakapi.RealmRepresentation{SmtpServer: &inSyncSmtpServer}, nil, nil)
+
+				return m
+			},
+			wantHash: resolvedHash,
+			wantErr:  require.NoError,
+		},
+		{
+			name:       "empty stored hash (upgrade path) — write forced",
+			storedHash: "",
+			forceWrite: false,
+			k8sClient:  newK8sClient(t, "password"),
+			realmClient: func(t *testing.T) keycloakapi.RealmClient {
+				m := v2mocks.NewMockRealmClient(t)
+				m.EXPECT().GetRealm(mock.Anything, "realm").
+					Return(&keycloakapi.RealmRepresentation{SmtpServer: &inSyncSmtpServer}, nil, nil)
+				m.EXPECT().UpdateRealm(mock.Anything, "realm", mock.Anything).Return(nil, nil)
+
+				return m
+			},
+			wantHash: resolvedHash,
+			wantErr:  require.NoError,
+		},
+		{
+			name:       "forceWrite true — write applied even though in sync",
+			storedHash: resolvedHash,
+			forceWrite: true,
+			k8sClient:  newK8sClient(t, "password"),
+			realmClient: func(t *testing.T) keycloakapi.RealmClient {
+				m := v2mocks.NewMockRealmClient(t)
+				m.EXPECT().GetRealm(mock.Anything, "realm").
+					Return(&keycloakapi.RealmRepresentation{SmtpServer: &inSyncSmtpServer}, nil, nil)
+				m.EXPECT().UpdateRealm(mock.Anything, "realm", mock.Anything).Return(nil, nil)
+
+				return m
+			},
+			wantHash: resolvedHash,
+			wantErr:  require.NoError,
+		},
+		{
+			name:       "password rotated — hash mismatch forces write despite matching non-password fields",
+			storedHash: secretref.ValuesHash(map[string][]string{"password": {"old-password"}}),
+			forceWrite: false,
+			k8sClient:  newK8sClient(t, "password"),
+			realmClient: func(t *testing.T) keycloakapi.RealmClient {
+				m := v2mocks.NewMockRealmClient(t)
+				m.EXPECT().GetRealm(mock.Anything, "realm").
+					Return(&keycloakapi.RealmRepresentation{SmtpServer: &inSyncSmtpServer}, nil, nil)
+				m.EXPECT().UpdateRealm(mock.Anything, "realm", mock.Anything).Return(nil, nil)
+
+				return m
+			},
+			wantHash: resolvedHash,
+			wantErr:  require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotHash, err := ConfigureRealmEmail(
+				context.Background(),
+				"realm",
+				emailSpec,
+				namespace,
+				tt.realmClient(t),
+				tt.k8sClient,
+				tt.storedHash,
+				tt.forceWrite,
+			)
+
+			tt.wantErr(t, err)
+			require.Equal(t, tt.wantHash, gotHash)
 		})
 	}
 }

--- a/internal/controller/keycloakrealm/chain/realm_localization_texts.go
+++ b/internal/controller/keycloakrealm/chain/realm_localization_texts.go
@@ -66,7 +66,8 @@ func SyncLocalizationTexts(ctx context.Context, kClient *keycloakapi.KeycloakCli
 // are ignored — removal is not supported by the Keycloak POST /localization API.
 func localesAlreadyInSync(current, desired map[string]string) bool {
 	for k, v := range desired {
-		if current[k] != v {
+		cv, ok := current[k]
+		if !ok || cv != v {
 			return false
 		}
 	}

--- a/internal/controller/keycloakrealm/chain/realm_localization_texts_test.go
+++ b/internal/controller/keycloakrealm/chain/realm_localization_texts_test.go
@@ -127,6 +127,28 @@ func TestRealmLocalizationTexts_ServeRequest(t *testing.T) {
 			},
 		},
 		{
+			// Regression: an explicit empty-string translation for a key absent from
+			// Keycloak must still be posted, not silently treated as in-sync.
+			name: "desired empty string for key absent from current — PostRealmLocalization called",
+			realm: &keycloakApi.KeycloakRealm{
+				Spec: keycloakApi.KeycloakRealmSpec{
+					RealmName: "realm1",
+					Localization: &keycloakApi.RealmLocalization{
+						LocalizationTexts: map[string]map[string]string{
+							"en": {"hello": ""},
+						},
+					},
+				},
+			},
+			setupMock: func(m *v2mocks.MockRealmClient) {
+				m.EXPECT().GetRealmLocalization(mock.Anything, "realm1", "en").
+					Return(map[string]string{}, nil, nil)
+				m.EXPECT().PostRealmLocalization(mock.Anything, "realm1", "en", map[string]string{"hello": ""}).
+					Return(nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
 			name: "empty locale kv map — skipped",
 			realm: &keycloakApi.KeycloakRealm{
 				Spec: keycloakApi.KeycloakRealmSpec{
@@ -191,6 +213,14 @@ func TestLocalesAlreadyInSync(t *testing.T) {
 			current: map[string]string{},
 			desired: map[string]string{},
 			want:    true,
+		},
+		{
+			// Regression: a missing key must not be conflated with an explicit empty-string
+			// desired value — both compare equal to the zero value of a plain map index.
+			name:    "desired empty string for key absent from current",
+			current: map[string]string{},
+			desired: map[string]string{"a": ""},
+			want:    false,
 		},
 	}
 

--- a/internal/controller/keycloakrealm/chain/realm_settings_test.go
+++ b/internal/controller/keycloakrealm/chain/realm_settings_test.go
@@ -26,13 +26,13 @@ func TestRealmSettings_ServeRequest(t *testing.T) {
 		wantErr         require.ErrorAssertionFunc
 	}{
 		{
-			name:  "minimal realm — no event config",
+			// Empty spec overlaid on an empty current realm produces no diff, so
+			// UpdateRealm is intentionally not stubbed here.
+			name:  "minimal realm — no event config, no diff, no write",
 			realm: &keycloakApi.KeycloakRealm{},
 			setupMock: func(m *v2mocks.MockRealmClient) {
 				m.EXPECT().GetRealm(mock.Anything, "").
 					Return(&keycloakapi.RealmRepresentation{}, nil, nil)
-				m.EXPECT().UpdateRealm(mock.Anything, "", mock.Anything).
-					Return(nil, nil)
 			},
 			setupEventsMock: func(_ *v2mocks.MockEventsClient) {},
 			wantErr:         require.NoError,
@@ -127,8 +127,12 @@ func TestRealmSettings_ServeRequest(t *testing.T) {
 			},
 		},
 		{
-			name:  "UpdateRealm fails",
-			realm: &keycloakApi.KeycloakRealm{},
+			name: "UpdateRealm fails",
+			realm: &keycloakApi.KeycloakRealm{
+				Spec: keycloakApi.KeycloakRealmSpec{
+					DisplayName: ptr.To("New Name"),
+				},
+			},
 			setupMock: func(m *v2mocks.MockRealmClient) {
 				m.EXPECT().GetRealm(mock.Anything, "").
 					Return(&keycloakapi.RealmRepresentation{}, nil, nil)

--- a/internal/controller/keycloakrealm/chain/set_labels.go
+++ b/internal/controller/keycloakrealm/chain/set_labels.go
@@ -23,12 +23,13 @@ func (s SetLabels) ServeRequest(ctx context.Context, realm *keycloakApi.Keycloak
 		realm.Labels = make(map[string]string)
 	}
 
-	if tr, ok := realm.Labels[TargetRealmLabel]; !ok || tr != realm.Spec.RealmName {
+	tr, ok := realm.Labels[TargetRealmLabel]
+	if !ok || tr != realm.Spec.RealmName {
 		realm.Labels[TargetRealmLabel] = realm.Spec.RealmName
-	}
 
-	if err := s.client.Update(ctx, realm); err != nil {
-		return fmt.Errorf("unable to update realm with new labels, realm: %+v: %w", realm, err)
+		if err := s.client.Update(ctx, realm); err != nil {
+			return fmt.Errorf("unable to update realm with new labels, realm: %+v: %w", realm, err)
+		}
 	}
 
 	return nextServeOrNil(ctx, s.next, realm, kClient)

--- a/internal/controller/keycloakrealm/chain/set_labels_test.go
+++ b/internal/controller/keycloakrealm/chain/set_labels_test.go
@@ -1,0 +1,92 @@
+package chain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+)
+
+func TestSetLabels_ServeRequest(t *testing.T) {
+	t.Parallel()
+
+	s := runtime.NewScheme()
+	require.NoError(t, keycloakApi.AddToScheme(s))
+
+	tests := []struct {
+		name          string
+		realm         *keycloakApi.KeycloakRealm
+		wantUnchanged bool
+	}{
+		{
+			name: "label already correct — no k8s update",
+			realm: &keycloakApi.KeycloakRealm{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "realm1",
+					Namespace: "default",
+					Labels:    map[string]string{TargetRealmLabel: "realm1"},
+				},
+				Spec: keycloakApi.KeycloakRealmSpec{RealmName: "realm1"},
+			},
+			wantUnchanged: true,
+		},
+		{
+			name: "label missing — k8s update applied",
+			realm: &keycloakApi.KeycloakRealm{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "realm2",
+					Namespace: "default",
+				},
+				Spec: keycloakApi.KeycloakRealmSpec{RealmName: "realm2"},
+			},
+			wantUnchanged: false,
+		},
+		{
+			name: "label stale — k8s update applied",
+			realm: &keycloakApi.KeycloakRealm{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "realm3",
+					Namespace: "default",
+					Labels:    map[string]string{TargetRealmLabel: "old-realm-name"},
+				},
+				Spec: keycloakApi.KeycloakRealmSpec{RealmName: "realm3"},
+			},
+			wantUnchanged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			k8sClient := fake.NewClientBuilder().WithScheme(s).WithObjects(tt.realm.DeepCopy()).Build()
+
+			fetched := &keycloakApi.KeycloakRealm{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(tt.realm), fetched))
+			initialResourceVersion := fetched.ResourceVersion
+
+			h := SetLabels{client: k8sClient}
+			err := h.ServeRequest(ctx, fetched, &keycloakapi.KeycloakClient{})
+			require.NoError(t, err)
+			require.Equal(t, tt.realm.Spec.RealmName, fetched.Labels[TargetRealmLabel])
+
+			stored := &keycloakApi.KeycloakRealm{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(tt.realm), stored))
+
+			if tt.wantUnchanged {
+				require.Equal(t, initialResourceVersion, stored.ResourceVersion)
+			} else {
+				require.NotEqual(t, initialResourceVersion, stored.ResourceVersion)
+				require.Equal(t, tt.realm.Spec.RealmName, stored.Labels[TargetRealmLabel])
+			}
+		})
+	}
+}

--- a/internal/controller/keycloakrealm/chain/user_profile.go
+++ b/internal/controller/keycloakrealm/chain/user_profile.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 
@@ -12,6 +13,7 @@ import (
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/internal/controller/keycloakrealm/chain/handler"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+	"github.com/epam/edp-keycloak-operator/pkg/jsonutil"
 )
 
 type UserProfile struct {
@@ -45,12 +47,20 @@ func ProcessUserProfile(ctx context.Context, realm string, userProfileSpec *comm
 		return fmt.Errorf("unable to get current user profile: %w", err)
 	}
 
-	userProfileToUpdate := userProfileConfigSpecToModel(userProfileSpec)
-	attributesToUpdate := userProfileConfigAttributeToMap(&userProfileToUpdate)
-
 	if userProfile.Attributes == nil {
 		userProfile.Attributes = &[]keycloakapi.UserProfileAttribute{}
 	}
+
+	if userProfile.Groups == nil {
+		userProfile.Groups = &[]keycloakapi.UserProfileGroup{}
+	}
+
+	// Snapshot taken after the nil-to-empty normalization so nil-vs-empty slices
+	// cannot defeat the compare.
+	before, beforeErr := json.Marshal(userProfile)
+
+	userProfileToUpdate := userProfileConfigSpecToModel(userProfileSpec)
+	attributesToUpdate := userProfileConfigAttributeToMap(&userProfileToUpdate)
 
 	for i := 0; i < len(*userProfile.Attributes); i++ {
 		attribute := (*userProfile.Attributes)[i]
@@ -67,10 +77,6 @@ func ProcessUserProfile(ctx context.Context, realm string, userProfileSpec *comm
 
 	groupsToUpdate := userProfileConfigGroupToMap(&userProfileToUpdate)
 
-	if userProfile.Groups == nil {
-		userProfile.Groups = &[]keycloakapi.UserProfileGroup{}
-	}
-
 	for i := 0; i < len(*userProfile.Groups); i++ {
 		group := (*userProfile.Groups)[i]
 		if v, ok := groupsToUpdate[*group.Name]; ok {
@@ -85,6 +91,10 @@ func ProcessUserProfile(ctx context.Context, realm string, userProfileSpec *comm
 	}
 
 	userProfile.UnmanagedAttributePolicy = userProfileToUpdate.UnmanagedAttributePolicy
+
+	if jsonutil.Unchanged(before, beforeErr, userProfile) {
+		return nil
+	}
 
 	if _, _, err = kClient.Users.UpdateUsersProfile(
 		ctx,

--- a/internal/controller/keycloakrealm/chain/user_profile_test.go
+++ b/internal/controller/keycloakrealm/chain/user_profile_test.go
@@ -201,6 +201,46 @@ func TestUserProfile_ServeRequest(t *testing.T) {
 			},
 			wantErr: require.NoError,
 		},
+		{
+			// GetUsersProfile returns exactly what the merge would produce, so
+			// UpdateUsersProfile is intentionally not stubbed here.
+			name: "user profile already in sync — no update",
+			realm: &keycloakApi.KeycloakRealm{
+				Spec: keycloakApi.KeycloakRealmSpec{
+					RealmName: "realm",
+					UserProfileConfig: &common.UserProfileConfig{
+						UnmanagedAttributePolicy: "ADMIN_VIEW",
+						Attributes: []common.UserProfileAttribute{
+							{
+								DisplayName: "Attribute 1",
+								Name:        "attr1",
+							},
+						},
+					},
+				},
+			},
+			kClient: func(t *testing.T) *keycloakapi.KeycloakClient {
+				mockUsers := keycloakapimocks.NewMockUsersClient(t)
+
+				mockUsers.On("GetUsersProfile", mock.Anything, "realm").
+					Return(&keycloakapi.UserProfileConfig{
+						UnmanagedAttributePolicy: ptr.To(keycloakapi.UnmanagedAttributePolicy("ADMIN_VIEW")),
+						Attributes: &[]keycloakapi.UserProfileAttribute{
+							{
+								DisplayName: ptr.To("Attribute 1"),
+								Name:        ptr.To("attr1"),
+								Multivalued: ptr.To(false),
+								Annotations: &map[string]any{},
+								Validations: &map[string]map[string]any{},
+							},
+						},
+						Groups: &[]keycloakapi.UserProfileGroup{},
+					}, nil, nil)
+
+				return &keycloakapi.KeycloakClient{Users: mockUsers}
+			},
+			wantErr: require.NoError,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/controller/keycloakrealm/keycloakrealm_controller.go
+++ b/internal/controller/keycloakrealm/keycloakrealm_controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -92,6 +93,10 @@ func (r *ReconcileKeycloakRealm) Reconcile(ctx context.Context, request reconcil
 		return result, resultErr
 	}
 
+	// Captured before the chain runs: the chain mutates Status.ConfigSecretsHash in place,
+	// and the DeepEqual guard below must compare against the persisted status.
+	oldStatus := instance.Status
+
 	if err := r.tryReconcile(ctx, instance); err != nil {
 		if errors.Is(err, helper.ErrKeycloakIsNotAvailable) {
 			return ctrl.Result{
@@ -108,11 +113,14 @@ func (r *ReconcileKeycloakRealm) Reconcile(ctx context.Context, request reconcil
 		instance.Status.Available = true
 		instance.Status.Value = common.StatusOK
 		instance.Status.FailureCount = 0
+		instance.Status.ObservedGeneration = instance.Generation
 		result.RequeueAfter = r.successReconcileTimeout
 	}
 
-	if err := r.client.Status().Update(ctx, instance); err != nil {
-		resultErr = fmt.Errorf("unable to update status: %w", err)
+	if !equality.Semantic.DeepEqual(&instance.Status, &oldStatus) {
+		if err := r.client.Status().Update(ctx, instance); err != nil {
+			resultErr = fmt.Errorf("unable to update status: %w", err)
+		}
 	}
 
 	return result, resultErr

--- a/pkg/client/keycloakapi/realm.go
+++ b/pkg/client/keycloakapi/realm.go
@@ -127,6 +127,10 @@ func (c *realmClient) SetRealmBrowserFlow(ctx context.Context, realm string, flo
 		return resp, fmt.Errorf("unable to get realm: %w", err)
 	}
 
+	if current.BrowserFlow != nil && *current.BrowserFlow == flowAlias {
+		return resp, nil
+	}
+
 	current.BrowserFlow = &flowAlias
 
 	return c.UpdateRealm(ctx, realm, *current)

--- a/pkg/jsonutil/jsonutil.go
+++ b/pkg/jsonutil/jsonutil.go
@@ -1,0 +1,19 @@
+// Package jsonutil provides JSON-based comparison helpers.
+package jsonutil
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// Unchanged reports whether v marshals to exactly before.
+// Any marshal failure reports false so callers fall back to writing.
+func Unchanged(before []byte, beforeErr error, v any) bool {
+	if beforeErr != nil {
+		return false
+	}
+
+	after, err := json.Marshal(v)
+
+	return err == nil && bytes.Equal(before, after)
+}

--- a/pkg/jsonutil/jsonutil_test.go
+++ b/pkg/jsonutil/jsonutil_test.go
@@ -1,0 +1,35 @@
+package jsonutil
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnchanged(t *testing.T) {
+	t.Parallel()
+
+	type rep struct {
+		Name  *string           `json:"name,omitempty"`
+		Attrs map[string]string `json:"attrs,omitempty"`
+	}
+
+	name := "realm"
+	v := &rep{Name: &name, Attrs: map[string]string{"a": "1"}}
+
+	before, err := json.Marshal(v)
+
+	assert.NoError(t, err)
+	assert.True(t, Unchanged(before, nil, v))
+
+	v.Attrs["a"] = "2"
+	assert.False(t, Unchanged(before, nil, v))
+
+	v.Attrs["a"] = "1"
+	assert.True(t, Unchanged(before, nil, v))
+
+	assert.False(t, Unchanged(before, errors.New("marshal failed"), v))
+	assert.False(t, Unchanged(before, nil, func() {}))
+}

--- a/pkg/realmbuilder/settings_builder.go
+++ b/pkg/realmbuilder/settings_builder.go
@@ -2,8 +2,10 @@ package realmbuilder
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -13,6 +15,7 @@ import (
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/api/v1alpha1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+	"github.com/epam/edp-keycloak-operator/pkg/jsonutil"
 )
 
 // commonRealmSpec holds the normalized, API-version-agnostic fields shared by
@@ -63,6 +66,8 @@ func ApplyRealmEventConfig(
 		current = &keycloakapi.RealmEventsConfigRepresentation{}
 	}
 
+	before, beforeErr := json.Marshal(current)
+
 	if cfg.AdminEventsDetailsEnabled != nil {
 		current.AdminEventsDetailsEnabled = cfg.AdminEventsDetailsEnabled
 	}
@@ -80,11 +85,15 @@ func ApplyRealmEventConfig(
 	}
 
 	if cfg.EnabledEventTypes != nil {
-		current.EnabledEventTypes = &cfg.EnabledEventTypes
+		mergeStringSet(&current.EnabledEventTypes, &cfg.EnabledEventTypes)
 	}
 
 	if cfg.EventsListeners != nil {
-		current.EventsListeners = &cfg.EventsListeners
+		mergeStringSet(&current.EventsListeners, &cfg.EventsListeners)
+	}
+
+	if jsonutil.Unchanged(before, beforeErr, current) {
+		return nil
 	}
 
 	if _, err := eventsClient.SetEventsConfig(ctx, realmName, *current); err != nil {
@@ -107,7 +116,13 @@ func ApplyRealmSettings(
 		return fmt.Errorf("unable to get realm: %w", err)
 	}
 
+	before, beforeErr := json.Marshal(current)
+
 	MergeRealmRepresentation(current, &overlay)
+
+	if jsonutil.Unchanged(before, beforeErr, current) {
+		return nil
+	}
 
 	if _, err := realmClient.UpdateRealm(ctx, realmName, *current); err != nil {
 		return fmt.Errorf("unable to update realm settings: %w", err)
@@ -320,8 +335,35 @@ func mergeRealmAppearance(base, overlay *keycloakapi.RealmRepresentation) {
 	mergePtr(&base.EmailTheme, &overlay.EmailTheme)
 	mergePtr(&base.InternationalizationEnabled, &overlay.InternationalizationEnabled)
 	mergePtr(&base.PasswordPolicy, &overlay.PasswordPolicy)
-	mergePtr(&base.SupportedLocales, &overlay.SupportedLocales)
+	mergeStringSet(&base.SupportedLocales, overlay.SupportedLocales)
 	mergePtr(&base.DefaultLocale, &overlay.DefaultLocale)
+}
+
+// mergeStringSet replaces base only when the sets differ: Keycloak stores supportedLocales,
+// enabledEventTypes and eventsListeners as sets and returns them in arbitrary order, so an
+// order-only difference must not defeat the snapshot compare.
+func mergeStringSet(base **[]string, overlay *[]string) {
+	if overlay == nil {
+		return
+	}
+
+	if *base != nil && equalStringSets(**base, *overlay) {
+		return
+	}
+
+	*base = overlay
+}
+
+func equalStringSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	as, bs := slices.Clone(a), slices.Clone(b)
+	slices.Sort(as)
+	slices.Sort(bs)
+
+	return slices.Equal(as, bs)
 }
 
 func mergeRealmTokenSettings(base, overlay *keycloakapi.RealmRepresentation) {

--- a/pkg/realmbuilder/settings_builder_test.go
+++ b/pkg/realmbuilder/settings_builder_test.go
@@ -2,6 +2,7 @@ package realmbuilder
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -772,6 +773,53 @@ func TestApplyRealmEventConfig(t *testing.T) {
 			wantErr: require.NoError,
 		},
 		{
+			// Keycloak stores enabledEventTypes as a set and returns it in arbitrary order:
+			// SetEventsConfig is intentionally not stubbed here.
+			name: "in sync — enabledEventTypes differ only in order, no write",
+			cfg: &common.RealmEventConfig{
+				EnabledEventTypes: []string{"LOGIN", "LOGOUT"},
+			},
+			setupMock: func(m *v2mocks.MockEventsClient) {
+				m.EXPECT().GetEventsConfig(mock.Anything, "test-realm").
+					Return(&keycloakapi.RealmEventsConfigRepresentation{
+						EnabledEventTypes: &[]string{"LOGOUT", "LOGIN"},
+					}, nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
+			// eventsListeners is a set too; SetEventsConfig is intentionally not stubbed here.
+			name: "in sync — eventsListeners differ only in order, no write",
+			cfg: &common.RealmEventConfig{
+				EventsListeners: []string{"jboss-logging", "email"},
+			},
+			setupMock: func(m *v2mocks.MockEventsClient) {
+				m.EXPECT().GetEventsConfig(mock.Anything, "test-realm").
+					Return(&keycloakapi.RealmEventsConfigRepresentation{
+						EventsListeners: &[]string{"email", "jboss-logging"},
+					}, nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "drift — enabledEventTypes sets differ, write applied",
+			cfg: &common.RealmEventConfig{
+				EnabledEventTypes: []string{"LOGIN", "LOGOUT"},
+			},
+			setupMock: func(m *v2mocks.MockEventsClient) {
+				m.EXPECT().GetEventsConfig(mock.Anything, "test-realm").
+					Return(&keycloakapi.RealmEventsConfigRepresentation{
+						EnabledEventTypes: &[]string{"LOGIN"},
+					}, nil, nil)
+				m.EXPECT().SetEventsConfig(mock.Anything, "test-realm",
+					mock.MatchedBy(func(rep keycloakapi.RealmEventsConfigRepresentation) bool {
+						return rep.EnabledEventTypes != nil &&
+							slices.Equal(*rep.EnabledEventTypes, []string{"LOGIN", "LOGOUT"})
+					})).Return(nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
 			name: "explicit false propagated for all boolean fields",
 			cfg: &common.RealmEventConfig{
 				AdminEventsDetailsEnabled: ptr.To(false),
@@ -851,6 +899,23 @@ func TestApplyRealmEventConfig(t *testing.T) {
 			wantErr: require.NoError,
 		},
 		{
+			name: "in sync — cfg already matches current, no write",
+			cfg: &common.RealmEventConfig{
+				AdminEventsDetailsEnabled: ptr.To(true),
+				AdminEventsEnabled:        ptr.To(true),
+				EventsEnabled:             ptr.To(true),
+			},
+			setupMock: func(m *v2mocks.MockEventsClient) {
+				m.EXPECT().GetEventsConfig(mock.Anything, "test-realm").
+					Return(&keycloakapi.RealmEventsConfigRepresentation{
+						AdminEventsDetailsEnabled: ptr.To(true),
+						AdminEventsEnabled:        ptr.To(true),
+						EventsEnabled:             ptr.To(true),
+					}, nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
 			name: "GetEventsConfig fails — error returned",
 			cfg:  &common.RealmEventConfig{EventsEnabled: ptr.To(true)},
 			setupMock: func(m *v2mocks.MockEventsClient) {
@@ -913,7 +978,12 @@ func TestApplyRealmSettings(t *testing.T) {
 			wantErr: require.NoError,
 		},
 		{
-			name: "unset fields in overlay preserve externally-set Keycloak values",
+			// Overlay fields are unset (nil), so the merge leaves current untouched; current
+			// already carries these values, so the before/after JSON snapshots are equal and
+			// the write is skipped. UpdateRealm is intentionally not stubbed: a merge
+			// regression that clobbers these fields triggers an unexpected mock call and
+			// fails the test.
+			name: "in sync — unset overlay fields already match externally-set Keycloak values, no write",
 			overlay: BuildRealmRepresentationFromV1(&keycloakApi.KeycloakRealm{
 				Spec: keycloakApi.KeycloakRealmSpec{RealmName: "test-realm"},
 			}),
@@ -924,10 +994,50 @@ func TestApplyRealmSettings(t *testing.T) {
 						DisplayNameHtml:      ptr.To("<b>Externally Set</b>"),
 						OrganizationsEnabled: ptr.To(true),
 					}, nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
+			// Keycloak stores supportedLocales as a set and returns it in arbitrary order:
+			// an order-only difference must not trigger a write.
+			name: "in sync — supportedLocales differ only in order, no write",
+			overlay: keycloakapi.RealmRepresentation{
+				InternationalizationEnabled: ptr.To(true),
+				SupportedLocales:            &[]string{"en", "de"},
+			},
+			setupMock: func(m *v2mocks.MockRealmClient) {
+				m.EXPECT().GetRealm(mock.Anything, "test-realm").
+					Return(&keycloakapi.RealmRepresentation{
+						InternationalizationEnabled: ptr.To(true),
+						SupportedLocales:            &[]string{"de", "en"},
+					}, nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "drift — supportedLocales sets differ, write applied",
+			overlay: keycloakapi.RealmRepresentation{
+				SupportedLocales: &[]string{"en", "fr"},
+			},
+			setupMock: func(m *v2mocks.MockRealmClient) {
+				m.EXPECT().GetRealm(mock.Anything, "test-realm").
+					Return(&keycloakapi.RealmRepresentation{
+						SupportedLocales: &[]string{"de", "en"},
+					}, nil, nil)
 				m.EXPECT().UpdateRealm(mock.Anything, "test-realm", mock.MatchedBy(func(rep keycloakapi.RealmRepresentation) bool {
-					return rep.DisplayName != nil && *rep.DisplayName == "Externally Set" &&
-						rep.DisplayNameHtml != nil && *rep.DisplayNameHtml == "<b>Externally Set</b>" &&
-						rep.OrganizationsEnabled != nil && *rep.OrganizationsEnabled
+					return rep.SupportedLocales != nil && slices.Equal(*rep.SupportedLocales, []string{"en", "fr"})
+				})).Return(nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name:    "drift — overlay differs from current, write applied",
+			overlay: keycloakapi.RealmRepresentation{DisplayName: ptr.To("New Name")},
+			setupMock: func(m *v2mocks.MockRealmClient) {
+				m.EXPECT().GetRealm(mock.Anything, "test-realm").
+					Return(&keycloakapi.RealmRepresentation{DisplayName: ptr.To("Old Name")}, nil, nil)
+				m.EXPECT().UpdateRealm(mock.Anything, "test-realm", mock.MatchedBy(func(rep keycloakapi.RealmRepresentation) bool {
+					return rep.DisplayName != nil && *rep.DisplayName == "New Name"
 				})).Return(nil, nil)
 			},
 			wantErr: require.NoError,
@@ -946,7 +1056,7 @@ func TestApplyRealmSettings(t *testing.T) {
 		},
 		{
 			name:    "UpdateRealm fails — error returned",
-			overlay: keycloakapi.RealmRepresentation{},
+			overlay: keycloakapi.RealmRepresentation{DisplayName: ptr.To("New Name")},
 			setupMock: func(m *v2mocks.MockRealmClient) {
 				m.EXPECT().GetRealm(mock.Anything, "test-realm").
 					Return(&keycloakapi.RealmRepresentation{}, nil, nil)

--- a/pkg/secretref/secretref.go
+++ b/pkg/secretref/secretref.go
@@ -123,18 +123,14 @@ func GenerateSecretRef(secretName, secretFiled string) string {
 	return fmt.Sprintf("%s%s:%s", secretRefPrefix, secretName, secretFiled)
 }
 
-// ConfigSecretsHash hashes the resolved values of secret-ref config keys so that rotating the
-// referenced k8s Secret (which does not bump the CR generation) still forces a write. No secret
-// material is stored, only the digest.
-func ConfigSecretsHash(rawCfg, resolvedCfg map[string][]string) string {
+// ValuesHash hashes resolved secret values so that rotating the backing k8s Secret (which
+// does not bump the CR generation) still forces a write. No secret material is stored, only
+// the digest.
+func ValuesHash(cfg map[string][]string) string {
 	h := sha256.New()
 
-	for _, k := range slices.Sorted(maps.Keys(rawCfg)) {
-		if !HasAnySecretRef(rawCfg[k]) {
-			continue
-		}
-
-		values := resolvedCfg[k]
+	for _, k := range slices.Sorted(maps.Keys(cfg)) {
+		values := cfg[k]
 
 		// Length- and count-prefixed to avoid delimiter ambiguity between adjacent key/value
 		// entries. hash.Hash.Write never returns an error.
@@ -146,6 +142,19 @@ func ConfigSecretsHash(rawCfg, resolvedCfg map[string][]string) string {
 	}
 
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ConfigSecretsHash is ValuesHash restricted to keys whose raw config value is a secret ref.
+func ConfigSecretsHash(rawCfg, resolvedCfg map[string][]string) string {
+	secretBacked := make(map[string][]string)
+
+	for k, raw := range rawCfg {
+		if HasAnySecretRef(raw) {
+			secretBacked[k] = resolvedCfg[k]
+		}
+	}
+
+	return ValuesHash(secretBacked)
 }
 
 // ConfigSecretsHashSingle is ConfigSecretsHash for single-value config maps: each value is


### PR DESCRIPTION


Both realm controllers wrote to Keycloak unconditionally on every reconcile cycle: two full-realm PUTs (settings merge + SMTP), the events-config PUT, the browser-flow PUT and the user-profile PUT ran even when nothing changed, plus unconditional k8s label and status writes.

- ApplyRealmSettings/ApplyRealmEventConfig/ProcessUserProfile take a JSON snapshot of the fetched representation before the in-place merge and skip the write only when the merged payload is byte-identical (jsonutil.Unchanged; marshal errors fall through to the write)
- supportedLocales, enabledEventTypes and eventsListeners are merged as sets (mergeStringSet): Keycloak stores each as a set and returns it in arbitrary order, so an order-only difference no longer forces a write every cycle
- ConfigureRealmEmail compares the full SMTP map excluding the masked password; password rotation propagates via status.configSecretsHash (secretref.ValuesHash); spec edits force one write via observedGeneration
- SetRealmBrowserFlow skips the PUT when the realm already uses the requested flow
- localesAlreadyInSync uses a two-value map lookup so an explicit empty-string translation for a never-posted key is applied
- SetLabels updates the CR only when the label actually changes; both controllers stamp observedGeneration and skip no-op status writes
- both statuses gain observedGeneration and configSecretsHash

