### PR TITLE
chore(ci): bump actions and Keycloak versions

### DIFF
--- a/.github/actions/setup-keycloak/action.yml
+++ b/.github/actions/setup-keycloak/action.yml
@@ -29,8 +29,8 @@ runs:
         docker run -d \
           --name keycloak \
           -p ${{ inputs.port }}:${{ inputs.port }} \
-          -e KEYCLOAK_ADMIN=${{ inputs.admin-user }} \
-          -e KEYCLOAK_ADMIN_PASSWORD=${{ inputs.admin-password }} \
+          -e KC_BOOTSTRAP_ADMIN_USERNAME=${{ inputs.admin-user }} \
+          -e KC_BOOTSTRAP_ADMIN_PASSWORD=${{ inputs.admin-password }} \
           -e KC_FEATURES=admin-fine-grained-authz:v1 \
           -e KC_HTTP_PORT=${{ inputs.port }} \
           quay.io/keycloak/keycloak:${{ inputs.keycloak-version }} \

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -6,7 +6,7 @@ on:
 
 env:
   GOLANG_VERSION: '1.25'
-  KEYCLOAK_VERSION: '26.5'
+  KEYCLOAK_VERSION: '26.7'
 
 jobs:
 
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GOLANG_VERSION }}
 
@@ -32,7 +32,7 @@ jobs:
         run: TEST_KEYCLOAK_URL="http://localhost:8081" make test
 
       - name: Upload codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GOLANG_VERSION }}
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload e2e logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-logs-k8s-${{ matrix.kube-version }}-master
           path: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -50,12 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GOLANG_VERSION }}
 
@@ -74,23 +74,23 @@ jobs:
      CHART_SCHEMA_FILE_PATH: "chart_schema.yaml"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: ${{ env.HELM_VERSION }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.0
+        uses: helm/chart-testing-action@v2.8.0
 
       - name: Run chart-testing (lint)
         run: ct lint --target-branch ${{ github.event.repository.default_branch }} \
@@ -104,17 +104,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GOLANG_VERSION }}
 
       - name: Cache golangci-lint
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/golangci-lint
           key: ${{ runner.os }}-golangci-lint-${{ hashFiles('**/go.sum') }}
@@ -134,12 +134,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Run hadolint
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.5.0
         with:
           dockerfile: Dockerfile
 
@@ -149,16 +149,18 @@ jobs:
     strategy:
       matrix:
         keycloak-version:
+        - "26.7"
+        - "26.6"
         - "26.5"
         - "26.4"
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 1
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version: ${{ env.GOLANG_VERSION }}
 
@@ -201,12 +203,12 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GOLANG_VERSION }}
 
@@ -220,7 +222,7 @@ jobs:
 
       - name: Upload e2e logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-logs-k8s-${{ matrix.kube-version }}
           path: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,17 +11,19 @@ jobs:
   prepare-release:
     name: Perform automatic release on trigger ${{ github.ref }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       # The name of the tag as supplied by the GitHub event
       SOURCE_TAG: ${{ github.ref }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: '0'
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GOLANG_VERSION }}
 
@@ -78,11 +80,11 @@ jobs:
           echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
 
       - name: Create GitHub release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v3.0.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: create_release
         with:
           tag_name: ${{ env.RELEASE_TAG }}
-          release_name: ${{ env.RELEASE_TAG }}
+          name: ${{ env.RELEASE_TAG }}
           body_path: release.md

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ E2E_IMAGE_REPOSITORY?="keycloak-image"
 E2E_IMAGE_TAG?="latest"
 
 TEST_KEYCLOAK_URL?=""
+# Keep in sync with the newest entry of the CI integration-test matrix in .github/workflows/pr.yaml.
+KEYCLOAK_TEST_VERSION?=26.7
 
 override LDFLAGS += \
   -X ${PACKAGE}.version=${VERSION} \
@@ -331,7 +333,7 @@ docker-push: ## Push docker image with the manager.
 
 .PHONY: start-keycloak
 start-keycloak: ## Start Keycloak instance for testing
-	docker run -d -p 8086:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -e KC_FEATURES=admin-fine-grained-authz:v1 --name keycloak-test quay.io/keycloak/keycloak:latest start-dev
+	docker run -d -p 8086:8080 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -e KC_FEATURES=admin-fine-grained-authz:v1 --name keycloak-test quay.io/keycloak/keycloak:$(KEYCLOAK_TEST_VERSION) start-dev
 
 .PHONY: delete-keycloak
 delete-keycloak: ## Stop Keycloak test instance

--- a/tests/e2e/helm-success-path/01-install-keycloak-server.yaml
+++ b/tests/e2e/helm-success-path/01-install-keycloak-server.yaml
@@ -62,7 +62,7 @@ spec:
           - name: configs
             mountPath: /etc/nginx/conf.d
         - name: keycloak
-          image: quay.io/keycloak/keycloak:26.3
+          image: quay.io/keycloak/keycloak:26.7
           args:
             - "start-dev"
             - "--proxy-headers"

--- a/tests/e2e/keycloak-selfsigned-certificates/01-install-keycloak-server.yaml
+++ b/tests/e2e/keycloak-selfsigned-certificates/01-install-keycloak-server.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:26.3
+          image: quay.io/keycloak/keycloak:26.7
           args:
             - "start-dev"
             - "--https-port=8443"


### PR DESCRIPTION
Replace the deprecated KEYCLOAK_ADMIN and KEYCLOAK_ADMIN_PASSWORD env vars with KC_BOOTSTRAP_ADMIN_USERNAME and
KC_BOOTSTRAP_ADMIN_PASSWORD in the local Makefile target and the setup-keycloak composite action.

Pin the local test Keycloak through KEYCLOAK_TEST_VERSION instead of the floating latest tag, so local runs match CI.

Extend the integration-test matrix to 26.7, 26.6, 26.5 and 26.4, move the codecov job to 26.7, and raise the e2e KUTTL manifests from 26.3 to 26.7.

Update all GitHub Actions to their current major releases. These are Node 20 to Node 24 runtime moves. Swap the archived actions/create-release for softprops/action-gh-release and grant the release job contents: write, which the replacement requires.

Verified locally: unit, integration and KUTTL e2e suites pass against Keycloak 26.7.

