### PR TITLE
test(integration): give every integration suite a unique Keycloak realm name

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -147,6 +147,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check-commit-message]
     strategy:
+      # Run every version to the end so a failure points at the version that broke.
+      fail-fast: false
       matrix:
         keycloak-version:
         - "26.7"

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,8 @@ oapi-codegen: $(OAPICODEGEN) ## Download oapi-codegen locally if necessary.
 $(OAPICODEGEN): $(LOCALBIN)
 	$(call go-install-tool,$(OAPICODEGEN),github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen,latest)
 
-KEYCLOAK_VERSION ?= 26.5.2
+# Source version for the spec download below; the checked-in spec is hand-edited and tracks 26.6.
+KEYCLOAK_VERSION ?= 26.7.3
 .PHONY: generate-keycloak-go-client
 generate-keycloak-go-client: oapi-codegen
 # Currently, the OpenApi spec is manually edited due to the issue https://github.com/keycloak/keycloak/issues/46015

--- a/internal/controller/clusterkeycloakrealm/clusterkeycloakrealm_controller_integration_test.go
+++ b/internal/controller/clusterkeycloakrealm/clusterkeycloakrealm_controller_integration_test.go
@@ -16,6 +16,16 @@ import (
 	keycloakAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	"github.com/epam/edp-keycloak-operator/pkg/objectmeta"
+	"github.com/epam/edp-keycloak-operator/pkg/testutils"
+)
+
+// Realm names are unique per test process: all suites share one Keycloak.
+var (
+	realmMain       = testutils.RealmName("test-realm")
+	realmPreserved  = testutils.RealmName("test-realm2")
+	realmLogin      = testutils.RealmName("test-realm-login")
+	realmSSOSession = testutils.RealmName("test-realm-sso-session")
+	realmBruteForce = testutils.RealmName("test-realm-brute-force")
 )
 
 var _ = Describe("ClusterKeycloakRealm controller", func() {
@@ -30,7 +40,7 @@ var _ = Describe("ClusterKeycloakRealm controller", func() {
 			},
 			Spec: keycloakAlpha.ClusterKeycloakRealmSpec{
 				ClusterKeycloakRef: ClusterKeycloakCR,
-				RealmName:          "test-realm",
+				RealmName:          realmMain,
 				FrontendURL:        "https://test.com",
 				TokenSettings: &common.TokenSettings{
 					DefaultSignatureAlgorithm:           "RS256",
@@ -61,7 +71,7 @@ var _ = Describe("ClusterKeycloakRealm controller", func() {
 
 		By("Verifying the realm was created in Keycloak")
 		Eventually(func(g Gomega) {
-			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, "test-realm")
+			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmMain)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(realm).ShouldNot(BeNil())
 
@@ -109,7 +119,7 @@ var _ = Describe("ClusterKeycloakRealm controller", func() {
 
 		By("Checking realm configuration")
 		Eventually(func(g Gomega) {
-			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, "test-realm")
+			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmMain)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(realm.BrowserFlow).Should(Equal(ptr.To("browser")))
 		}, time.Second*30, time.Second).Should(Succeed())
@@ -134,7 +144,7 @@ var _ = Describe("ClusterKeycloakRealm controller", func() {
 			},
 			Spec: keycloakAlpha.ClusterKeycloakRealmSpec{
 				ClusterKeycloakRef: ClusterKeycloakCR,
-				RealmName:          "test-realm2",
+				RealmName:          realmPreserved,
 				FrontendURL:        "https://test.com",
 			},
 		}
@@ -163,7 +173,7 @@ var _ = Describe("ClusterKeycloakRealm controller", func() {
 			},
 			Spec: keycloakAlpha.ClusterKeycloakRealmSpec{
 				ClusterKeycloakRef: ClusterKeycloakCR,
-				RealmName:          "test-realm-login",
+				RealmName:          realmLogin,
 				Login: &keycloakApi.RealmLogin{
 					UserRegistration: true,
 					ForgotPassword:   true,
@@ -189,7 +199,7 @@ var _ = Describe("ClusterKeycloakRealm controller", func() {
 
 		By("Verifying the realm login settings in Keycloak")
 		Eventually(func(g Gomega) {
-			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, "test-realm-login")
+			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmLogin)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(realm).ShouldNot(BeNil())
 
@@ -221,7 +231,7 @@ var _ = Describe("ClusterKeycloakRealm controller", func() {
 			},
 			Spec: keycloakAlpha.ClusterKeycloakRealmSpec{
 				ClusterKeycloakRef: ClusterKeycloakCR,
-				RealmName:          "test-realm-sso-session",
+				RealmName:          realmSSOSession,
 				Sessions: &common.RealmSessions{
 					SSOSessionSettings: &common.RealmSSOSessionSettings{
 						IdleTimeout:           1801,
@@ -254,7 +264,7 @@ var _ = Describe("ClusterKeycloakRealm controller", func() {
 
 		By("Verifying the realm SSO session settings in Keycloak")
 		Eventually(func(g Gomega) {
-			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, "test-realm-sso-session")
+			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmSSOSession)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(realm).ShouldNot(BeNil())
 
@@ -291,7 +301,7 @@ var _ = Describe("ClusterKeycloakRealm controller", func() {
 			},
 			Spec: keycloakAlpha.ClusterKeycloakRealmSpec{
 				ClusterKeycloakRef: ClusterKeycloakCR,
-				RealmName:          "test-realm-brute-force",
+				RealmName:          realmBruteForce,
 				BruteForceDetection: &common.BruteForceDetection{
 					BruteForceProtected:          ptr.To(true),
 					BruteForceStrategy:           string(keycloakapi.BruteForceStrategyMultiple),
@@ -319,7 +329,7 @@ var _ = Describe("ClusterKeycloakRealm controller", func() {
 
 		By("Verifying the realm brute force detection settings in Keycloak")
 		Eventually(func(g Gomega) {
-			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, "test-realm-brute-force")
+			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmBruteForce)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(realm).ShouldNot(BeNil())
 
@@ -345,7 +355,7 @@ var _ = Describe("ClusterKeycloakRealm controller", func() {
 
 		By("Verifying only FailureFactor changed while other brute force fields were preserved")
 		Eventually(func(g Gomega) {
-			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, "test-realm-brute-force")
+			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmBruteForce)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(realm).ShouldNot(BeNil())
 

--- a/internal/controller/clusterkeycloakrealm/clusterkeycloakrealm_idempotency_integration_test.go
+++ b/internal/controller/clusterkeycloakrealm/clusterkeycloakrealm_idempotency_integration_test.go
@@ -18,11 +18,12 @@ import (
 // Idempotency suite for ClusterKeycloakRealm.
 var _ = Describe("ClusterKeycloakRealm idempotent reconcile", Ordered, func() {
 	const (
-		crName    = "idem-cluster-realm"
-		realmName = "idem-cluster-realm"
-		settle    = testutils.Settle
-		longWait  = testutils.LongWait
+		crName   = "idem-cluster-realm"
+		settle   = testutils.Settle
+		longWait = testutils.LongWait
 	)
+
+	realmName := testutils.RealmName("idem-cluster-realm")
 
 	var recorder *testutils.AdminEventRecorder
 

--- a/internal/controller/keycloakauthflow/keycloakauthflow_idempotency_integration_test.go
+++ b/internal/controller/keycloakauthflow/keycloakauthflow_idempotency_integration_test.go
@@ -19,10 +19,11 @@ var _ = Describe("KeycloakAuthFlow idempotent reconcile", Ordered, func() {
 	const (
 		crName    = "idem-flow"
 		flowAlias = "idem-flow"
-		realmCR   = "idem-flow-realm"
 		settle    = testutils.Settle
 		longWait  = testutils.LongWait
 	)
+
+	realmCR := testutils.RealmName("idem-flow-realm")
 
 	var recorder *testutils.AdminEventRecorder
 

--- a/internal/controller/keycloakauthflow/suite_test.go
+++ b/internal/controller/keycloakauthflow/suite_test.go
@@ -41,13 +41,15 @@ var (
 )
 
 const (
-	KeycloakCR      = "test-keycloak"
-	KeycloakRealmCR = "test-auth-flow"
-	ns              = "test-auth-flow"
+	KeycloakCR = "test-keycloak"
+	ns         = "test-auth-flow"
 
 	timeout  = time.Second * 10
 	interval = time.Second
 )
+
+// KeycloakRealmCR names both the KeycloakRealm CR and the Keycloak realm it manages.
+var KeycloakRealmCR = testutils.RealmName("test-auth-flow")
 
 func TestKeycloakAuthFlow(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/internal/controller/keycloakclient/keycloakclient_controller_integration_test.go
+++ b/internal/controller/keycloakclient/keycloakclient_controller_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/epam/edp-keycloak-operator/internal/controller/keycloakclient/chain"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	"github.com/epam/edp-keycloak-operator/pkg/secretref"
+	"github.com/epam/edp-keycloak-operator/pkg/testutils"
 )
 
 var _ = Describe("KeycloakClient controller", Ordered, func() {
@@ -1028,13 +1029,14 @@ var _ = Describe("KeycloakClient controller", Ordered, func() {
 
 	It("Should successfully delete KeycloakClient if ErrKeycloakRealmNotFound occurs", func() {
 		By("By creating a KeycloakRealm")
+		realmName := testutils.RealmName("test-realm")
 		testRealm := &keycloakApi.KeycloakRealm{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-realm",
+				Name:      realmName,
 				Namespace: ns,
 			},
 			Spec: keycloakApi.KeycloakRealmSpec{
-				RealmName: "test-realm",
+				RealmName: realmName,
 				KeycloakRef: common.KeycloakRef{
 					Kind: keycloakApi.KeycloakKind,
 					Name: KeycloakCR,
@@ -1050,7 +1052,7 @@ var _ = Describe("KeycloakClient controller", Ordered, func() {
 				Namespace: ns,
 			},
 			Spec: keycloakApi.KeycloakClientSpec{
-				RealmRef: common.RealmRef{Name: "test-realm"},
+				RealmRef: common.RealmRef{Name: realmName},
 				ClientId: "test-client-id",
 			},
 		}

--- a/internal/controller/keycloakclient/suite_test.go
+++ b/internal/controller/keycloakclient/suite_test.go
@@ -43,13 +43,15 @@ var (
 )
 
 const (
-	KeycloakCR      = "test-keycloak"
-	KeycloakRealmCR = "test-keycloak-client-realm"
-	ns              = "test-client"
+	KeycloakCR = "test-keycloak"
+	ns         = "test-client"
 
 	timeout  = time.Second * 30
 	interval = time.Millisecond * 250
 )
+
+// KeycloakRealmCR names both the KeycloakRealm CR and the Keycloak realm it manages.
+var KeycloakRealmCR = testutils.RealmName("test-keycloak-client-realm")
 
 func TestKeycloakClient(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/internal/controller/keycloakclientscope/suite_test.go
+++ b/internal/controller/keycloakclientscope/suite_test.go
@@ -41,13 +41,15 @@ var (
 )
 
 const (
-	KeycloakCR      = "test-keycloak"
-	KeycloakRealmCR = "test-client-scope"
-	ns              = "test-client-scope"
+	KeycloakCR = "test-keycloak"
+	ns         = "test-client-scope"
 
 	timeout  = time.Second * 10
 	interval = time.Second
 )
+
+// KeycloakRealmCR names both the KeycloakRealm CR and the Keycloak realm it manages.
+var KeycloakRealmCR = testutils.RealmName("test-client-scope")
 
 func TestKeycloakClientScope(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/internal/controller/keycloakorganization/suite_test.go
+++ b/internal/controller/keycloakorganization/suite_test.go
@@ -43,13 +43,15 @@ var (
 )
 
 const (
-	KeycloakCR      = "test-keycloak"
-	KeycloakRealmCR = "test-org-realm"
-	ns              = "test-org"
+	KeycloakCR = "test-keycloak"
+	ns         = "test-org"
 
 	timeout  = time.Second * 10
 	interval = time.Millisecond * 250
 )
+
+// KeycloakRealmCR names both the KeycloakRealm CR and the Keycloak realm it manages.
+var KeycloakRealmCR = testutils.RealmName("test-org-realm")
 
 func TestKeycloakOrganization(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/internal/controller/keycloakrealm/keycloakrealm_controller_integration_test.go
+++ b/internal/controller/keycloakrealm/keycloakrealm_controller_integration_test.go
@@ -15,6 +15,15 @@ import (
 	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+	"github.com/epam/edp-keycloak-operator/pkg/testutils"
+)
+
+// Realm names are unique per test process: all suites share one Keycloak.
+var (
+	realmFullConfig = testutils.RealmName("test-realm-with-full-config")
+	realmLogin      = testutils.RealmName("test-realm-login")
+	realmSSOSession = testutils.RealmName("test-realm-sso-session")
+	realmBruteForce = testutils.RealmName("test-realm-brute-force")
 )
 
 var _ = Describe("KeycloakRealm controller", Ordered, func() {
@@ -41,7 +50,7 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 				Namespace: ns,
 			},
 			Spec: keycloakApi.KeycloakRealmSpec{
-				RealmName: "test-realm-with-full-config",
+				RealmName: realmFullConfig,
 				KeycloakRef: common.KeycloakRef{
 					Name: keycloakCR,
 					Kind: keycloakApi.KeycloakKind,
@@ -202,7 +211,7 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 
 		By("Verifying the realm was created in Keycloak")
 		Eventually(func(g Gomega) {
-			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, "test-realm-with-full-config")
+			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmFullConfig)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(realm).ShouldNot(BeNil())
 
@@ -261,17 +270,17 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 			g.Expect(realm.DefaultLocale).Should(Equal(ptr.To("nl")))
 
 			// localizationTexts must be verified via /localization/{locale}, not from realm representation
-			enTexts, _, err := keycloakApiClient.Realms.GetRealmLocalization(ctx, "test-realm-with-full-config", "en")
+			enTexts, _, err := keycloakApiClient.Realms.GetRealmLocalization(ctx, realmFullConfig, "en")
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(enTexts["test.key"]).Should(Equal("this is a test"))
-			nlTexts, _, err := keycloakApiClient.Realms.GetRealmLocalization(ctx, "test-realm-with-full-config", "nl")
+			nlTexts, _, err := keycloakApiClient.Realms.GetRealmLocalization(ctx, realmFullConfig, "nl")
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(nlTexts["test.key"]).Should(Equal("dit is een test"))
 		}, time.Second*10, time.Second).Should(Succeed())
 
 		By("Verifying the user profile was configured in Keycloak")
 		Eventually(func(g Gomega) {
-			userProfile, _, err := keycloakApiClient.Users.GetUsersProfile(ctx, "test-realm-with-full-config")
+			userProfile, _, err := keycloakApiClient.Users.GetUsersProfile(ctx, realmFullConfig)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(userProfile).ShouldNot(BeNil())
 
@@ -294,7 +303,7 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 
 		By("Verifying the user was created in Keycloak")
 		Eventually(func(g Gomega) {
-			user, _, err := keycloakApiClient.Users.FindUserByUsername(ctx, "test-realm-with-full-config", "keycloakrealm-user@mail.com")
+			user, _, err := keycloakApiClient.Users.FindUserByUsername(ctx, realmFullConfig, "keycloakrealm-user@mail.com")
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(user).ShouldNot(BeNil())
 		}, time.Second*10, time.Second).Should(Succeed())
@@ -322,14 +331,14 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 
 		By("Verifying the realm was updated in Keycloak")
 		Eventually(func(g Gomega) {
-			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, "test-realm-with-full-config")
+			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmFullConfig)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(realm).ShouldNot(BeNil())
 			g.Expect(realm.Attributes).ShouldNot(BeNil())
 			g.Expect((*realm.Attributes)["frontendUrl"]).Should(Equal("https://test-updated.com"))
 			g.Expect(realm.DefaultLocale).Should(Equal(ptr.To("en")))
 
-			enTexts, _, err := keycloakApiClient.Realms.GetRealmLocalization(ctx, "test-realm-with-full-config", "en")
+			enTexts, _, err := keycloakApiClient.Realms.GetRealmLocalization(ctx, realmFullConfig, "en")
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(enTexts["new.key"]).Should(Equal("new value"))
 			g.Expect(enTexts["test.key"]).Should(Equal("this is a test"))
@@ -358,7 +367,7 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 				Namespace: ns,
 			},
 			Spec: keycloakApi.KeycloakRealmSpec{
-				RealmName: "test-realm-login",
+				RealmName: realmLogin,
 				KeycloakRef: common.KeycloakRef{
 					Name: keycloakCR,
 					Kind: keycloakApi.KeycloakKind,
@@ -392,7 +401,7 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 
 		By("Verifying the realm login settings in Keycloak")
 		Eventually(func(g Gomega) {
-			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, "test-realm-login")
+			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmLogin)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(realm).ShouldNot(BeNil())
 
@@ -424,7 +433,7 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 				Namespace: ns,
 			},
 			Spec: keycloakApi.KeycloakRealmSpec{
-				RealmName: "test-realm-sso-session",
+				RealmName: realmSSOSession,
 				KeycloakRef: common.KeycloakRef{
 					Name: keycloakCR,
 					Kind: keycloakApi.KeycloakKind,
@@ -468,7 +477,7 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 
 		By("Verifying the realm SSO session settings in Keycloak")
 		Eventually(func(g Gomega) {
-			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, "test-realm-sso-session")
+			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmSSOSession)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(realm).ShouldNot(BeNil())
 
@@ -505,7 +514,7 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 				Namespace: ns,
 			},
 			Spec: keycloakApi.KeycloakRealmSpec{
-				RealmName: "test-realm-brute-force",
+				RealmName: realmBruteForce,
 				KeycloakRef: common.KeycloakRef{
 					Name: keycloakCR,
 					Kind: keycloakApi.KeycloakKind,
@@ -541,7 +550,7 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 
 		By("Verifying the realm brute force detection settings in Keycloak")
 		Eventually(func(g Gomega) {
-			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, "test-realm-brute-force")
+			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmBruteForce)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(realm).ShouldNot(BeNil())
 
@@ -567,7 +576,7 @@ var _ = Describe("KeycloakRealm controller", Ordered, func() {
 
 		By("Verifying only FailureFactor changed while other brute force fields were preserved")
 		Eventually(func(g Gomega) {
-			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, "test-realm-brute-force")
+			realm, _, err := keycloakApiClient.Realms.GetRealm(ctx, realmBruteForce)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(realm).ShouldNot(BeNil())
 

--- a/internal/controller/keycloakrealm/keycloakrealm_external_settings_integration_test.go
+++ b/internal/controller/keycloakrealm/keycloakrealm_external_settings_integration_test.go
@@ -13,13 +13,15 @@ import (
 
 	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/epam/edp-keycloak-operator/pkg/testutils"
 )
 
 var _ = Describe("KeycloakRealm admin events expiration", Ordered, func() {
 	const (
-		crName    = "test-keycloak-realm-admin-events"
-		realmName = "test-realm-admin-events"
+		crName = "test-keycloak-realm-admin-events"
 	)
+
+	realmName := testutils.RealmName("test-realm-admin-events")
 
 	It("Should preserve externally-set adminEventsExpiration when the CR omits it", func() {
 		By("Creating a KeycloakRealm without realmEventConfig")
@@ -95,9 +97,10 @@ var _ = Describe("KeycloakRealm admin events expiration", Ordered, func() {
 
 var _ = Describe("KeycloakRealm externally-managed settings", Ordered, func() {
 	const (
-		crName    = "test-keycloak-realm-external"
-		realmName = "test-realm-external-managed"
+		crName = "test-keycloak-realm-external"
 	)
+
+	realmName := testutils.RealmName("test-realm-external-managed")
 
 	It("Should preserve externally-set realm settings not defined in the CR", func() {
 		By("Creating a minimal KeycloakRealm without display name or organizations settings")

--- a/internal/controller/keycloakrealm/keycloakrealm_idempotency_integration_test.go
+++ b/internal/controller/keycloakrealm/keycloakrealm_idempotency_integration_test.go
@@ -21,11 +21,12 @@ import (
 // resets the event log without it.
 var _ = Describe("KeycloakRealm idempotent reconcile", Ordered, func() {
 	const (
-		crName    = "idem-realm"
-		realmName = "idem-realm"
-		settle    = testutils.Settle
-		longWait  = testutils.LongWait
+		crName   = "idem-realm"
+		settle   = testutils.Settle
+		longWait = testutils.LongWait
 	)
+
+	realmName := testutils.RealmName("idem-realm")
 
 	var recorder *testutils.AdminEventRecorder
 

--- a/internal/controller/keycloakrealmcomponent/suite_test.go
+++ b/internal/controller/keycloakrealmcomponent/suite_test.go
@@ -42,13 +42,15 @@ var (
 )
 
 const (
-	KeycloakCR      = "test-keycloak"
-	KeycloakRealmCR = "test-keycloak-component-realm"
-	ns              = "test-component"
+	KeycloakCR = "test-keycloak"
+	ns         = "test-component"
 
 	timeout  = time.Second * 10
 	interval = time.Millisecond * 250
 )
+
+// KeycloakRealmCR names both the KeycloakRealm CR and the Keycloak realm it manages.
+var KeycloakRealmCR = testutils.RealmName("test-keycloak-component-realm")
 
 func TestKeycloakComponent(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/internal/controller/keycloakrealmgroup/suite_test.go
+++ b/internal/controller/keycloakrealmgroup/suite_test.go
@@ -41,13 +41,15 @@ var (
 )
 
 const (
-	KeycloakCR      = "test-keycloak"
-	KeycloakRealmCR = "test-group-realm"
-	ns              = "test-group"
+	KeycloakCR = "test-keycloak"
+	ns         = "test-group"
 
 	timeout  = time.Second * 10
 	interval = time.Millisecond * 250
 )
+
+// KeycloakRealmCR names both the KeycloakRealm CR and the Keycloak realm it manages.
+var KeycloakRealmCR = testutils.RealmName("test-group-realm")
 
 func TestKeycloakGroup(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -185,6 +187,14 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+	createdKeycloakRealm := &keycloakApi.KeycloakRealm{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: KeycloakRealmCR, Namespace: ns}, createdKeycloakRealm); err == nil {
+		Expect(k8sClient.Delete(ctx, createdKeycloakRealm)).To(Succeed())
+		Eventually(func() bool {
+			return k8sClient.Get(ctx, types.NamespacedName{Name: KeycloakRealmCR, Namespace: ns}, &keycloakApi.KeycloakRealm{}) != nil
+		}, timeout, interval).Should(BeTrue())
+	}
+
 	cancel()
 	By("tearing down the test environment")
 	err := testEnv.Stop()

--- a/internal/controller/keycloakrealmidentityprovider/keycloakrealmidentityprovider_controller_integration_test.go
+++ b/internal/controller/keycloakrealmidentityprovider/keycloakrealmidentityprovider_controller_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/objectmeta"
+	"github.com/epam/edp-keycloak-operator/pkg/testutils"
 )
 
 var _ = Describe("KeycloakRealmIdentityProvider controller", Ordered, func() {
@@ -294,13 +295,14 @@ var _ = Describe("KeycloakRealmIdentityProvider controller", Ordered, func() {
 	})
 	It("Should successfully delete KeycloakRealmIdentityProvider if realm is deleted first", func() {
 		By("By creating a KeycloakRealm")
+		realmName := testutils.RealmName("test-idp-realm-for-deletion")
 		testRealm := &keycloakApi.KeycloakRealm{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-idp-realm-for-deletion",
+				Name:      realmName,
 				Namespace: ns,
 			},
 			Spec: keycloakApi.KeycloakRealmSpec{
-				RealmName: "test-idp-realm-for-deletion",
+				RealmName: realmName,
 				KeycloakRef: common.KeycloakRef{
 					Kind: keycloakApi.KeycloakKind,
 					Name: KeycloakCR,

--- a/internal/controller/keycloakrealmidentityprovider/suite_test.go
+++ b/internal/controller/keycloakrealmidentityprovider/suite_test.go
@@ -41,13 +41,15 @@ var (
 )
 
 const (
-	KeycloakCR      = "test-keycloak"
-	KeycloakRealmCR = "test-keycloak-identity-provider-realm"
-	ns              = "test-identity-provider"
+	KeycloakCR = "test-keycloak"
+	ns         = "test-identity-provider"
 
 	timeout  = time.Second * 10
 	interval = time.Second
 )
+
+// KeycloakRealmCR names both the KeycloakRealm CR and the Keycloak realm it manages.
+var KeycloakRealmCR = testutils.RealmName("test-keycloak-identity-provider-realm")
 
 func TestKeycloakIdentityProvider(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/internal/controller/keycloakrealmrole/suite_test.go
+++ b/internal/controller/keycloakrealmrole/suite_test.go
@@ -41,13 +41,15 @@ var (
 )
 
 const (
-	KeycloakCR      = "test-keycloak"
-	KeycloakRealmCR = "test-keycloak-role-realm"
-	ns              = "test-role"
+	KeycloakCR = "test-keycloak"
+	ns         = "test-role"
 
 	timeout  = time.Second * 10
 	interval = time.Millisecond * 250
 )
+
+// KeycloakRealmCR names both the KeycloakRealm CR and the Keycloak realm it manages.
+var KeycloakRealmCR = testutils.RealmName("test-keycloak-role-realm")
 
 func TestKeycloakRole(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/internal/controller/keycloakrealmuser/suite_test.go
+++ b/internal/controller/keycloakrealmuser/suite_test.go
@@ -42,13 +42,15 @@ var (
 )
 
 const (
-	KeycloakCR      = "test-keycloak"
-	KeycloakRealmCR = "test-user-realm"
-	ns              = "test-user"
+	KeycloakCR = "test-keycloak"
+	ns         = "test-user"
 
 	timeout  = time.Second * 10
 	interval = time.Millisecond * 250
 )
+
+// KeycloakRealmCR names both the KeycloakRealm CR and the Keycloak realm it manages.
+var KeycloakRealmCR = testutils.RealmName("test-user-realm")
 
 func TestKeycloakUser(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/testutils/realm.go
+++ b/pkg/testutils/realm.go
@@ -1,0 +1,24 @@
+package testutils
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// realmSuffix is fixed for the lifetime of one test binary and differs between
+// concurrent test binaries. Base 36 keeps generated names short.
+var realmSuffix = fmt.Sprintf(
+	"%s-%s",
+	strconv.FormatInt(int64(os.Getpid()), 36),
+	strconv.FormatInt(time.Now().UnixNano(), 36),
+)
+
+// RealmName appends the per-process suffix to base.
+// Every integration suite shares one Keycloak at TEST_KEYCLOAK_URL and realm
+// names are global there. All test realm names must go through this function.
+// The result is a valid Kubernetes object name, so it also serves as a CR name.
+func RealmName(base string) string {
+	return fmt.Sprintf("%s-%s", base, realmSuffix)
+}


### PR DESCRIPTION


All integration packages run in parallel against the single Keycloak at TEST_KEYCLOAK_URL, where realm names are global. The KeycloakClient suite created and then deleted realm "test-realm" while the ClusterKeycloakRealm suite was asserting on it, so the realm vanished mid-spec and CI failed with a 404. The login, SSO-session and brute-force realms were shared the same way between the KeycloakRealm and ClusterKeycloakRealm suites.

Route every test realm name through testutils.RealmName, which appends a per-process suffix, so one suite can no longer delete a realm another suite owns. Add the missing realm cleanup to the KeycloakRealmGroup suite, which otherwise leaks one realm per run now that names are never reused.

Keep the integration matrix running after a failure so every Keycloak version reports its own result, and point the client generator at Keycloak 26.7.3.

