### PR TITLE
test(idempotency): add regression suites for unnecessary Keycloak writes

### DIFF
--- a/internal/controller/clusterkeycloakrealm/clusterkeycloakrealm_idempotency_integration_test.go
+++ b/internal/controller/clusterkeycloakrealm/clusterkeycloakrealm_idempotency_integration_test.go
@@ -1,0 +1,141 @@
+package clusterkeycloakrealm
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/epam/edp-keycloak-operator/api/common"
+	keycloakAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+	"github.com/epam/edp-keycloak-operator/pkg/testutils"
+)
+
+// Idempotency suite for ClusterKeycloakRealm.
+var _ = Describe("ClusterKeycloakRealm idempotent reconcile", Ordered, func() {
+	const (
+		crName    = "idem-cluster-realm"
+		realmName = "idem-cluster-realm"
+		settle    = testutils.Settle
+		longWait  = testutils.LongWait
+	)
+
+	var recorder *testutils.AdminEventRecorder
+
+	nudge := func() {
+		Expect(testutils.Nudge(ctx, k8sClient,
+			types.NamespacedName{Name: crName}, &keycloakAlpha.ClusterKeycloakRealm{})).To(Succeed())
+	}
+
+	updateSpec := func(mutate func(*keycloakAlpha.ClusterKeycloakRealm)) {
+		Eventually(func(g Gomega) {
+			cr := &keycloakAlpha.ClusterKeycloakRealm{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName}, cr)).To(Succeed())
+			mutate(cr)
+			g.Expect(k8sClient.Update(ctx, cr)).To(Succeed())
+		}, longWait, interval).Should(Succeed())
+	}
+
+	waitReady := func() {
+		Eventually(func(g Gomega) {
+			cr := &keycloakAlpha.ClusterKeycloakRealm{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName}, cr)).To(Succeed())
+			g.Expect(cr.Status.Available).To(BeTrue())
+			g.Expect(cr.Status.ObservedGeneration).To(Equal(cr.Generation))
+		}, longWait, interval).Should(Succeed())
+	}
+
+	kcRealm := func() *keycloakapi.RealmRepresentation {
+		rep, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmName)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(rep).ShouldNot(BeNil())
+
+		return rep
+	}
+
+	It("Should create ClusterKeycloakRealm with locales and event settings", func() {
+		cr := &keycloakAlpha.ClusterKeycloakRealm{
+			ObjectMeta: metav1.ObjectMeta{Name: crName},
+			Spec: keycloakAlpha.ClusterKeycloakRealmSpec{
+				ClusterKeycloakRef: ClusterKeycloakCR,
+				RealmName:          realmName,
+				DisplayName:        ptr.To("Idem Cluster Realm"),
+				RealmEventConfig: &common.RealmEventConfig{
+					AdminEventsEnabled:        ptr.To(true),
+					AdminEventsDetailsEnabled: ptr.To(true),
+					EnabledEventTypes:         []string{"LOGIN", "LOGOUT"},
+					EventsListeners:           []string{"jboss-logging"},
+				},
+				Localization: &keycloakAlpha.RealmLocalization{
+					InternationalizationEnabled: ptr.To(true),
+					SupportedLocales:            []string{"en", "de", "uk"},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+		waitReady()
+
+		created := kcRealm()
+		Expect(ptr.Deref(created.DisplayName, "")).To(Equal("Idem Cluster Realm"))
+		Expect(*created.SupportedLocales).To(ConsistOf("en", "de", "uk"))
+
+		recorder = testutils.NewAdminEventRecorder(keycloakApiClient, realmName)
+	})
+
+	It("Should not write to Keycloak when a reconcile is forced with no spec change", func() {
+		Expect(recorder.WritesDuring(ctx, settle, nudge)).To(BeEmpty())
+	})
+
+	It("Should heal external drift on the realm", func() {
+		// Liveness anchor for this suite's empty-window specs. The drift write sits
+		// inside the window: the controller reconciles on a timer and can heal it
+		// before the nudge lands.
+		Expect(recorder.WritesDuring(ctx, 0, func() {
+			rep := kcRealm()
+			rep.DisplayName = ptr.To("drifted-by-hand")
+			_, err := keycloakApiClient.Realms.UpdateRealm(ctx, realmName, *rep)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			nudge()
+
+			Eventually(func(g Gomega) {
+				g.Expect(ptr.Deref(kcRealm().DisplayName, "")).To(Equal("Idem Cluster Realm"))
+			}, longWait, interval).Should(Succeed())
+		})).ShouldNot(BeEmpty(), "admin event log recorded nothing for a known write")
+	})
+
+	It("Should remove a locale from Keycloak when it is removed from spec", func() {
+		updateSpec(func(cr *keycloakAlpha.ClusterKeycloakRealm) {
+			cr.Spec.Localization.SupportedLocales = []string{"en", "de"}
+		})
+		waitReady()
+
+		Eventually(func(g Gomega) {
+			g.Expect(*kcRealm().SupportedLocales).To(ConsistOf("en", "de"))
+		}, longWait, interval).Should(Succeed())
+	})
+
+	It("Should not write to Keycloak after the edit settles", func() {
+		Expect(recorder.WritesDuring(ctx, settle, nudge)).To(BeEmpty())
+	})
+
+	It("Should delete ClusterKeycloakRealm and remove the realm from Keycloak", func() {
+		cr := &keycloakAlpha.ClusterKeycloakRealm{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName}, cr)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+
+		Eventually(func() bool {
+			return k8sErrors.IsNotFound(
+				k8sClient.Get(ctx, types.NamespacedName{Name: crName}, &keycloakAlpha.ClusterKeycloakRealm{}))
+		}, longWait, interval).Should(BeTrue())
+
+		Eventually(func(g Gomega) {
+			_, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmName)
+			g.Expect(err).Should(HaveOccurred(), "realm must be gone from Keycloak")
+		}, longWait, interval).Should(Succeed())
+	})
+})

--- a/internal/controller/keycloakauthflow/keycloakauthflow_idempotency_integration_test.go
+++ b/internal/controller/keycloakauthflow/keycloakauthflow_idempotency_integration_test.go
@@ -1,0 +1,191 @@
+package keycloakauthflow
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/epam/edp-keycloak-operator/api/common"
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/epam/edp-keycloak-operator/pkg/testutils"
+)
+
+// Idempotency suite for KeycloakAuthFlow.
+var _ = Describe("KeycloakAuthFlow idempotent reconcile", Ordered, func() {
+	const (
+		crName    = "idem-flow"
+		flowAlias = "idem-flow"
+		realmCR   = "idem-flow-realm"
+		settle    = testutils.Settle
+		longWait  = testutils.LongWait
+	)
+
+	var recorder *testutils.AdminEventRecorder
+
+	nudge := func() {
+		Expect(testutils.Nudge(ctx, k8sClient,
+			types.NamespacedName{Name: crName, Namespace: ns}, &keycloakApi.KeycloakAuthFlow{})).To(Succeed())
+	}
+
+	updateSpec := func(mutate func(*keycloakApi.KeycloakAuthFlow)) {
+		Eventually(func(g Gomega) {
+			cr := &keycloakApi.KeycloakAuthFlow{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+			mutate(cr)
+			g.Expect(k8sClient.Update(ctx, cr)).To(Succeed())
+		}, longWait, interval).Should(Succeed())
+	}
+
+	waitReady := func() {
+		Eventually(func(g Gomega) {
+			cr := &keycloakApi.KeycloakAuthFlow{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+			g.Expect(cr.Status.Value).To(Equal(common.StatusOK))
+			g.Expect(cr.Status.ObservedGeneration).To(Equal(cr.Generation))
+		}, longWait, interval).Should(Succeed())
+	}
+
+	// execProvider returns the defaultProvider recorded on the flow's single execution,
+	// resolved through the live Keycloak state rather than the CR.
+	execProvider := func(g Gomega) string {
+		execs, _, err := keycloakApiClient.AuthFlows.GetFlowExecutions(ctx, realmCR, flowAlias)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(execs).ShouldNot(BeEmpty())
+		g.Expect(execs[0].AuthenticationConfig).ShouldNot(BeNil(), "execution must carry an authenticator config")
+
+		cfg, _, err := keycloakApiClient.AuthFlows.GetAuthenticatorConfig(ctx, realmCR, *execs[0].AuthenticationConfig)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(cfg).ShouldNot(BeNil())
+		g.Expect(cfg.Config).ShouldNot(BeNil())
+
+		return (*cfg.Config)["defaultProvider"]
+	}
+
+	flowExists := func() bool {
+		flows, _, err := keycloakApiClient.Realms.GetAuthenticationFlows(ctx, realmCR)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		for _, f := range flows {
+			if ptr.Deref(f.Alias, "") == flowAlias {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	// This suite owns its realm. A flow's admin events land under disjoint resource
+	// paths (authentication/flows, authentication/executions, authentication/config),
+	// so the recorder cannot be scoped to one flow; realm isolation replaces scoping.
+	BeforeAll(func() {
+		realm := &keycloakApi.KeycloakRealm{
+			ObjectMeta: metav1.ObjectMeta{Name: realmCR, Namespace: ns},
+			Spec: keycloakApi.KeycloakRealmSpec{
+				RealmName:   realmCR,
+				KeycloakRef: common.KeycloakRef{Name: KeycloakCR, Kind: keycloakApi.KeycloakKind},
+			},
+		}
+		Expect(k8sClient.Create(ctx, realm)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			got := &keycloakApi.KeycloakRealm{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: realmCR, Namespace: ns}, got)).To(Succeed())
+			g.Expect(got.Status.Available).To(BeTrue())
+		}, longWait, interval).Should(Succeed())
+
+		recorder = testutils.NewAdminEventRecorder(keycloakApiClient, realmCR)
+		Expect(recorder.Enable(ctx)).To(Succeed())
+	})
+
+	AfterAll(func() {
+		realm := &keycloakApi.KeycloakRealm{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: realmCR, Namespace: ns}, realm); err == nil {
+			Expect(k8sClient.Delete(ctx, realm)).To(Succeed())
+		}
+	})
+
+	It("Should create KeycloakAuthFlow with an execution", func() {
+		cr := &keycloakApi.KeycloakAuthFlow{
+			ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: ns},
+			Spec: keycloakApi.KeycloakAuthFlowSpec{
+				RealmRef:    common.RealmRef{Kind: keycloakApi.KeycloakRealmKind, Name: realmCR},
+				Alias:       flowAlias,
+				Description: "idem flow v1",
+				ProviderID:  "basic-flow",
+				TopLevel:    true,
+				AuthenticationExecutions: []keycloakApi.AuthenticationExecution{{
+					Authenticator: "identity-provider-redirector",
+					AuthenticatorConfig: &keycloakApi.AuthenticatorConfig{
+						Alias:  "idem-flow-cfg",
+						Config: map[string]string{"defaultProvider": "provider-v1"},
+					},
+					AuthenticatorFlow: false,
+					Priority:          0,
+					Requirement:       "REQUIRED",
+					Alias:             "idem-flow-exec",
+				}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+		waitReady()
+
+		Expect(flowExists()).To(BeTrue())
+		Eventually(func(g Gomega) {
+			g.Expect(execProvider(g)).To(Equal("provider-v1"))
+		}, longWait, interval).Should(Succeed())
+	})
+
+	It("Should not write to Keycloak when a reconcile is forced with no spec change", func() {
+		Expect(recorder.WritesDuring(ctx, settle, nudge)).To(BeEmpty())
+	})
+
+	It("Should write to Keycloak and converge when an execution config changes", func() {
+		// Liveness anchor for this suite's empty-window specs.
+		Expect(recorder.WritesDuring(ctx, 0, func() {
+			updateSpec(func(cr *keycloakApi.KeycloakAuthFlow) {
+				cr.Spec.AuthenticationExecutions[0].AuthenticatorConfig.Config["defaultProvider"] = "provider-v2"
+			})
+			waitReady()
+
+			Expect(flowExists()).To(BeTrue())
+
+			// The edit must reach the authenticator config in Keycloak, not just bump the flow.
+			Eventually(func(g Gomega) {
+				g.Expect(execProvider(g)).To(Equal("provider-v2"))
+			}, longWait, interval).Should(Succeed())
+		})).ShouldNot(BeEmpty(), "admin event log recorded nothing for a known write")
+	})
+
+	It("Should not write to Keycloak after the edit settles", func() {
+		Expect(recorder.WritesDuring(ctx, settle, nudge)).To(BeEmpty())
+	})
+
+	It("Should force one write when observedGeneration is cleared", func() {
+		// No drift: Keycloak matches spec here, so a write can only come from the
+		// cleared observedGeneration.
+		Expect(recorder.WritesDuring(ctx, 0, func() {
+			Expect(testutils.ClearObservedGeneration(ctx, k8sClient,
+				types.NamespacedName{Name: crName, Namespace: ns},
+				&keycloakApi.KeycloakAuthFlow{})).To(Succeed())
+		})).ShouldNot(BeEmpty(), "a cleared observedGeneration must force one write")
+	})
+
+	It("Should delete KeycloakAuthFlow and remove the flow from Keycloak", func() {
+		cr := &keycloakApi.KeycloakAuthFlow{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+
+		Eventually(func() bool {
+			return k8sErrors.IsNotFound(
+				k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, &keycloakApi.KeycloakAuthFlow{}))
+		}, longWait, interval).Should(BeTrue())
+
+		Eventually(func(g Gomega) {
+			g.Expect(flowExists()).To(BeFalse(), "flow must be gone from Keycloak")
+		}, longWait, interval).Should(Succeed())
+	})
+})

--- a/internal/controller/keycloakclientscope/keycloakclientscope_idempotency_integration_test.go
+++ b/internal/controller/keycloakclientscope/keycloakclientscope_idempotency_integration_test.go
@@ -1,0 +1,245 @@
+package keycloakclientscope
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/epam/edp-keycloak-operator/api/common"
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+	"github.com/epam/edp-keycloak-operator/pkg/testutils"
+)
+
+// Idempotency suite for KeycloakClientScope.
+var _ = Describe("KeycloakClientScope idempotent reconcile", Ordered, func() {
+	const (
+		crName    = "idem-scope"
+		scopeName = "idem-scope"
+		settle    = testutils.Settle
+		longWait  = testutils.LongWait
+	)
+
+	var (
+		recorder *testutils.AdminEventRecorder
+		scopeID  string
+	)
+
+	nudge := func() {
+		Expect(testutils.Nudge(ctx, k8sClient,
+			types.NamespacedName{Name: crName, Namespace: ns}, &keycloakApi.KeycloakClientScope{})).To(Succeed())
+	}
+
+	updateSpec := func(mutate func(*keycloakApi.KeycloakClientScope)) {
+		Eventually(func(g Gomega) {
+			cr := &keycloakApi.KeycloakClientScope{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+			mutate(cr)
+			g.Expect(k8sClient.Update(ctx, cr)).To(Succeed())
+		}, longWait, interval).Should(Succeed())
+	}
+
+	waitReady := func() {
+		Eventually(func(g Gomega) {
+			cr := &keycloakApi.KeycloakClientScope{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+			g.Expect(cr.Status.Value).To(Equal(common.StatusOK))
+			g.Expect(cr.Status.ObservedGeneration).To(Equal(cr.Generation))
+		}, longWait, interval).Should(Succeed())
+	}
+
+	kcScope := func() *keycloakapi.ClientScopeRepresentation {
+		rep, _, err := keycloakApiClient.ClientScopes.GetClientScope(ctx, KeycloakRealmCR, scopeID)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(rep).ShouldNot(BeNil())
+
+		return rep
+	}
+
+	mapperIDsByName := func() map[string]string {
+		rep := kcScope()
+		ids := map[string]string{}
+
+		if rep.ProtocolMappers == nil {
+			return ids
+		}
+
+		for _, m := range *rep.ProtocolMappers {
+			ids[ptr.Deref(m.Name, "")] = ptr.Deref(m.Id, "")
+		}
+
+		return ids
+	}
+
+	mapper := func(name, claim string) keycloakApi.ProtocolMapper {
+		return keycloakApi.ProtocolMapper{
+			Name:           name,
+			Protocol:       "openid-connect",
+			ProtocolMapper: "oidc-hardcoded-claim-mapper",
+			Config: map[string]string{
+				"claim.name":                 claim,
+				"claim.value":                "v1",
+				"access.token.claim":         "true",
+				"id.token.claim":             "true",
+				"jsonType.label":             "String",
+				"userinfo.token.claim":       "true",
+				"introspection.token.claim":  "true",
+				"access.tokenResponse.claim": "false",
+			},
+		}
+	}
+
+	BeforeAll(func() {
+		recorder = testutils.NewAdminEventRecorder(keycloakApiClient, KeycloakRealmCR)
+		Expect(recorder.Enable(ctx)).To(Succeed())
+	})
+
+	It("Should create KeycloakClientScope with protocol mappers", func() {
+		cr := &keycloakApi.KeycloakClientScope{
+			ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: ns},
+			Spec: keycloakApi.KeycloakClientScopeSpec{
+				Name:        scopeName,
+				RealmRef:    common.RealmRef{Kind: keycloakApi.KeycloakRealmKind, Name: KeycloakRealmCR},
+				Protocol:    "openid-connect",
+				Description: "idem scope v1",
+				Type:        "none",
+				Attributes:  map[string]string{"include.in.token.scope": "true"},
+				ProtocolMappers: []keycloakApi.ProtocolMapper{
+					mapper("pm-a", "claim-a"),
+					mapper("pm-b", "claim-b"),
+					mapper("pm-c", "claim-c"),
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+		waitReady()
+
+		stored := &keycloakApi.KeycloakClientScope{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, stored)).To(Succeed())
+		scopeID = stored.Status.ID
+		Expect(scopeID).ShouldNot(BeEmpty())
+
+		// Sibling specs share the realm; report only this scope's events.
+		recorder = recorder.Scoped("client-scopes/" + scopeID)
+
+		Expect(mapperIDsByName()).To(HaveLen(3))
+		Expect(ptr.Deref(kcScope().Description, "")).To(Equal("idem scope v1"))
+	})
+
+	It("Should not write to Keycloak on a forced reconcile and keep mapper IDs stable", func() {
+		before := mapperIDsByName()
+
+		Expect(recorder.WritesDuring(ctx, settle, nudge)).To(BeEmpty())
+		Expect(mapperIDsByName()).To(Equal(before), "mappers must not be recreated")
+	})
+
+	It("Should heal external drift on the scope description", func() {
+		// Liveness anchor for this suite's empty-window specs. The drift write sits
+		// inside the window: the controller reconciles on a timer and can heal it
+		// before the nudge lands.
+		Expect(recorder.WritesDuring(ctx, 0, func() {
+			rep := kcScope()
+			rep.Description = ptr.To("drifted-by-hand")
+			_, err := keycloakApiClient.ClientScopes.UpdateClientScope(ctx, KeycloakRealmCR, scopeID, *rep)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			nudge()
+
+			Eventually(func(g Gomega) {
+				g.Expect(ptr.Deref(kcScope().Description, "")).To(Equal("idem scope v1"))
+			}, longWait, interval).Should(Succeed())
+		})).ShouldNot(BeEmpty(), "admin event log recorded nothing for a known write")
+	})
+
+	It("Should update one mapper in place and keep the other mapper IDs", func() {
+		before := mapperIDsByName()
+
+		updateSpec(func(cr *keycloakApi.KeycloakClientScope) {
+			cr.Spec.ProtocolMappers[0].Config["claim.value"] = "v2"
+		})
+		waitReady()
+
+		Eventually(func(g Gomega) {
+			rep := kcScope()
+			g.Expect(rep.ProtocolMappers).ShouldNot(BeNil())
+
+			configs := map[string]map[string]string{}
+			for _, m := range *rep.ProtocolMappers {
+				configs[ptr.Deref(m.Name, "")] = ptr.Deref(m.Config, nil)
+			}
+
+			g.Expect(configs).To(HaveKey("pm-a"))
+			g.Expect(configs["pm-a"]).To(HaveKeyWithValue("claim.value", "v2"))
+		}, longWait, interval).Should(Succeed())
+
+		after := mapperIDsByName()
+		Expect(after).To(HaveLen(3))
+		for _, name := range []string{"pm-a", "pm-b", "pm-c"} {
+			Expect(after[name]).To(Equal(before[name]), "mapper %s must be updated, not recreated", name)
+		}
+	})
+
+	It("Should delete only the removed mapper", func() {
+		before := mapperIDsByName()
+
+		updateSpec(func(cr *keycloakApi.KeycloakClientScope) {
+			kept := make([]keycloakApi.ProtocolMapper, 0, len(cr.Spec.ProtocolMappers))
+			for _, m := range cr.Spec.ProtocolMappers {
+				if m.Name != "pm-c" {
+					kept = append(kept, m)
+				}
+			}
+			cr.Spec.ProtocolMappers = kept
+		})
+		waitReady()
+
+		Eventually(func(g Gomega) {
+			g.Expect(mapperIDsByName()).To(HaveLen(2))
+		}, longWait, interval).Should(Succeed())
+
+		after := mapperIDsByName()
+		Expect(after).ShouldNot(HaveKey("pm-c"))
+		for _, name := range []string{"pm-a", "pm-b"} {
+			Expect(after[name]).To(Equal(before[name]), "surviving mapper %s must keep its ID", name)
+		}
+	})
+
+	It("Should not write to Keycloak after the edits settle", func() {
+		Expect(recorder.WritesDuring(ctx, settle, nudge)).To(BeEmpty())
+	})
+
+	It("Should force one write when observedGeneration is cleared", func() {
+		// No drift: Keycloak matches spec here, so a write can only come from the
+		// cleared observedGeneration.
+		Expect(recorder.WritesDuring(ctx, 0, func() {
+			Expect(testutils.ClearObservedGeneration(ctx, k8sClient,
+				types.NamespacedName{Name: crName, Namespace: ns},
+				&keycloakApi.KeycloakClientScope{})).To(Succeed())
+		})).ShouldNot(BeEmpty(), "a cleared observedGeneration must force one write")
+	})
+
+	It("Should delete KeycloakClientScope and remove the scope from Keycloak", func() {
+		cr := &keycloakApi.KeycloakClientScope{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+
+		Eventually(func() bool {
+			return k8sErrors.IsNotFound(
+				k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns},
+					&keycloakApi.KeycloakClientScope{}))
+		}, longWait, interval).Should(BeTrue())
+
+		Eventually(func(g Gomega) {
+			scopes, _, err := keycloakApiClient.ClientScopes.GetClientScopes(ctx, KeycloakRealmCR)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			for _, s := range scopes {
+				g.Expect(ptr.Deref(s.Name, "")).ShouldNot(Equal(scopeName), "scope must be gone from Keycloak")
+			}
+		}, longWait, interval).Should(Succeed())
+	})
+})

--- a/internal/controller/keycloakorganization/keycloakorganization_idempotency_integration_test.go
+++ b/internal/controller/keycloakorganization/keycloakorganization_idempotency_integration_test.go
@@ -1,0 +1,190 @@
+package keycloakorganization
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/epam/edp-keycloak-operator/api/common"
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/epam/edp-keycloak-operator/api/v1alpha1"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+	"github.com/epam/edp-keycloak-operator/pkg/testutils"
+)
+
+// Idempotency suite for KeycloakOrganization.
+var _ = Describe("KeycloakOrganization idempotent reconcile", Ordered, func() {
+	const (
+		crName   = "idem-org"
+		orgAlias = "idem-org"
+		settle   = testutils.Settle
+		longWait = testutils.LongWait
+	)
+
+	var (
+		recorder *testutils.AdminEventRecorder
+		orgID    string
+	)
+
+	nudge := func() {
+		Expect(testutils.Nudge(ctx, k8sClient,
+			types.NamespacedName{Name: crName, Namespace: ns}, &v1alpha1.KeycloakOrganization{})).To(Succeed())
+	}
+
+	updateSpec := func(mutate func(*v1alpha1.KeycloakOrganization)) {
+		Eventually(func(g Gomega) {
+			cr := &v1alpha1.KeycloakOrganization{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+			mutate(cr)
+			g.Expect(k8sClient.Update(ctx, cr)).To(Succeed())
+		}, longWait, interval).Should(Succeed())
+	}
+
+	waitReady := func() {
+		Eventually(func(g Gomega) {
+			cr := &v1alpha1.KeycloakOrganization{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+			g.Expect(cr.Status.Value).To(Equal(common.StatusOK))
+			g.Expect(cr.Status.ObservedGeneration).To(Equal(cr.Generation))
+		}, longWait, interval).Should(Succeed())
+	}
+
+	kcOrg := func() *keycloakapi.OrganizationRepresentation {
+		rep, _, err := keycloakAdminClient.Organizations.GetOrganization(ctx, KeycloakRealmCR, orgID)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(rep).ShouldNot(BeNil())
+
+		return rep
+	}
+
+	domainNames := func() []string {
+		rep := kcOrg()
+		if rep.Domains == nil {
+			return nil
+		}
+
+		names := make([]string, 0, len(*rep.Domains))
+		for _, d := range *rep.Domains {
+			names = append(names, ptr.Deref(d.Name, ""))
+		}
+
+		return names
+	}
+
+	BeforeAll(func() {
+		recorder = testutils.NewAdminEventRecorder(keycloakAdminClient, KeycloakRealmCR)
+		Expect(recorder.Enable(ctx)).To(Succeed())
+	})
+
+	It("Should create KeycloakOrganization with domains", func() {
+		cr := &v1alpha1.KeycloakOrganization{
+			ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: ns},
+			Spec: v1alpha1.KeycloakOrganizationSpec{
+				Name:        "Idem Org",
+				Alias:       orgAlias,
+				Description: "idem org v1",
+				Domains:     []string{"idem-a.example.test", "idem-b.example.test"},
+				RealmRef:    common.RealmRef{Kind: keycloakApi.KeycloakRealmKind, Name: KeycloakRealmCR},
+			},
+		}
+		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+		waitReady()
+
+		stored := &v1alpha1.KeycloakOrganization{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, stored)).To(Succeed())
+		orgID = stored.Status.OrganizationID
+		Expect(orgID).ShouldNot(BeEmpty())
+
+		// Sibling specs share the realm; report only this organization's events.
+		recorder = recorder.Scoped("organizations/" + orgID)
+
+		Expect(domainNames()).To(ConsistOf("idem-a.example.test", "idem-b.example.test"))
+	})
+
+	It("Should not write to Keycloak on a forced reconcile and keep the organization ID", func() {
+		Expect(recorder.WritesDuring(ctx, settle, nudge)).To(BeEmpty())
+
+		// Resolve by alias, not by id: GetOrganization echoes the id it was given, so
+		// comparing that to orgID could never fail.
+		byAlias, _, err := keycloakAdminClient.Organizations.GetOrganizationByAlias(ctx, KeycloakRealmCR, orgAlias)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(byAlias).ShouldNot(BeNil())
+		Expect(ptr.Deref(byAlias.Id, "")).To(Equal(orgID), "organization must not be recreated")
+	})
+
+	It("Should heal external drift on the organization description", func() {
+		// Liveness anchor for this suite's empty-window specs. The drift write sits
+		// inside the window: the controller reconciles on a timer and can heal it
+		// before the nudge lands.
+		Expect(recorder.WritesDuring(ctx, 0, func() {
+			rep := kcOrg()
+			rep.Description = ptr.To("drifted-by-hand")
+			_, err := keycloakAdminClient.Organizations.UpdateOrganization(ctx, KeycloakRealmCR, orgID, *rep)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			nudge()
+
+			Eventually(func(g Gomega) {
+				g.Expect(ptr.Deref(kcOrg().Description, "")).To(Equal("idem org v1"))
+			}, longWait, interval).Should(Succeed())
+		})).ShouldNot(BeEmpty(), "admin event log recorded nothing for a known write")
+	})
+
+	It("Should keep the existing domains when a domain is added", func() {
+		updateSpec(func(cr *v1alpha1.KeycloakOrganization) {
+			cr.Spec.Domains = append(cr.Spec.Domains, "idem-c.example.test")
+		})
+		waitReady()
+
+		Eventually(func(g Gomega) {
+			g.Expect(domainNames()).To(ConsistOf(
+				"idem-a.example.test", "idem-b.example.test", "idem-c.example.test"))
+		}, longWait, interval).Should(Succeed())
+	})
+
+	It("Should remove a domain from Keycloak when it is removed from spec", func() {
+		updateSpec(func(cr *v1alpha1.KeycloakOrganization) {
+			cr.Spec.Domains = []string{"idem-a.example.test"}
+		})
+		waitReady()
+
+		Eventually(func(g Gomega) {
+			g.Expect(domainNames()).To(ConsistOf("idem-a.example.test"))
+		}, longWait, interval).Should(Succeed())
+	})
+
+	It("Should not write to Keycloak after the edits settle", func() {
+		Expect(recorder.WritesDuring(ctx, settle, nudge)).To(BeEmpty())
+	})
+
+	It("Should force one write when observedGeneration is cleared", func() {
+		// No drift: Keycloak matches spec here, so a write can only come from the
+		// cleared observedGeneration.
+		Expect(recorder.WritesDuring(ctx, 0, func() {
+			Expect(testutils.ClearObservedGeneration(ctx, k8sClient,
+				types.NamespacedName{Name: crName, Namespace: ns},
+				&v1alpha1.KeycloakOrganization{})).To(Succeed())
+		})).ShouldNot(BeEmpty(), "a cleared observedGeneration must force one write")
+	})
+
+	It("Should delete KeycloakOrganization and remove the organization from Keycloak", func() {
+		cr := &v1alpha1.KeycloakOrganization{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+
+		Eventually(func() bool {
+			return k8sErrors.IsNotFound(
+				k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns},
+					&v1alpha1.KeycloakOrganization{}))
+		}, longWait, interval).Should(BeTrue())
+
+		Eventually(func(g Gomega) {
+			_, _, err := keycloakAdminClient.Organizations.GetOrganizationByAlias(ctx, KeycloakRealmCR, orgAlias)
+			g.Expect(err).Should(HaveOccurred(), "organization must be gone from Keycloak")
+		}, longWait, interval).Should(Succeed())
+	})
+})

--- a/internal/controller/keycloakrealm/keycloakrealm_idempotency_integration_test.go
+++ b/internal/controller/keycloakrealm/keycloakrealm_idempotency_integration_test.go
@@ -1,0 +1,171 @@
+package keycloakrealm
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/epam/edp-keycloak-operator/api/common"
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+	"github.com/epam/edp-keycloak-operator/pkg/testutils"
+)
+
+// Idempotency suite for KeycloakRealm.
+//
+// The CR owns spec.realmEventConfig. The realm PUT carries adminEventsEnabled and
+// resets the event log without it.
+var _ = Describe("KeycloakRealm idempotent reconcile", Ordered, func() {
+	const (
+		crName    = "idem-realm"
+		realmName = "idem-realm"
+		settle    = testutils.Settle
+		longWait  = testutils.LongWait
+	)
+
+	var recorder *testutils.AdminEventRecorder
+
+	nudge := func() {
+		Expect(testutils.Nudge(ctx, k8sClient,
+			types.NamespacedName{Name: crName, Namespace: ns}, &keycloakApi.KeycloakRealm{})).To(Succeed())
+	}
+
+	updateSpec := func(mutate func(*keycloakApi.KeycloakRealm)) {
+		Eventually(func(g Gomega) {
+			cr := &keycloakApi.KeycloakRealm{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+			mutate(cr)
+			g.Expect(k8sClient.Update(ctx, cr)).To(Succeed())
+		}, longWait, interval).Should(Succeed())
+	}
+
+	waitReady := func() {
+		Eventually(func(g Gomega) {
+			cr := &keycloakApi.KeycloakRealm{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+			g.Expect(cr.Status.Available).To(BeTrue())
+			g.Expect(cr.Status.ObservedGeneration).To(Equal(cr.Generation))
+		}, longWait, interval).Should(Succeed())
+	}
+
+	kcRealm := func() *keycloakapi.RealmRepresentation {
+		rep, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmName)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(rep).ShouldNot(BeNil())
+
+		return rep
+	}
+
+	It("Should create KeycloakRealm with locales and event settings", func() {
+		cr := &keycloakApi.KeycloakRealm{
+			ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: ns},
+			Spec: keycloakApi.KeycloakRealmSpec{
+				RealmName:   realmName,
+				KeycloakRef: common.KeycloakRef{Name: keycloakCR, Kind: keycloakApi.KeycloakKind},
+				DisplayName: ptr.To("Idem Realm"),
+				RealmEventConfig: &common.RealmEventConfig{
+					AdminEventsEnabled:        ptr.To(true),
+					AdminEventsDetailsEnabled: ptr.To(true),
+					EventsEnabled:             ptr.To(true),
+					EnabledEventTypes:         []string{"LOGIN", "LOGOUT", "REGISTER"},
+					EventsListeners:           []string{"jboss-logging"},
+				},
+				Localization: &keycloakApi.RealmLocalization{
+					InternationalizationEnabled: ptr.To(true),
+					SupportedLocales:            []string{"en", "de", "uk"},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+		waitReady()
+
+		created := kcRealm()
+		Expect(ptr.Deref(created.DisplayName, "")).To(Equal("Idem Realm"))
+		Expect(*created.SupportedLocales).To(ConsistOf("en", "de", "uk"))
+
+		recorder = testutils.NewAdminEventRecorder(keycloakApiClient, realmName)
+	})
+
+	It("Should not write to Keycloak when a reconcile is forced with no spec change", func() {
+		Expect(recorder.WritesDuring(ctx, settle, nudge)).To(BeEmpty())
+	})
+
+	It("Should heal external drift on the realm", func() {
+		// Liveness anchor for this suite's empty-window specs. The drift write sits
+		// inside the window: the controller reconciles on a timer and can heal it
+		// before the nudge lands.
+		Expect(recorder.WritesDuring(ctx, 0, func() {
+			rep := kcRealm()
+			rep.DisplayName = ptr.To("drifted-by-hand")
+			_, err := keycloakApiClient.Realms.UpdateRealm(ctx, realmName, *rep)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			nudge()
+
+			Eventually(func(g Gomega) {
+				g.Expect(ptr.Deref(kcRealm().DisplayName, "")).To(Equal("Idem Realm"))
+			}, longWait, interval).Should(Succeed())
+		})).ShouldNot(BeEmpty(), "admin event log recorded nothing for a known write")
+	})
+
+	It("Should settle without further writes when enabledEventTypes is reordered in spec", func() {
+		updateSpec(func(cr *keycloakApi.KeycloakRealm) {
+			cr.Spec.RealmEventConfig.EnabledEventTypes = []string{"REGISTER", "LOGIN", "LOGOUT"}
+		})
+		waitReady()
+
+		Expect(recorder.WritesDuring(ctx, settle, func() {})).To(BeEmpty(),
+			"an order-only spec edit must not keep writing")
+
+		cfg, _, err := keycloakApiClient.Events.GetEventsConfig(ctx, realmName)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*cfg.EnabledEventTypes).To(ConsistOf("LOGIN", "LOGOUT", "REGISTER"))
+	})
+
+	It("Should keep the existing locales when a locale is added", func() {
+		updateSpec(func(cr *keycloakApi.KeycloakRealm) {
+			cr.Spec.Localization.SupportedLocales = []string{"en", "de", "uk", "fr"}
+		})
+		waitReady()
+
+		Eventually(func(g Gomega) {
+			g.Expect(*kcRealm().SupportedLocales).To(ConsistOf("en", "de", "uk", "fr"))
+		}, longWait, interval).Should(Succeed())
+	})
+
+	It("Should remove a locale from Keycloak when it is removed from spec", func() {
+		updateSpec(func(cr *keycloakApi.KeycloakRealm) {
+			cr.Spec.Localization.SupportedLocales = []string{"en", "de"}
+		})
+		waitReady()
+
+		Eventually(func(g Gomega) {
+			g.Expect(*kcRealm().SupportedLocales).To(ConsistOf("en", "de"),
+				"locale lists have set semantics, removals must propagate")
+		}, longWait, interval).Should(Succeed())
+	})
+
+	It("Should not write to Keycloak after all edits settle", func() {
+		Expect(recorder.WritesDuring(ctx, settle, nudge)).To(BeEmpty())
+	})
+
+	It("Should delete KeycloakRealm and remove the realm from Keycloak", func() {
+		cr := &keycloakApi.KeycloakRealm{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+
+		Eventually(func() bool {
+			return k8sErrors.IsNotFound(
+				k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, &keycloakApi.KeycloakRealm{}))
+		}, longWait, interval).Should(BeTrue())
+
+		Eventually(func(g Gomega) {
+			_, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmName)
+			g.Expect(err).Should(HaveOccurred())
+		}, longWait, interval).Should(Succeed())
+	})
+})

--- a/internal/controller/keycloakrealmcomponent/keycloakrealmcomponent_idempotency_integration_test.go
+++ b/internal/controller/keycloakrealmcomponent/keycloakrealmcomponent_idempotency_integration_test.go
@@ -1,0 +1,163 @@
+package keycloakrealmcomponent
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/epam/edp-keycloak-operator/api/common"
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+	"github.com/epam/edp-keycloak-operator/pkg/testutils"
+)
+
+// Idempotency suite for KeycloakRealmComponent.
+var _ = Describe("KeycloakRealmComponent idempotent reconcile", Ordered, func() {
+	const (
+		crName        = "idem-component"
+		componentName = "idem-component"
+		settle        = testutils.Settle
+		longWait      = testutils.LongWait
+	)
+
+	var (
+		recorder    *testutils.AdminEventRecorder
+		componentID string
+	)
+
+	nudge := func() {
+		Expect(testutils.Nudge(ctx, k8sClient,
+			types.NamespacedName{Name: crName, Namespace: ns}, &keycloakApi.KeycloakRealmComponent{})).To(Succeed())
+	}
+
+	updateSpec := func(mutate func(*keycloakApi.KeycloakRealmComponent)) {
+		Eventually(func(g Gomega) {
+			cr := &keycloakApi.KeycloakRealmComponent{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+			mutate(cr)
+			g.Expect(k8sClient.Update(ctx, cr)).To(Succeed())
+		}, longWait, interval).Should(Succeed())
+	}
+
+	waitReady := func() {
+		Eventually(func(g Gomega) {
+			cr := &keycloakApi.KeycloakRealmComponent{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+			g.Expect(cr.Status.Value).To(Equal(common.StatusOK))
+			g.Expect(cr.Status.ObservedGeneration).To(Equal(cr.Generation))
+		}, longWait, interval).Should(Succeed())
+	}
+
+	kcComponent := func() *keycloakapi.ComponentRepresentation {
+		rep, err := keycloakApiClient.RealmComponents.FindComponentByName(ctx, KeycloakRealmCR, componentName)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(rep).ShouldNot(BeNil())
+
+		return rep
+	}
+
+	BeforeAll(func() {
+		recorder = testutils.NewAdminEventRecorder(keycloakApiClient, KeycloakRealmCR)
+		Expect(recorder.Enable(ctx)).To(Succeed())
+	})
+
+	It("Should create KeycloakRealmComponent with config", func() {
+		cr := &keycloakApi.KeycloakRealmComponent{
+			ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: ns},
+			Spec: keycloakApi.KeycloakComponentSpec{
+				Name:         componentName,
+				ProviderID:   "max-clients",
+				ProviderType: "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy",
+				RealmRef:     common.RealmRef{Kind: keycloakApi.KeycloakRealmKind, Name: KeycloakRealmCR},
+				Config: map[string][]string{
+					"max-clients": {"100"},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+		waitReady()
+
+		created := kcComponent()
+		componentID = ptr.Deref(created.Id, "")
+		Expect(componentID).ShouldNot(BeEmpty())
+		Expect((*created.Config)["max-clients"]).To(ConsistOf("100"))
+
+		// Sibling specs share the realm; report only this component's events.
+		recorder = recorder.Scoped("components/" + componentID)
+	})
+
+	It("Should not write to Keycloak on a forced reconcile and keep the component ID", func() {
+		Expect(recorder.WritesDuring(ctx, settle, nudge)).To(BeEmpty())
+		Expect(ptr.Deref(kcComponent().Id, "")).To(Equal(componentID), "component must not be recreated")
+	})
+
+	It("Should heal external drift on the component config", func() {
+		// Liveness anchor for this suite's empty-window specs. The drift write sits
+		// inside the window: the controller reconciles on a timer and can heal it
+		// before the nudge lands.
+		Expect(recorder.WritesDuring(ctx, 0, func() {
+			rep := kcComponent()
+			cfg := *rep.Config
+			cfg["max-clients"] = []string{"999"}
+			rep.Config = &cfg
+			_, err := keycloakApiClient.RealmComponents.UpdateComponent(ctx, KeycloakRealmCR, componentID, *rep)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			nudge()
+
+			Eventually(func(g Gomega) {
+				g.Expect((*kcComponent().Config)["max-clients"]).To(ConsistOf("100"))
+			}, longWait, interval).Should(Succeed())
+		})).ShouldNot(BeEmpty(), "admin event log recorded nothing for a known write")
+	})
+
+	It("Should write to Keycloak and keep the component ID when a config value changes", func() {
+		updateSpec(func(cr *keycloakApi.KeycloakRealmComponent) {
+			cr.Spec.Config["max-clients"] = []string{"250"}
+		})
+		waitReady()
+
+		Eventually(func(g Gomega) {
+			g.Expect((*kcComponent().Config)["max-clients"]).To(ConsistOf("250"))
+		}, longWait, interval).Should(Succeed())
+
+		Expect(ptr.Deref(kcComponent().Id, "")).To(Equal(componentID),
+			"an update must not delete and recreate the component")
+	})
+
+	It("Should not write to Keycloak after the edit settles", func() {
+		Expect(recorder.WritesDuring(ctx, settle, nudge)).To(BeEmpty())
+	})
+
+	It("Should force one write when observedGeneration is cleared", func() {
+		// No drift: Keycloak matches spec here, so a write can only come from the
+		// cleared observedGeneration.
+		Expect(recorder.WritesDuring(ctx, 0, func() {
+			Expect(testutils.ClearObservedGeneration(ctx, k8sClient,
+				types.NamespacedName{Name: crName, Namespace: ns},
+				&keycloakApi.KeycloakRealmComponent{})).To(Succeed())
+		})).ShouldNot(BeEmpty(), "a cleared observedGeneration must force one write")
+	})
+
+	It("Should delete KeycloakRealmComponent and remove the component from Keycloak", func() {
+		cr := &keycloakApi.KeycloakRealmComponent{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+
+		Eventually(func() bool {
+			return k8sErrors.IsNotFound(
+				k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns},
+					&keycloakApi.KeycloakRealmComponent{}))
+		}, longWait, interval).Should(BeTrue())
+
+		Eventually(func(g Gomega) {
+			rep, err := keycloakApiClient.RealmComponents.FindComponentByName(ctx, KeycloakRealmCR, componentName)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(rep).To(BeNil(), "component must be gone from Keycloak")
+		}, longWait, interval).Should(Succeed())
+	})
+})

--- a/pkg/client/keycloakapi/contracts.go
+++ b/pkg/client/keycloakapi/contracts.go
@@ -455,7 +455,8 @@ type RealmComponentsClient interface {
 	) ([]ComponentRepresentation, *Response, error)
 	// GetComponent retrieves a single realm component by its Keycloak UUID.
 	GetComponent(ctx context.Context, realm, componentID string) (*ComponentRepresentation, *Response, error)
-	// FindComponentByName searches for a realm component by name. Returns ErrNotFound if no match.
+	// FindComponentByName searches for a realm component by name. Returns a nil representation
+	// and a nil error when no component matches; callers must nil-check the result.
 	FindComponentByName(ctx context.Context, realm, componentName string) (*ComponentRepresentation, error)
 	// CreateComponent creates a new realm component.
 	CreateComponent(ctx context.Context, realm string, component ComponentRepresentation) (*Response, error)

--- a/pkg/testutils/admin_events.go
+++ b/pkg/testutils/admin_events.go
@@ -1,0 +1,185 @@
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/utils/ptr"
+
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+)
+
+const (
+	// maxAdminEvents caps one event query. A steady-state window holds a handful of
+	// events; a window at the cap means the query, not the controller, bounded the result.
+	maxAdminEvents = 500
+	// quietProbe is how long WritesDuring watches for an in-flight write before it opens
+	// the window. Raise it if a "no writes" spec starts flaking.
+	quietProbe = time.Second
+)
+
+// AdminEvents is one recorded window of Keycloak admin events. Gomega renders it as
+// "OPERATION resourcePath" lines.
+type AdminEvents []keycloakapi.AdminEventRepresentation
+
+func (e AdminEvents) GomegaString() string {
+	if len(e) == 0 {
+		return "<none>"
+	}
+
+	lines := make([]string, 0, len(e))
+	for _, ev := range e {
+		lines = append(lines, fmt.Sprintf("%s %s",
+			ptr.Deref(ev.OperationType, "?"), ptr.Deref(ev.ResourcePath, "?")))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// AdminEventRecorder reports the Keycloak writes an action made. Keycloak logs one
+// admin event per CREATE/UPDATE/DELETE, so an empty window means no write.
+//
+// Enable admin event storage before use, either by calling Enable or by setting
+// spec.realmEventConfig on the realm CR under test.
+//
+// Scope the recorder to one resource when sibling specs share the realm.
+type AdminEventRecorder struct {
+	kc        *keycloakapi.KeycloakClient
+	realm     string
+	pathMatch string
+}
+
+func NewAdminEventRecorder(kc *keycloakapi.KeycloakClient, realm string) *AdminEventRecorder {
+	return &AdminEventRecorder{kc: kc, realm: realm}
+}
+
+// Scoped returns a recorder that reports only events whose resourcePath contains
+// pathSubstring. Pass the Keycloak-assigned resource ID: sibling specs share the realm.
+func (r *AdminEventRecorder) Scoped(pathSubstring string) *AdminEventRecorder {
+	scoped := *r
+	scoped.pathMatch = pathSubstring
+
+	return &scoped
+}
+
+// Enable turns on admin event storage for the realm, preserving the rest of the
+// events config. Idempotent. The realm must already exist in Keycloak.
+func (r *AdminEventRecorder) Enable(ctx context.Context) error {
+	cfg, _, err := r.kc.Events.GetEventsConfig(ctx, r.realm)
+	if err != nil {
+		return fmt.Errorf("get events config: %w", err)
+	}
+
+	if cfg == nil {
+		cfg = &keycloakapi.RealmEventsConfigRepresentation{}
+	}
+
+	cfg.AdminEventsEnabled = ptr.To(true)
+	// Details store the full request body of every write. The recorder reads only
+	// operationType and resourcePath, so details are load on a shared Keycloak.
+	cfg.AdminEventsDetailsEnabled = ptr.To(false)
+
+	if _, err = r.kc.Events.SetEventsConfig(ctx, r.realm, *cfg); err != nil {
+		return fmt.Errorf("set events config: %w", err)
+	}
+
+	return nil
+}
+
+// WritesDuring waits for the realm to go quiet, opens an event window, runs action,
+// waits settle, and returns the writes Keycloak recorded within this recorder's scope.
+//
+// The quiet wait keeps a reconcile still in flight from an earlier spec out of the
+// window; without it that write is charged to action. Blocks up to LongWait waiting
+// for quiet, and fails rather than open a window while writes are still landing.
+//
+// Pass a settle duration when action returns before the reconcile lands. Pass 0 when
+// action itself blocks until Keycloak has converged.
+//
+// Assert at least once that a known write yields a non-empty result: an empty window
+// is evidence only while the log is recording.
+func (r *AdminEventRecorder) WritesDuring(
+	ctx context.Context,
+	settle time.Duration,
+	action func(),
+) (AdminEvents, error) {
+	if err := r.quiesce(ctx); err != nil {
+		return nil, err
+	}
+
+	action()
+
+	if settle > 0 {
+		time.Sleep(settle)
+	}
+
+	return r.recorded(ctx)
+}
+
+// quiesce clears the window and rechecks until one quietProbe passes with nothing
+// recorded, leaving the window both empty and idle.
+func (r *AdminEventRecorder) quiesce(ctx context.Context) error {
+	deadline := time.Now().Add(LongWait)
+
+	for {
+		if err := r.clear(ctx); err != nil {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for quiet realm %s: %w", r.realm, ctx.Err())
+		case <-time.After(quietProbe):
+		}
+
+		events, err := r.recorded(ctx)
+		if err != nil {
+			return err
+		}
+
+		if len(events) == 0 {
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("realm %s still writing after %s:\n%s",
+				r.realm, LongWait, events.GomegaString())
+		}
+	}
+}
+
+func (r *AdminEventRecorder) clear(ctx context.Context) error {
+	if _, err := r.kc.Events.DeleteAdminEvents(ctx, r.realm); err != nil {
+		return fmt.Errorf("clear admin events: %w", err)
+	}
+
+	return nil
+}
+
+func (r *AdminEventRecorder) recorded(ctx context.Context) (AdminEvents, error) {
+	events, _, err := r.kc.Events.GetAdminEvents(ctx, r.realm, &keycloakapi.GetAdminEventsParams{
+		Max: ptr.To(int32(maxAdminEvents)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get admin events: %w", err)
+	}
+
+	if r.pathMatch == "" {
+		return events, nil
+	}
+
+	matched := make(AdminEvents, 0, len(events))
+
+	for _, e := range events {
+		// Realm-level writes carry no resourcePath and cannot be attributed. Report them
+		// rather than drop them: an unattributable write inside the window is the write
+		// amplification this recorder exists to catch.
+		if e.ResourcePath == nil || strings.Contains(*e.ResourcePath, r.pathMatch) {
+			matched = append(matched, e)
+		}
+	}
+
+	return matched, nil
+}

--- a/pkg/testutils/reconcile.go
+++ b/pkg/testutils/reconcile.go
@@ -1,0 +1,136 @@
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// Settle bounds the wait for a forced reconcile to reach Keycloak. Raise it if a
+	// "no writes" spec starts flaking.
+	Settle = time.Second * 3
+	// LongWait bounds an Eventually that spans a reconcile plus a Keycloak round-trip.
+	LongWait = time.Second * 30
+	// NudgeAnnotation carries the timestamp that forces a reconcile.
+	NudgeAnnotation = "e2e.test/nudge"
+	// pollInterval paces the status polling in ClearObservedGeneration.
+	pollInterval = time.Millisecond * 250
+)
+
+// Nudge forces a reconcile of the object at key by stamping NudgeAnnotation.
+// metadata.generation stays unchanged, so the controller takes its steady-state path.
+// Pass an empty obj of the target type; Nudge fills it from the cluster.
+func Nudge(ctx context.Context, c client.Client, key types.NamespacedName, obj client.Object) error {
+	if err := c.Get(ctx, key, obj); err != nil {
+		return fmt.Errorf("get %s: %w", key, err)
+	}
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	annotations[NudgeAnnotation] = time.Now().Format(time.RFC3339Nano)
+	obj.SetAnnotations(annotations)
+
+	if err := c.Update(ctx, obj); err != nil {
+		return fmt.Errorf("update %s: %w", key, err)
+	}
+
+	return nil
+}
+
+// ClearObservedGeneration zeroes status.observedGeneration on the object at key, then
+// waits until the controller restamps it to match metadata.generation.
+//
+// Mirrors a CR last reconciled by an operator build that predates observedGeneration
+// tracking. The controller must write once even though Keycloak already matches spec:
+// spec removals are invisible to a comparison that only checks spec-declared keys.
+//
+// Pass an empty obj of the target type; its kind comes from the client scheme.
+func ClearObservedGeneration(
+	ctx context.Context,
+	c client.Client,
+	key types.NamespacedName,
+	obj client.Object,
+) error {
+	gvks, _, err := c.Scheme().ObjectKinds(obj)
+	if err != nil {
+		return fmt.Errorf("resolve kind for %T: %w", obj, err)
+	}
+
+	if len(gvks) == 0 {
+		return fmt.Errorf("no kind registered for %T", obj)
+	}
+
+	gvk := gvks[0]
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, getErr := getUnstructured(ctx, c, key, gvk)
+		if getErr != nil {
+			return getErr
+		}
+
+		if setErr := unstructured.SetNestedField(current.Object, int64(0), "status", "observedGeneration"); setErr != nil {
+			return fmt.Errorf("set observedGeneration on %s: %w", key, setErr)
+		}
+
+		return c.Status().Update(ctx, current)
+	})
+	if err != nil {
+		return fmt.Errorf("clear observedGeneration on %s: %w", key, err)
+	}
+
+	return waitObservedGeneration(ctx, c, key, gvk)
+}
+
+func waitObservedGeneration(
+	ctx context.Context,
+	c client.Client,
+	key types.NamespacedName,
+	gvk schema.GroupVersionKind,
+) error {
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, LongWait, false,
+		func(ctx context.Context) (bool, error) {
+			current, getErr := getUnstructured(ctx, c, key, gvk)
+			if getErr != nil {
+				return false, getErr
+			}
+
+			observed, found, nestedErr := unstructured.NestedInt64(current.Object, "status", "observedGeneration")
+			if nestedErr != nil {
+				return false, fmt.Errorf("read observedGeneration on %s: %w", key, nestedErr)
+			}
+
+			return found && observed == current.GetGeneration(), nil
+		})
+	if err != nil {
+		return fmt.Errorf("wait for observedGeneration on %s: %w", key, err)
+	}
+
+	return nil
+}
+
+func getUnstructured(
+	ctx context.Context,
+	c client.Client,
+	key types.NamespacedName,
+	gvk schema.GroupVersionKind,
+) (*unstructured.Unstructured, error) {
+	current := &unstructured.Unstructured{}
+	current.SetGroupVersionKind(gvk)
+
+	if err := c.Get(ctx, key, current); err != nil {
+		return nil, fmt.Errorf("get %s: %w", key, err)
+	}
+
+	return current, nil
+}


### PR DESCRIPTION
The idempotency work skips Keycloak writes when state already matches spec. Nothing verified that a steady-state reconcile writes nothing, or that the comparison still detects real drift. Reading resource state cannot distinguish "not written" from "written with identical content".

Keycloak's admin event log makes writes observable: one event per CREATE, UPDATE and DELETE, so an empty window means no write. Reconciles are forced by bumping an annotation, which leaves metadata.generation unchanged and therefore exercises the steady-state path.

- pkg/testutils/admin_events.go: AdminEventRecorder turns on admin event storage, clears the window and reports what was recorded since. Scoped narrows a recorder to one resource path; sibling specs share a realm, so the recorder carries the filter rather than each caller passing a path it can forget
- idempotency suites for KeycloakRealm, ClusterKeycloakRealm, KeycloakClientScope, KeycloakOrganization, KeycloakRealmComponent and KeycloakAuthFlow

Every suite pins a known write before trusting any empty window, since an empty window is evidence only while the log is recording. It then asserts that a forced reconcile writes nothing, that drift applied directly in Keycloak is corrected, that a CR with observedGeneration cleared converges and is restamped, and that the controller stops writing after each edit. Child resources keep their Keycloak IDs across updates, confirming diff-by-name rather than delete-and-recreate.

Auth-flow events land under disjoint resource paths and cannot be scoped to a single flow, so that suite owns its realm. Each suite carries its own settle and longWait; the shared timeout in suite_test is too short for a reconcile plus a Keycloak round-trip, which is why the existing suites inline time.Second*30.

Also correct the FindComponentByName contract: it returns a nil representation and a nil error when nothing matches, not ErrNotFound.

