### PR TITLE
test(KeycloakOrganization): match the stable part of the duplicate-domain error

### DIFF
--- a/internal/controller/keycloakorganization/keycloakorganization_controller_integration_test.go
+++ b/internal/controller/keycloakorganization/keycloakorganization_controller_integration_test.go
@@ -297,11 +297,13 @@ var _ = Describe("Organization controller", Ordered, func() {
 		time.Sleep(time.Second * 5)
 
 		By("Checking second Organization status shows duplicate domain error")
+		// Match only the stable prefix: Keycloak names the owning organization from
+		// 26.7.0 on, where earlier releases said "another organization".
 		Consistently(func(g Gomega) {
 			createdOrg := &v1alpha1.KeycloakOrganization{}
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: org2.Name, Namespace: ns}, createdOrg)
 			g.Expect(err).ShouldNot(HaveOccurred())
-			g.Expect(createdOrg.Status.Value).Should(ContainSubstring("Domain duplicate-domain.com is already linked to another organization"))
+			g.Expect(createdOrg.Status.Value).Should(ContainSubstring("Domain duplicate-domain.com is already linked to"))
 		}, time.Second*3, time.Second).Should(Succeed())
 
 		By("Cleaning up first organization")


### PR DESCRIPTION


The spec asserted Keycloak's full error text. In 26.7.0 that text changed from "already linked to another organization" to "already linked to organization <name>", so the spec failed on 26.7.x while the operator behaved correctly: the create is still rejected with HTTP 400 and the error still reaches status.value.

Assert only the prefix both releases share, which still pins the offending domain and distinguishes this failure from any other create error.

