### PR TITLE
fix(security): correct the destination allowlist

### DIFF
--- a/.claude/skills/cr-field/SKILL.md
+++ b/.claude/skills/cr-field/SKILL.md
@@ -82,6 +82,10 @@ Map the field in **both** paths:
 
 Reference: `internal/controller/keycloakrealmgroup/chain/create_or_update_group.go`
 
+**Destination guard.** If the field holds a remote address (host or URL), call
+`guard.RequireHost` on it before any Secret tied to it is resolved — inject the guard and
+copy the pattern from `internal/controller/keycloakrealm/chain/configure_email.go`.
+
 ---
 
 ## Step 6 — Update unit tests

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -62,8 +62,8 @@ const (
 	successReconcileTimeout = "SUCCESS_RECONCILE_TIMEOUT"
 	operatorNamespaceEnv    = "OPERATOR_NAMESPACE"
 
-	allowedDestinationHostsEnv = "ALLOWED_DESTINATION_HOSTS"
-	enforceDestinationEnv      = "ENFORCE_DESTINATION_ALLOWLIST"
+	allowedDestinationHostsEnv     = "ALLOWED_DESTINATION_HOSTS"
+	enforceDestinationAllowlistEnv = "ENFORCE_DESTINATION_ALLOWLIST"
 )
 
 func init() {
@@ -260,15 +260,25 @@ func main() {
 
 	setupLog.Info("Destination allowlist configured",
 		"allowedDestinationHosts", destinationGuard.Hosts(),
-		"enforce", os.Getenv(enforceDestinationEnv) == "true")
+		"enforce", destinationGuard.Enforcing())
 
-	h := helper.MakeHelper(
+	secretRefClient, err := secretref.NewSecretRef(mgr.GetClient(), destinationGuard)
+	if err != nil {
+		setupLog.Error(err, "unable to configure secret reference resolver")
+		os.Exit(1)
+	}
+
+	h, err := helper.MakeHelper(
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		operatorNamespace,
+		destinationGuard,
 		helper.EnableOwnerRef(enableOwnerRef()),
-		helper.WithDestinationGuard(destinationGuard),
 	)
+	if err != nil {
+		setupLog.Error(err, "unable to configure controller helper")
+		os.Exit(1)
+	}
 
 	keycloakCtrl := keycloak.NewReconcileKeycloak(mgr.GetClient(), mgr.GetScheme(), h)
 	if err = keycloakCtrl.SetupWithManager(mgr, successReconcileTimeoutValue); err != nil {
@@ -276,7 +286,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	keycloakClientCtrl := keycloakclient.NewReconcileKeycloakClient(mgr.GetClient(), h, destinationGuard)
+	keycloakClientCtrl := keycloakclient.NewReconcileKeycloakClient(mgr.GetClient(), h, secretRefClient)
 	if err = keycloakClientCtrl.SetupWithManager(mgr, successReconcileTimeoutValue); err != nil {
 		setupLog.Error(err, "unable to create keycloak-client controller")
 		os.Exit(1)
@@ -328,14 +338,14 @@ func main() {
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		h,
-		secretref.NewSecretRef(mgr.GetClient(), destinationGuard),
+		secretRefClient,
 	).
 		SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create keycloak-realm-component controller")
 		os.Exit(1)
 	}
 
-	if err = keycloakrealmidentityprovider.NewIdentityProviderReconciler(mgr.GetClient(), h, destinationGuard).
+	if err = keycloakrealmidentityprovider.NewIdentityProviderReconciler(mgr.GetClient(), h, secretRefClient).
 		SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create keycloak-realm-identity-provider controller")
 		os.Exit(1)
@@ -451,12 +461,18 @@ func makeDestinationGuard() (*destination.Guard, error) {
 		hosts = strings.Split(raw, ",")
 	}
 
-	guard, err := destination.New(hosts, os.Getenv(enforceDestinationEnv) == "true")
-	if err != nil {
-		return nil, fmt.Errorf("invalid destination allowlist configuration: %w", err)
+	enforce := false
+
+	if raw := strings.TrimSpace(os.Getenv(enforceDestinationAllowlistEnv)); raw != "" {
+		parsed, err := strconv.ParseBool(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s must be a boolean: %w", enforceDestinationAllowlistEnv, err)
+		}
+
+		enforce = parsed
 	}
 
-	return guard, nil
+	return destination.New(hosts, enforce)
 }
 
 func getOperatorNamespace() (string, error) {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeDestinationGuard is the only place the operator's security policy is read from the
+// environment.
+func TestMakeDestinationGuard(t *testing.T) {
+	tests := []struct {
+		name        string
+		hosts       string
+		enforce     string
+		wantHosts   []string
+		wantEnforce bool
+		wantErr     require.ErrorAssertionFunc
+	}{
+		{
+			name:      "unset is an inactive guard",
+			wantHosts: []string{},
+			wantErr:   require.NoError,
+		},
+		{
+			name:      "empty values are an inactive guard",
+			hosts:     "",
+			enforce:   "",
+			wantHosts: []string{},
+			wantErr:   require.NoError,
+		},
+		{
+			name:      "comma separated list with padding",
+			hosts:     " keycloak.example.com , smtp.example.com ",
+			wantHosts: []string{"keycloak.example.com", "smtp.example.com"},
+			wantErr:   require.NoError,
+		},
+		{
+			name:        "enforcement with a list",
+			hosts:       "keycloak.example.com",
+			enforce:     "true",
+			wantHosts:   []string{"keycloak.example.com"},
+			wantEnforce: true,
+			wantErr:     require.NoError,
+		},
+		{
+			name:        "ParseBool spellings are honoured",
+			hosts:       "keycloak.example.com",
+			enforce:     "True",
+			wantHosts:   []string{"keycloak.example.com"},
+			wantEnforce: true,
+			wantErr:     require.NoError,
+		},
+		{
+			name:    "a malformed boolean is fatal rather than silently permissive",
+			hosts:   "keycloak.example.com",
+			enforce: "yes-please",
+			wantErr: require.Error,
+		},
+		{
+			name:    "enforcement without a list is fatal",
+			enforce: "true",
+			wantErr: require.Error,
+		},
+		{
+			name:    "an entry carrying a scheme is fatal",
+			hosts:   "https://keycloak.example.com",
+			wantErr: require.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(allowedDestinationHostsEnv, tt.hosts)
+			t.Setenv(enforceDestinationAllowlistEnv, tt.enforce)
+
+			guard, err := makeDestinationGuard()
+			tt.wantErr(t, err)
+
+			if err != nil {
+				return
+			}
+
+			assert.ElementsMatch(t, tt.wantHosts, guard.Hosts())
+			assert.Equal(t, tt.wantEnforce, guard.Enforcing())
+		})
+	}
+}

--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -133,14 +133,14 @@ Development versions are also available from the [snapshot helm chart repository
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for pod assignment |
-| allowedDestinationHosts | list | `[]` | Hostnames the operator and Keycloak may reach with credentials resolved from Secrets. Covers Keycloak spec.url, realm spec.smtp.connection.host, and URLs inside identity provider and realm component config. Exact, case-insensitive match; no wildcards. Write the hostname only, without scheme, port or path, and prefer fully qualified names. An empty list allows every destination. |
+| allowedDestinationHosts | list | `[]` | Hostnames the operator and Keycloak may reach with credentials resolved from Secrets. Covers Keycloak spec.url, realm spec.smtp.connection.host, and the known destination keys (tokenUrl, connectionUrl, ...) inside identity provider and realm component config. Values in other config keys are not checked. Exact, case-insensitive match; no wildcards. Write the hostname only, without scheme, port or path, and prefer fully qualified names. An empty list means no policy: every destination is allowed and nothing is logged or counted. Add at least one host (for example the Keycloak host) to turn on reporting. |
 | annotations | object | `{}` | Annotations to be added to the Deployment |
 | clusterDomain | string | `"cluster.local"` | Cluster domain for constructing service DNS names |
 | clusterReconciliationEnabled | bool | `false` | If clusterReconciliationEnabled is true, the operator reconciles all Keycloak instances in the cluster;  otherwise, it only reconciles instances in the same namespace by default, and cluster-scoped resources are ignored. |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Container Security Context Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | enableOwnerRef | bool | `true` | If set to true, the operator will set the owner reference for all resources that have Keycloak or KeycloakRealm as reference. This is legacy behavior and not recommended for use. In the future, this will be set to false by default. |
 | enableWebhooks | bool | `true` | If set to true, enables webhook resources (ValidatingWebhookConfiguration, Service, and Certificate). Webhooks require cert-manager to be installed in the cluster. |
-| enforceDestinationAllowlist | bool | `false` | If true, a destination absent from allowedDestinationHosts fails the reconcile. If false, it is only logged and counted, so the list can be built from a running cluster. Enabling this with an empty allowedDestinationHosts stops the operator at startup. |
+| enforceDestinationAllowlist | bool | `false` | If true, a destination absent from allowedDestinationHosts fails the reconcile. If false, destinations absent from a non-empty list are logged and counted, so the list can be built from a running cluster before enforcement is turned on. Enabling this with an empty allowedDestinationHosts stops the operator at startup. |
 | extraVolumeMounts | list | `[]` | Additional volumeMounts to be added to the container |
 | extraVolumes | list | `[]` | Additional volumes to be added to the pod |
 | image.registry | string | `""` | KubeRocketCI keycloak-operator Docker image registry. |

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -68,14 +68,17 @@ clusterReconciliationEnabled: false
 enableOwnerRef: true
 
 # -- Hostnames the operator and Keycloak may reach with credentials resolved from Secrets.
-# Covers Keycloak spec.url, realm spec.smtp.connection.host, and URLs inside identity provider
-# and realm component config. Exact, case-insensitive match; no wildcards. Write the hostname
-# only, without scheme, port or path, and prefer fully qualified names.
-# An empty list allows every destination.
+# Covers Keycloak spec.url, realm spec.smtp.connection.host, and the known destination keys
+# (tokenUrl, connectionUrl, ...) inside identity provider and realm component config.
+# Values in other config keys are not checked. Exact, case-insensitive match; no wildcards.
+# Write the hostname only, without scheme, port or path, and prefer fully qualified names.
+# An empty list means no policy: every destination is allowed and nothing is logged or counted.
+# Add at least one host (for example the Keycloak host) to turn on reporting.
 allowedDestinationHosts: []
 
 # -- If true, a destination absent from allowedDestinationHosts fails the reconcile.
-# If false, it is only logged and counted, so the list can be built from a running cluster.
+# If false, destinations absent from a non-empty list are logged and counted, so the list
+# can be built from a running cluster before enforcement is turned on.
 # Enabling this with an empty allowedDestinationHosts stops the operator at startup.
 enforceDestinationAllowlist: false
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.36.3
+	github.com/prometheus/client_golang v1.22.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/net v0.55.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -52,13 +53,13 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/internal/controller/clusterkeycloak/suite_test.go
+++ b/internal/controller/clusterkeycloak/suite_test.go
@@ -22,6 +22,7 @@ import (
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	keycloakAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
 	"github.com/epam/edp-keycloak-operator/internal/controller/helper"
+	"github.com/epam/edp-keycloak-operator/pkg/destination"
 	"github.com/epam/edp-keycloak-operator/pkg/testutils"
 )
 
@@ -78,7 +79,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	h := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default")
+	h, err := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default", destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = NewReconcile(k8sManager.GetClient(), k8sManager.GetScheme(), h).
 		SetupWithManager(k8sManager)

--- a/internal/controller/clusterkeycloakrealm/chain/configure_email.go
+++ b/internal/controller/clusterkeycloakrealm/chain/configure_email.go
@@ -32,17 +32,16 @@ func (s ConfigureEmail) ServeRequest(ctx context.Context, realm *keycloakApi.Clu
 	l := ctrl.LoggerFrom(ctx)
 	l.Info("Configuring email for realm")
 
-	newHash, err := keycloakrealmchain.ConfigureRealmEmail(
-		ctx,
-		realm.Spec.RealmName,
-		realm.Spec.Smtp,
-		s.operatorNs,
-		kClient.Realms,
-		s.client,
-		realm.Status.ConfigSecretsHash,
-		helper.SpecChanged(realm.Generation, realm.Status.ObservedGeneration),
-		s.guard,
-	)
+	newHash, err := keycloakrealmchain.ConfigureRealmEmail(ctx, keycloakrealmchain.RealmEmailParams{
+		RealmName:        realm.Spec.RealmName,
+		EmailSpec:        realm.Spec.Smtp,
+		SecretsNamespace: s.operatorNs,
+		RealmClient:      kClient.Realms,
+		K8sClient:        s.client,
+		StoredHash:       realm.Status.ConfigSecretsHash,
+		ForceWrite:       helper.SpecChanged(realm.Generation, realm.Status.ObservedGeneration),
+		Guard:            s.guard,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to configure email: %w", err)
 	}

--- a/internal/controller/clusterkeycloakrealm/suite_test.go
+++ b/internal/controller/clusterkeycloakrealm/suite_test.go
@@ -94,7 +94,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	h := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), ns)
+	h, err := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), ns, destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = clusterkeycloak.NewReconcile(k8sManager.GetClient(), k8sManager.GetScheme(), h).
 		SetupWithManager(k8sManager)

--- a/internal/controller/helper/controller_helper.go
+++ b/internal/controller/helper/controller_helper.go
@@ -65,38 +65,41 @@ type Helper struct {
 	// enableOwnerRef is a flag to enable legacy owner reference to Keycloak and KeycloakRealm for operator objects.
 	// This is needed for backward compatibility with the old version of the operator.
 	enableOwnerRef bool
-	// guard vets the Keycloak URL a custom resource points at. Defaults to permissive; cmd/main.go
-	// supplies the configured one.
+	// guard vets the Keycloak URL a custom resource points at.
 	guard *destination.Guard
 }
 
-func MakeHelper(k8sClient client.Client, scheme *runtime.Scheme, operatorNamespace string, options ...func(*Helper)) *Helper {
+func MakeHelper(
+	k8sClient client.Client,
+	scheme *runtime.Scheme,
+	operatorNamespace string,
+	guard *destination.Guard,
+	options ...func(*Helper),
+) (*Helper, error) {
+	// Nil is a wiring fault, not policy-off; policy-off is AllowAll.
+	if guard == nil {
+		return nil, destination.ErrGuardRequired
+	}
+
 	helper := &Helper{
 		client:            k8sClient,
 		scheme:            scheme,
 		operatorNamespace: operatorNamespace,
 		enableOwnerRef:    false,
-		guard:             destination.AllowAll(),
+		guard:             guard,
 	}
 
 	for _, option := range options {
 		option(helper)
 	}
 
-	return helper
+	return helper, nil
 }
 
 // EnableOwnerRef is an option to set the enableOwnerRef field in Helper.
 func EnableOwnerRef(setOwnerRef bool) func(*Helper) {
 	return func(h *Helper) {
 		h.enableOwnerRef = setOwnerRef
-	}
-}
-
-// WithDestinationGuard sets the guard applied to spec.url.
-func WithDestinationGuard(guard *destination.Guard) func(*Helper) {
-	return func(h *Helper) {
-		h.guard = guard
 	}
 }
 

--- a/internal/controller/helper/controller_helper_auth.go
+++ b/internal/controller/helper/controller_helper_auth.go
@@ -14,7 +14,6 @@ import (
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	keycloakAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
 	keycloakClient "github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
-	"github.com/epam/edp-keycloak-operator/pkg/destination"
 	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 )
 
@@ -58,7 +57,7 @@ func (h *Helper) CreateKeycloakClientFromRealm(ctx context.Context, realm *keycl
 }
 
 func (h *Helper) CreateKeycloakClientFromKeycloak(ctx context.Context, kc *keycloakApi.Keycloak) (*keycloakClient.KeycloakClient, error) {
-	authData, err := MakeKeycloakAuthDataFromKeycloak(ctx, kc, h.client, h.guard)
+	authData, err := MakeKeycloakAuthDataFromKeycloak(ctx, kc, h.client)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +66,7 @@ func (h *Helper) CreateKeycloakClientFromKeycloak(ctx context.Context, kc *keycl
 }
 
 func (h *Helper) CreateKeycloakClientFromClusterKeycloak(ctx context.Context, kc *keycloakAlpha.ClusterKeycloak) (*keycloakClient.KeycloakClient, error) {
-	authData, err := MakeKeycloakAuthDataFromClusterKeycloak(ctx, kc, h.operatorNamespace, h.client, h.guard)
+	authData, err := MakeKeycloakAuthDataFromClusterKeycloak(ctx, kc, h.operatorNamespace, h.client)
 	if err != nil {
 		return nil, err
 	}
@@ -94,8 +93,8 @@ func (h *Helper) CreateKeycloakClientFromClusterRealm(ctx context.Context, realm
 }
 
 func (h *Helper) createKeycloakClientFromAuthData(ctx context.Context, authData *KeycloakAuthData) (*keycloakClient.KeycloakClient, error) {
-	// The only path to NewKeycloakClient, so it backstops every caller of
-	// MakeKeycloakAuthDataFrom*. Runs before any credential is resolved below.
+	// Sole path to NewKeycloakClient; the check precedes any client construction.
+	// spec.caCert is resolved by the caller earlier; a CA root is never transmitted.
 	if err := h.guard.RequireHost(ctx, "spec.url", authData.Url); err != nil {
 		return nil, err
 	}
@@ -249,7 +248,7 @@ func (h *Helper) getKeycloakAuthDataFromRealm(ctx context.Context, realm *keyclo
 			return nil, ErrKeycloakIsNotAvailable
 		}
 
-		return MakeKeycloakAuthDataFromKeycloak(ctx, kc, h.client, h.guard)
+		return MakeKeycloakAuthDataFromKeycloak(ctx, kc, h.client)
 	case keycloakAlpha.ClusterKeycloakKind:
 		kc := &keycloakAlpha.ClusterKeycloak{}
 		if err := h.client.Get(ctx, types.NamespacedName{Name: name}, kc); err != nil {
@@ -260,7 +259,7 @@ func (h *Helper) getKeycloakAuthDataFromRealm(ctx context.Context, realm *keyclo
 			return nil, ErrKeycloakIsNotAvailable
 		}
 
-		return MakeKeycloakAuthDataFromClusterKeycloak(ctx, kc, h.operatorNamespace, h.client, h.guard)
+		return MakeKeycloakAuthDataFromClusterKeycloak(ctx, kc, h.operatorNamespace, h.client)
 	default:
 		return nil, fmt.Errorf("unknown keycloak kind: %s", kind)
 	}
@@ -276,20 +275,14 @@ func (h *Helper) getKeycloakAuthDataFromClusterRealm(ctx context.Context, realm 
 		return nil, ErrKeycloakIsNotAvailable
 	}
 
-	return MakeKeycloakAuthDataFromClusterKeycloak(ctx, kc, h.operatorNamespace, h.client, h.guard)
+	return MakeKeycloakAuthDataFromClusterKeycloak(ctx, kc, h.operatorNamespace, h.client)
 }
 
 func MakeKeycloakAuthDataFromKeycloak(
 	ctx context.Context,
 	keycloakCR *keycloakApi.Keycloak,
 	k8sClient client.Client,
-	guard *destination.Guard,
 ) (*KeycloakAuthData, error) {
-	// Checked before spec.caCert is resolved below, so a rejected URL reads no Secret at all.
-	if err := guard.RequireHost(ctx, "spec.url", keycloakCR.Spec.Url); err != nil {
-		return nil, err
-	}
-
 	auth := &KeycloakAuthData{
 		Url:                keycloakCR.Spec.Url,
 		SecretName:         keycloakCR.Spec.Secret,
@@ -315,13 +308,7 @@ func MakeKeycloakAuthDataFromClusterKeycloak(
 	keycloakCR *keycloakAlpha.ClusterKeycloak,
 	secretNamespace string,
 	k8sClient client.Client,
-	guard *destination.Guard,
 ) (*KeycloakAuthData, error) {
-	// Checked before spec.caCert is resolved below, so a rejected URL reads no Secret at all.
-	if err := guard.RequireHost(ctx, "spec.url", keycloakCR.Spec.Url); err != nil {
-		return nil, err
-	}
-
 	auth := &KeycloakAuthData{
 		Url:                keycloakCR.Spec.Url,
 		SecretName:         keycloakCR.Spec.Secret,

--- a/internal/controller/helper/controller_helper_auth_test.go
+++ b/internal/controller/helper/controller_helper_auth_test.go
@@ -218,7 +218,7 @@ func TestMakeKeycloakAuthDataFromKeycloak(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := MakeKeycloakAuthDataFromKeycloak(ctrl.LoggerInto(context.Background(), logr.Discard()), tt.keycloak, tt.k8sClient(t), destination.AllowAll())
+			got, err := MakeKeycloakAuthDataFromKeycloak(ctrl.LoggerInto(context.Background(), logr.Discard()), tt.keycloak, tt.k8sClient(t))
 
 			tt.wantErr(t, err)
 			require.Equal(t, tt.want, got)
@@ -289,7 +289,6 @@ func TestMakeKeycloakAuthDataFromClusterKeycloak(t *testing.T) {
 				tt.keycloak,
 				"ns-with-secrets",
 				tt.k8sClient(t),
-				destination.AllowAll(),
 			)
 
 			tt.wantErr(t, err)

--- a/internal/controller/helper/controller_helper_test.go
+++ b/internal/controller/helper/controller_helper_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	keycloakApiAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
+	"github.com/epam/edp-keycloak-operator/pkg/destination"
 )
 
 func TestHelper_GetOrCreateRealmOwnerRef(t *testing.T) {
@@ -31,7 +32,8 @@ func TestHelper_GetOrCreateRealmOwnerRef(t *testing.T) {
 	sch := runtime.NewScheme()
 	utilruntime.Must(keycloakApi.AddToScheme(sch))
 
-	helper := MakeHelper(&mc, sch, "default")
+	helper, err := MakeHelper(&mc, sch, "default", destination.AllowAll())
+	require.NoError(t, err)
 
 	kcGroup := keycloakApi.KeycloakRealmGroup{
 		ObjectMeta: metav1.ObjectMeta{
@@ -51,7 +53,7 @@ func TestHelper_GetOrCreateRealmOwnerRef(t *testing.T) {
 	}, &keycloakApi.KeycloakRealm{}).Return(nil)
 	mc.On("Update", testifymock.Anything, testifymock.Anything).Return(nil)
 
-	err := helper.SetRealmOwnerRef(context.Background(), &kcGroup)
+	err = helper.SetRealmOwnerRef(context.Background(), &kcGroup)
 	require.NoError(t, err)
 
 	kcGroup = keycloakApi.KeycloakRealmGroup{
@@ -76,7 +78,8 @@ func TestHelper_GetOrCreateRealmOwnerRef(t *testing.T) {
 }
 
 func TestMakeHelper(t *testing.T) {
-	h := MakeHelper(nil, nil, "default", EnableOwnerRef(true))
+	h, err := MakeHelper(nil, nil, "default", destination.AllowAll(), EnableOwnerRef(true))
+	require.NoError(t, err)
 	assert.True(t, h.enableOwnerRef)
 }
 
@@ -941,4 +944,13 @@ func TestHelper_SetKeycloakOwnerRef(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMakeHelper_RejectsNilGuard(t *testing.T) {
+	t.Parallel()
+
+	_, err := MakeHelper(nil, nil, "ns", nil)
+
+	require.ErrorIs(t, err, destination.ErrGuardRequired,
+		"a nil guard must fail at wiring time, not fail open at runtime")
 }

--- a/internal/controller/helper/destination_guard_test.go
+++ b/internal/controller/helper/destination_guard_test.go
@@ -67,7 +67,10 @@ func exfilHelper(t *testing.T, kc *keycloakApi.Keycloak, guard *destination.Guar
 
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(victim, kc).Build()
 
-	return MakeHelper(cl, s, "operator-ns", WithDestinationGuard(guard))
+	h, err := MakeHelper(cl, s, "operator-ns", guard)
+	require.NoError(t, err)
+
+	return h
 }
 
 // The advisory's exploit: a Keycloak CR pointing spec.url at an attacker endpoint while naming a
@@ -111,7 +114,7 @@ func TestCreateKeycloakClientFromKeycloak_DeniesUnlistedDestinationForLegacySecr
 	assert.Empty(t, received, "no request may reach an unlisted destination")
 }
 
-// Warn mode preserves today's behaviour so an upgrade breaks no existing installation.
+// Warn mode must not deny; only enforce mode blocks the request.
 func TestCreateKeycloakClientFromKeycloak_WarnModeStillConnects(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controller/keycloak/suite_test.go
+++ b/internal/controller/keycloak/suite_test.go
@@ -21,6 +21,7 @@ import (
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/internal/controller/helper"
+	"github.com/epam/edp-keycloak-operator/pkg/destination"
 	"github.com/epam/edp-keycloak-operator/pkg/testutils"
 )
 
@@ -75,7 +76,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	h := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default")
+	h, err := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default", destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = NewReconcileKeycloak(k8sManager.GetClient(), k8sManager.GetScheme(), h).
 		SetupWithManager(k8sManager, 0)

--- a/internal/controller/keycloakauthflow/suite_test.go
+++ b/internal/controller/keycloakauthflow/suite_test.go
@@ -96,7 +96,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	h := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default")
+	h, err := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default", destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = keycloak.NewReconcileKeycloak(k8sManager.GetClient(), k8sManager.GetScheme(), h).
 		SetupWithManager(k8sManager, 0)

--- a/internal/controller/keycloakclient/chain/chain.go
+++ b/internal/controller/keycloakclient/chain/chain.go
@@ -9,7 +9,6 @@ import (
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
-	"github.com/epam/edp-keycloak-operator/pkg/destination"
 	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 )
 
@@ -66,12 +65,12 @@ func (ch *Chain) Serve(
 func MakeChain(
 	kClient *keycloakapi.KeycloakClient,
 	k8sClient client.Client,
-	guard *destination.Guard,
+	secretRef *secretref.SecretRef,
 ) *Chain {
 	c := &Chain{}
 
 	c.Use(
-		NewPutClient(kClient, k8sClient, secretref.NewSecretRef(k8sClient, guard)),
+		NewPutClient(kClient, k8sClient, secretRef),
 		NewPutClientRole(kClient, k8sClient),
 		NewPutRealmRole(kClient, k8sClient),
 		NewPutClientScope(kClient, k8sClient),

--- a/internal/controller/keycloakclient/chain/chain_test.go
+++ b/internal/controller/keycloakclient/chain/chain_test.go
@@ -15,6 +15,7 @@ import (
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	"github.com/epam/edp-keycloak-operator/pkg/destination"
+	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 )
 
 type testHandler struct {
@@ -98,7 +99,10 @@ func TestMakeChain(t *testing.T) {
 
 	k8sClient := fake.NewClientBuilder().WithScheme(s).Build()
 
-	c := MakeChain(&keycloakapi.KeycloakClient{}, k8sClient, destination.AllowAll())
+	secretRefClient, err := secretref.NewSecretRef(k8sClient, destination.AllowAll())
+	require.NoError(t, err)
+
+	c := MakeChain(&keycloakapi.KeycloakClient{}, k8sClient, secretRefClient)
 
 	require.Len(t, c.handlers, 11)
 }

--- a/internal/controller/keycloakclient/keycloakclient_controller.go
+++ b/internal/controller/keycloakclient/keycloakclient_controller.go
@@ -20,7 +20,7 @@ import (
 	"github.com/epam/edp-keycloak-operator/internal/controller/helper"
 	"github.com/epam/edp-keycloak-operator/internal/controller/keycloakclient/chain"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
-	"github.com/epam/edp-keycloak-operator/pkg/destination"
+	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 )
 
 type Helper interface {
@@ -35,12 +35,12 @@ const keyCloakClientOperatorFinalizerName = "keycloak.client.operator.finalizer.
 func NewReconcileKeycloakClient(
 	k8sClient client.Client,
 	controllerHelper Helper,
-	guard *destination.Guard,
+	secretRef *secretref.SecretRef,
 ) *ReconcileKeycloakClient {
 	return &ReconcileKeycloakClient{
-		client: k8sClient,
-		helper: controllerHelper,
-		guard:  guard,
+		client:    k8sClient,
+		helper:    controllerHelper,
+		secretRef: secretRef,
 	}
 }
 
@@ -48,7 +48,7 @@ func NewReconcileKeycloakClient(
 type ReconcileKeycloakClient struct {
 	client                  client.Client
 	helper                  Helper
-	guard                   *destination.Guard
+	secretRef               *secretref.SecretRef
 	successReconcileTimeout time.Duration
 }
 
@@ -161,7 +161,7 @@ func (r *ReconcileKeycloakClient) handleReconciliation(ctx context.Context, inst
 
 	var resultErr error
 
-	if err := chain.MakeChain(kClient, r.client, r.guard).Serve(ctx, instance, realmName); err != nil {
+	if err := chain.MakeChain(kClient, r.client, r.secretRef).Serve(ctx, instance, realmName); err != nil {
 		if errors.Is(err, helper.ErrKeycloakIsNotAvailable) {
 			return ctrl.Result{RequeueAfter: helper.RequeueOnKeycloakNotAvailablePeriod}, nil
 		}

--- a/internal/controller/keycloakclient/suite_test.go
+++ b/internal/controller/keycloakclient/suite_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/epam/edp-keycloak-operator/internal/controller/keycloakrealm"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	"github.com/epam/edp-keycloak-operator/pkg/destination"
+	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 	"github.com/epam/edp-keycloak-operator/pkg/testutils"
 )
 
@@ -109,7 +110,10 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	controllerHelper = helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default")
+	controllerHelper, err = helper.MakeHelper(
+		k8sManager.GetClient(), k8sManager.GetScheme(), "default", destination.AllowAll(),
+	)
+	Expect(err).NotTo(HaveOccurred())
 
 	err = keycloak.NewReconcileKeycloak(k8sManager.GetClient(), k8sManager.GetScheme(), controllerHelper).
 		SetupWithManager(k8sManager, 0)
@@ -119,7 +123,10 @@ var _ = BeforeSuite(func() {
 		SetupWithManager(k8sManager, 0)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = NewReconcileKeycloakClient(k8sManager.GetClient(), controllerHelper, destination.AllowAll()).
+	secretRefClient, err := secretref.NewSecretRef(k8sManager.GetClient(), destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
+
+	err = NewReconcileKeycloakClient(k8sManager.GetClient(), controllerHelper, secretRefClient).
 		SetupWithManager(k8sManager, 0)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/keycloakclientscope/suite_test.go
+++ b/internal/controller/keycloakclientscope/suite_test.go
@@ -105,7 +105,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	h := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default")
+	h, err := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default", destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = keycloak.NewReconcileKeycloak(k8sManager.GetClient(), k8sManager.GetScheme(), h).
 		SetupWithManager(k8sManager, 0)

--- a/internal/controller/keycloakorganization/keycloakorganization_controller_integration_test.go
+++ b/internal/controller/keycloakorganization/keycloakorganization_controller_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/epam/edp-keycloak-operator/api/v1alpha1"
 	"github.com/epam/edp-keycloak-operator/internal/controller/helper"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+	"github.com/epam/edp-keycloak-operator/pkg/destination"
 	"github.com/epam/edp-keycloak-operator/pkg/objectmeta"
 )
 
@@ -30,7 +31,9 @@ var _ = Describe("Organization controller", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		h = helper.MakeHelper(k8sClient, k8sClient.Scheme(), "default")
+		var err error
+		h, err = helper.MakeHelper(k8sClient, k8sClient.Scheme(), "default", destination.AllowAll())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("Should create Organization", func() {

--- a/internal/controller/keycloakorganization/suite_test.go
+++ b/internal/controller/keycloakorganization/suite_test.go
@@ -99,7 +99,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	h := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default")
+	h, err := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default", destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = keycloak.NewReconcileKeycloak(k8sManager.GetClient(), k8sManager.GetScheme(), h).
 		SetupWithManager(k8sManager, 0)

--- a/internal/controller/keycloakrealm/chain/configure_email.go
+++ b/internal/controller/keycloakrealm/chain/configure_email.go
@@ -33,17 +33,16 @@ func (s ConfigureEmail) ServeRequest(ctx context.Context, realm *keycloakApi.Key
 	l := ctrl.LoggerFrom(ctx)
 	l.Info("Configuring email for realm")
 
-	newHash, err := ConfigureRealmEmail(
-		ctx,
-		realm.Spec.RealmName,
-		realm.Spec.Smtp,
-		realm.Namespace,
-		kClient.Realms,
-		s.client,
-		realm.Status.ConfigSecretsHash,
-		helper.SpecChanged(realm.Generation, realm.Status.ObservedGeneration),
-		s.guard,
-	)
+	newHash, err := ConfigureRealmEmail(ctx, RealmEmailParams{
+		RealmName:        realm.Spec.RealmName,
+		EmailSpec:        realm.Spec.Smtp,
+		SecretsNamespace: realm.Namespace,
+		RealmClient:      kClient.Realms,
+		K8sClient:        s.client,
+		StoredHash:       realm.Status.ConfigSecretsHash,
+		ForceWrite:       helper.SpecChanged(realm.Generation, realm.Status.ObservedGeneration),
+		Guard:            s.guard,
+	})
 	if err != nil {
 		return err
 	}
@@ -55,37 +54,39 @@ func (s ConfigureEmail) ServeRequest(ctx context.Context, realm *keycloakApi.Key
 	return nextServeOrNil(ctx, s.next, realm, kClient)
 }
 
-// ConfigureRealmEmail applies emailSpec to the realm's SMTP server config and returns the
+// RealmEmailParams carries the inputs of ConfigureRealmEmail.
+type RealmEmailParams struct {
+	RealmName        string
+	EmailSpec        *common.SMTP
+	SecretsNamespace string
+	RealmClient      keycloakapi.RealmClient
+	K8sClient        client.Client
+	StoredHash       string
+	ForceWrite       bool
+	Guard            *destination.Guard
+}
+
+// ConfigureRealmEmail applies EmailSpec to the realm's SMTP server config and returns the
 // resolved-secret hash. GetRealm always runs to obtain the comparison baseline; the UpdateRealm
-// write is skipped when forceWrite is false, storedHash matches the newly resolved hash, and
+// write is skipped when ForceWrite is false, StoredHash matches the newly resolved hash, and
 // the fetched SMTP config already matches spec.
-func ConfigureRealmEmail(
-	ctx context.Context,
-	realmName string,
-	emailSpec *common.SMTP,
-	secretsNamespace string,
-	realmClient keycloakapi.RealmClient,
-	k8sClient client.Client,
-	storedHash string,
-	forceWrite bool,
-	guard *destination.Guard,
-) (string, error) {
-	if emailSpec == nil {
+func ConfigureRealmEmail(ctx context.Context, p RealmEmailParams) (string, error) {
+	if p.EmailSpec == nil {
 		return "", nil
 	}
 
 	// Keycloak, not the operator, dials this host, and it carries the SMTP password.
 	// Checked before the password Secret is resolved below.
-	if err := guard.RequireHost(ctx, "spec.smtp.connection.host", emailSpec.Connection.Host); err != nil {
+	if err := p.Guard.RequireHost(ctx, "spec.smtp.connection.host", p.EmailSpec.Connection.Host); err != nil {
 		return "", err
 	}
 
-	current, _, err := realmClient.GetRealm(ctx, realmName)
+	current, _, err := p.RealmClient.GetRealm(ctx, p.RealmName)
 	if err != nil {
-		return "", fmt.Errorf("unable to get realm %v: %w", realmName, err)
+		return "", fmt.Errorf("unable to get realm %v: %w", p.RealmName, err)
 	}
 
-	emailMap, passwordVersion, err := convertEmailSpecToMap(ctx, emailSpec, secretsNamespace, k8sClient)
+	emailMap, passwordVersion, err := convertEmailSpecToMap(ctx, p.EmailSpec, p.SecretsNamespace, p.K8sClient)
 	if err != nil {
 		return "", err
 	}
@@ -93,20 +94,20 @@ func ConfigureRealmEmail(
 	// Rotating the password's k8s Secret bumps no CR generation; the hash of the secret's
 	// version token forces the write instead.
 	passwordVersions := map[string]string{}
-	if emailSpec.Connection.Authentication != nil {
+	if p.EmailSpec.Connection.Authentication != nil {
 		passwordVersions["password"] = passwordVersion
 	}
 
 	newHash := secretref.ValuesHashSingle(passwordVersions)
 
-	if !forceWrite && storedHash == newHash && smtpMatchesSpec(current.SmtpServer, emailMap) {
+	if !p.ForceWrite && p.StoredHash == newHash && smtpMatchesSpec(current.SmtpServer, emailMap) {
 		return newHash, nil
 	}
 
 	current.SmtpServer = &emailMap
 
-	if _, err = realmClient.UpdateRealm(ctx, realmName, *current); err != nil {
-		return "", fmt.Errorf("unable to update realm %v: %w", realmName, err)
+	if _, err = p.RealmClient.UpdateRealm(ctx, p.RealmName, *current); err != nil {
+		return "", fmt.Errorf("unable to update realm %v: %w", p.RealmName, err)
 	}
 
 	return newHash, nil

--- a/internal/controller/keycloakrealm/chain/configure_email_test.go
+++ b/internal/controller/keycloakrealm/chain/configure_email_test.go
@@ -362,17 +362,16 @@ func TestConfigureRealmEmail(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			gotHash, err := ConfigureRealmEmail(
-				context.Background(),
-				"realm",
-				emailSpec,
-				namespace,
-				tt.realmClient(t),
-				tt.k8sClient,
-				tt.storedHash,
-				tt.forceWrite,
-				destination.AllowAll(),
-			)
+			gotHash, err := ConfigureRealmEmail(context.Background(), RealmEmailParams{
+				RealmName:        "realm",
+				EmailSpec:        emailSpec,
+				SecretsNamespace: namespace,
+				RealmClient:      tt.realmClient(t),
+				K8sClient:        tt.k8sClient,
+				StoredHash:       tt.storedHash,
+				ForceWrite:       tt.forceWrite,
+				Guard:            destination.AllowAll(),
+			})
 
 			tt.wantErr(t, err)
 			require.Equal(t, tt.wantHash, gotHash)

--- a/internal/controller/keycloakrealm/suite_test.go
+++ b/internal/controller/keycloakrealm/suite_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/epam/edp-keycloak-operator/internal/controller/keycloakclient"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	"github.com/epam/edp-keycloak-operator/pkg/destination"
+	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 	"github.com/epam/edp-keycloak-operator/pkg/testutils"
 )
 
@@ -92,7 +93,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	h := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), ns)
+	h, err := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), ns, destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = keycloak.NewReconcileKeycloak(k8sManager.GetClient(), k8sManager.GetScheme(), h).
 		SetupWithManager(k8sManager, time.Second)
@@ -102,7 +104,10 @@ var _ = BeforeSuite(func() {
 		SetupWithManager(k8sManager, time.Second)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = keycloakclient.NewReconcileKeycloakClient(k8sManager.GetClient(), h, destination.AllowAll()).
+	secretRefClient, err := secretref.NewSecretRef(k8sManager.GetClient(), destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
+
+	err = keycloakclient.NewReconcileKeycloakClient(k8sManager.GetClient(), h, secretRefClient).
 		SetupWithManager(k8sManager, time.Second)
 
 	go func() {

--- a/internal/controller/keycloakrealmcomponent/chain/chain.go
+++ b/internal/controller/keycloakrealmcomponent/chain/chain.go
@@ -13,7 +13,7 @@ import (
 
 // SecretRefClient resolves secret references in component config.
 type SecretRefClient interface {
-	MapComponentConfigSecretsRefs(ctx context.Context, config map[string][]string, namespace string) (map[string][]string, error)
+	MapComponentConfigSecretsRefs(ctx context.Context, field string, config map[string][]string, namespace string) (map[string][]string, error)
 }
 
 // RealmComponentHandler is a handler in the chain of responsibility for KeycloakRealmComponent.

--- a/internal/controller/keycloakrealmcomponent/chain/chain_test.go
+++ b/internal/controller/keycloakrealmcomponent/chain/chain_test.go
@@ -77,6 +77,6 @@ type mockSecretRefClient struct {
 	err error
 }
 
-func (m *mockSecretRefClient) MapComponentConfigSecretsRefs(_ context.Context, _ map[string][]string, _ string) (map[string][]string, error) {
+func (m *mockSecretRefClient) MapComponentConfigSecretsRefs(_ context.Context, _ string, _ map[string][]string, _ string) (map[string][]string, error) {
 	return nil, m.err
 }

--- a/internal/controller/keycloakrealmcomponent/chain/create_or_update_component.go
+++ b/internal/controller/keycloakrealmcomponent/chain/create_or_update_component.go
@@ -55,7 +55,7 @@ func (h *CreateOrUpdateComponent) Serve(
 		config[k] = copied
 	}
 
-	secretVersions, err := h.secretRefClient.MapComponentConfigSecretsRefs(ctx, config, component.Namespace)
+	secretVersions, err := h.secretRefClient.MapComponentConfigSecretsRefs(ctx, "spec.config", config, component.Namespace)
 	if err != nil {
 		return fmt.Errorf("unable to map config secrets: %w", err)
 	}

--- a/internal/controller/keycloakrealmcomponent/chain/create_or_update_component_test.go
+++ b/internal/controller/keycloakrealmcomponent/chain/create_or_update_component_test.go
@@ -36,7 +36,7 @@ type fakeSecretRefClient struct {
 	err error
 }
 
-func (f *fakeSecretRefClient) MapComponentConfigSecretsRefs(_ context.Context, _ map[string][]string, _ string) (map[string][]string, error) {
+func (f *fakeSecretRefClient) MapComponentConfigSecretsRefs(_ context.Context, _ string, _ map[string][]string, _ string) (map[string][]string, error) {
 	return nil, f.err
 }
 
@@ -48,7 +48,7 @@ type mutatingSecretRefClient struct {
 	versions map[string][]string
 }
 
-func (f *mutatingSecretRefClient) MapComponentConfigSecretsRefs(_ context.Context, config map[string][]string, _ string) (map[string][]string, error) {
+func (f *mutatingSecretRefClient) MapComponentConfigSecretsRefs(_ context.Context, _ string, config map[string][]string, _ string) (map[string][]string, error) {
 	if f.mutate != nil {
 		f.mutate(config)
 	}

--- a/internal/controller/keycloakrealmcomponent/suite_test.go
+++ b/internal/controller/keycloakrealmcomponent/suite_test.go
@@ -106,7 +106,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	h := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default")
+	h, err := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default", destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = keycloak.NewReconcileKeycloak(k8sManager.GetClient(), k8sManager.GetScheme(), h).
 		SetupWithManager(k8sManager, 0)
@@ -116,7 +117,10 @@ var _ = BeforeSuite(func() {
 		SetupWithManager(k8sManager, 0)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = NewRealmComponentReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), h, secretref.NewSecretRef(k8sManager.GetClient(), destination.AllowAll())).
+	secretRefClient, err := secretref.NewSecretRef(k8sManager.GetClient(), destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
+
+	err = NewRealmComponentReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), h, secretRefClient).
 		SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/keycloakrealmgroup/suite_test.go
+++ b/internal/controller/keycloakrealmgroup/suite_test.go
@@ -96,7 +96,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	h := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default")
+	h, err := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default", destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = keycloak.NewReconcileKeycloak(k8sManager.GetClient(), k8sManager.GetScheme(), h).
 		SetupWithManager(k8sManager, 0)

--- a/internal/controller/keycloakrealmidentityprovider/chain/chain.go
+++ b/internal/controller/keycloakrealmidentityprovider/chain/chain.go
@@ -9,7 +9,6 @@ import (
 
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
-	"github.com/epam/edp-keycloak-operator/pkg/destination"
 	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 )
 
@@ -57,12 +56,12 @@ func (ch *Chain) Serve(
 func MakeChain(
 	kClient *keycloakapi.KeycloakClient,
 	k8sClient client.Client,
-	guard *destination.Guard,
+	secretRef *secretref.SecretRef,
 ) *Chain {
 	c := &Chain{}
 
 	c.Use(
-		NewPutIDP(kClient.IdentityProviders, secretref.NewSecretRef(k8sClient, guard)),
+		NewPutIDP(kClient.IdentityProviders, secretRef),
 		NewPutIDPMappers(kClient.IdentityProviders),
 		NewPutAdminFineGrainedPermissions(kClient),
 	)

--- a/internal/controller/keycloakrealmidentityprovider/chain/chain_test.go
+++ b/internal/controller/keycloakrealmidentityprovider/chain/chain_test.go
@@ -15,6 +15,7 @@ import (
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	"github.com/epam/edp-keycloak-operator/pkg/destination"
+	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 )
 
 type testHandler struct {
@@ -98,7 +99,10 @@ func TestMakeChain(t *testing.T) {
 
 	k8sClient := fake.NewClientBuilder().WithScheme(s).Build()
 
-	c := MakeChain(&keycloakapi.KeycloakClient{}, k8sClient, destination.AllowAll())
+	secretRefClient, err := secretref.NewSecretRef(k8sClient, destination.AllowAll())
+	require.NoError(t, err)
+
+	c := MakeChain(&keycloakapi.KeycloakClient{}, k8sClient, secretRefClient)
 
 	require.Len(t, c.handlers, 3)
 }

--- a/internal/controller/keycloakrealmidentityprovider/chain/put_idp.go
+++ b/internal/controller/keycloakrealmidentityprovider/chain/put_idp.go
@@ -16,7 +16,7 @@ import (
 )
 
 type refClient interface {
-	MapConfigSecretsRefs(ctx context.Context, config map[string]string, namespace string) (map[string]string, error)
+	MapConfigSecretsRefs(ctx context.Context, field string, config map[string]string, namespace string) (map[string]string, error)
 }
 
 type PutIDP struct {
@@ -37,7 +37,7 @@ func (h *PutIDP) Serve(ctx context.Context, keycloakRealmIDP *keycloakApi.Keyclo
 	config := make(map[string]string, len(rawSpecConfig))
 	maps.Copy(config, rawSpecConfig)
 
-	secretVersions, err := h.secretRef.MapConfigSecretsRefs(ctx, config, keycloakRealmIDP.Namespace)
+	secretVersions, err := h.secretRef.MapConfigSecretsRefs(ctx, "spec.config", config, keycloakRealmIDP.Namespace)
 	if err != nil {
 		return fmt.Errorf("unable to map config secrets: %w", err)
 	}

--- a/internal/controller/keycloakrealmidentityprovider/chain/put_idp_test.go
+++ b/internal/controller/keycloakrealmidentityprovider/chain/put_idp_test.go
@@ -59,7 +59,7 @@ func inSyncIDPRepresentation() *keycloakapi.IdentityProviderRepresentation {
 
 func noSecretRefMock(t *testing.T) refClient {
 	m := secretrefmocks.NewMockRefClient(t)
-	m.On("MapConfigSecretsRefs", mock.Anything, mock.Anything, "default").Return(map[string]string{}, nil)
+	m.On("MapConfigSecretsRefs", mock.Anything, mock.Anything, mock.Anything, "default").Return(map[string]string{}, nil)
 
 	return m
 }
@@ -108,7 +108,7 @@ func TestPutIDP_Serve(t *testing.T) {
 			},
 			secretRef: func(t *testing.T) refClient {
 				m := secretrefmocks.NewMockRefClient(t)
-				m.On("MapConfigSecretsRefs", mock.Anything, mock.Anything, "default").
+				m.On("MapConfigSecretsRefs", mock.Anything, mock.Anything, mock.Anything, "default").
 					Return(map[string]string{"clientSecret": "secret:secret-name:secret-key@uid-1@100"}, nil)
 				return m
 			},
@@ -151,7 +151,7 @@ func TestPutIDP_Serve(t *testing.T) {
 			},
 			secretRef: func(t *testing.T) refClient {
 				m := secretrefmocks.NewMockRefClient(t)
-				m.On("MapConfigSecretsRefs", mock.Anything, mock.Anything, "default").
+				m.On("MapConfigSecretsRefs", mock.Anything, mock.Anything, mock.Anything, "default").
 					Return(nil, fmt.Errorf("secret not found"))
 				return m
 			},
@@ -210,9 +210,9 @@ func TestPutIDP_Serve(t *testing.T) {
 			},
 			secretRef: func(t *testing.T) refClient {
 				m := secretrefmocks.NewMockRefClient(t)
-				m.On("MapConfigSecretsRefs", mock.Anything, mock.Anything, "default").
+				m.On("MapConfigSecretsRefs", mock.Anything, mock.Anything, mock.Anything, "default").
 					Run(func(args mock.Arguments) {
-						cfg, _ := args.Get(1).(map[string]string)
+						cfg, _ := args.Get(2).(map[string]string)
 						cfg["clientSecret"] = "resolved-secret-value"
 					}).
 					Return(map[string]string{"clientSecret": clientSecretVersionToken}, nil)

--- a/internal/controller/keycloakrealmidentityprovider/keycloakrealmidentityprovider_controller.go
+++ b/internal/controller/keycloakrealmidentityprovider/keycloakrealmidentityprovider_controller.go
@@ -18,7 +18,7 @@ import (
 	"github.com/epam/edp-keycloak-operator/internal/controller/helper"
 	"github.com/epam/edp-keycloak-operator/internal/controller/keycloakrealmidentityprovider/chain"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
-	"github.com/epam/edp-keycloak-operator/pkg/destination"
+	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 )
 
 const successRequeueTime = time.Minute * 10
@@ -34,20 +34,20 @@ type IdentityProviderReconcilerCtrlHelper interface {
 }
 
 type IdentityProviderReconciler struct {
-	client client.Client
-	helper IdentityProviderReconcilerCtrlHelper
-	guard  *destination.Guard
+	client    client.Client
+	helper    IdentityProviderReconcilerCtrlHelper
+	secretRef *secretref.SecretRef
 }
 
 func NewIdentityProviderReconciler(
 	k8sClient client.Client,
 	controllerHelper IdentityProviderReconcilerCtrlHelper,
-	guard *destination.Guard,
+	secretRef *secretref.SecretRef,
 ) *IdentityProviderReconciler {
 	return &IdentityProviderReconciler{
-		client: k8sClient,
-		helper: controllerHelper,
-		guard:  guard,
+		client:    k8sClient,
+		helper:    controllerHelper,
+		secretRef: secretRef,
 	}
 }
 
@@ -158,7 +158,7 @@ func (r *IdentityProviderReconciler) handleReconciliation(ctx context.Context, i
 
 	oldStatus := instance.Status
 
-	if err := chain.MakeChain(kClient, r.client, r.guard).Serve(ctx, instance, realmName); err != nil {
+	if err := chain.MakeChain(kClient, r.client, r.secretRef).Serve(ctx, instance, realmName); err != nil {
 		log.Error(err, "An error has occurred while handling KeycloakRealmIdentityProvider")
 
 		resultErr := fmt.Errorf("identity provider chain processing failed: %w", err)

--- a/internal/controller/keycloakrealmidentityprovider/suite_test.go
+++ b/internal/controller/keycloakrealmidentityprovider/suite_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/epam/edp-keycloak-operator/internal/controller/keycloakrealm"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	"github.com/epam/edp-keycloak-operator/pkg/destination"
+	"github.com/epam/edp-keycloak-operator/pkg/secretref"
 	"github.com/epam/edp-keycloak-operator/pkg/testutils"
 )
 
@@ -105,7 +106,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	h := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default")
+	h, err := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default", destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = keycloak.NewReconcileKeycloak(k8sManager.GetClient(), k8sManager.GetScheme(), h).
 		SetupWithManager(k8sManager, 0)
@@ -115,7 +117,10 @@ var _ = BeforeSuite(func() {
 		SetupWithManager(k8sManager, 0)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = NewIdentityProviderReconciler(k8sManager.GetClient(), h, destination.AllowAll()).
+	secretRefClient, err := secretref.NewSecretRef(k8sManager.GetClient(), destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
+
+	err = NewIdentityProviderReconciler(k8sManager.GetClient(), h, secretRefClient).
 		SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/keycloakrealmrole/suite_test.go
+++ b/internal/controller/keycloakrealmrole/suite_test.go
@@ -105,7 +105,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	h := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default")
+	h, err := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default", destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = keycloak.NewReconcileKeycloak(k8sManager.GetClient(), k8sManager.GetScheme(), h).
 		SetupWithManager(k8sManager, 0)

--- a/internal/controller/keycloakrealmrolebatch/keycloakrealmrolebatch_controller_test.go
+++ b/internal/controller/keycloakrealmrolebatch/keycloakrealmrolebatch_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/internal/controller/helper"
+	"github.com/epam/edp-keycloak-operator/pkg/destination"
 )
 
 type testLogger struct {
@@ -85,12 +86,15 @@ func TestReconcileKeycloakRealmRoleBatch_ReconcileDelete(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(&batch, &realm, &keycloak, &secret).Build()
 	log := newTestLogr()
+	controllerHelper, err := helper.MakeHelper(client, scheme, "default", destination.AllowAll())
+	require.NoError(t, err)
+
 	rkr := ReconcileKeycloakRealmRoleBatch{
 		client: client,
-		helper: helper.MakeHelper(client, scheme, "default"),
+		helper: controllerHelper,
 	}
 
-	_, err := rkr.Reconcile(context.Background(), reconcile.Request{
+	_, err = rkr.Reconcile(context.Background(), reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Name:      "test",
 			Namespace: ns,
@@ -145,10 +149,12 @@ func TestReconcileKeycloakRealmRoleBatch_Reconcile(t *testing.T) {
 		WithRuntimeObjects(&batch, &realm, &keycloak, &secret, &role).WithStatusSubresource(&batch).Build()
 
 	logger := newTestLogr()
+	controllerHelper, err := helper.MakeHelper(client, sch, "default", destination.AllowAll())
+	require.NoError(t, err)
 
 	rkr := ReconcileKeycloakRealmRoleBatch{
 		client:                  client,
-		helper:                  helper.MakeHelper(client, sch, "default"),
+		helper:                  controllerHelper,
 		successReconcileTimeout: time.Hour,
 	}
 
@@ -250,12 +256,15 @@ func TestReconcileKeycloakRealmRoleBatch_ReconcileFailure(t *testing.T) {
 		WithRuntimeObjects(&batch, &realm, &keycloak, &secret, &role).WithStatusSubresource(&batch).Build()
 
 	logger := newTestLogr()
+	controllerHelper, err := helper.MakeHelper(client, scheme, "default", destination.AllowAll())
+	require.NoError(t, err)
+
 	rkr := ReconcileKeycloakRealmRoleBatch{
 		client: client,
-		helper: helper.MakeHelper(client, scheme, "default"),
+		helper: controllerHelper,
 	}
 
-	_, err := rkr.Reconcile(ctrl.LoggerInto(context.Background(), logger), reconcile.Request{
+	_, err = rkr.Reconcile(ctrl.LoggerInto(context.Background(), logger), reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Name:      "batch1",
 			Namespace: ns,

--- a/internal/controller/keycloakrealmuser/suite_test.go
+++ b/internal/controller/keycloakrealmuser/suite_test.go
@@ -105,7 +105,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	h := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default")
+	h, err := helper.MakeHelper(k8sManager.GetClient(), k8sManager.GetScheme(), "default", destination.AllowAll())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = keycloak.NewReconcileKeycloak(k8sManager.GetClient(), k8sManager.GetScheme(), h).
 		SetupWithManager(k8sManager, 0)

--- a/pkg/destination/guard.go
+++ b/pkg/destination/guard.go
@@ -5,6 +5,13 @@
 // spec. The operator's ServiceAccount can read Secrets the author cannot, so without this check
 // the author can name any Secret and any destination and have the operator deliver one to the
 // other (GHSA-wj3g-w873-xwg7).
+//
+// Covered spec fields are listed in deploy-templates/values.yaml (allowedDestinationHosts);
+// update that list when adding a call site.
+//
+// The guard judges only fields this operator version knows: spec.url, spec.smtp.connection.host,
+// and the destination and credential keys listed below. Values in unrecognised config keys are
+// not judged. Egress control for the Keycloak pod itself belongs to a NetworkPolicy.
 package destination
 
 import (
@@ -14,6 +21,8 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -21,48 +30,73 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-// ErrNotAllowed wraps every denial so callers can distinguish policy from transport failure.
+// ErrNotAllowed wraps every denial, so callers can tell policy from transport failure.
 var ErrNotAllowed = errors.New("destination not allowed")
 
-// maxHostLen is the DNS name limit. Values are truncated to it before they reach a log line or
-// a status field.
+// ErrInvalidConfig wraps startup configuration faults, which are not denials.
+var ErrInvalidConfig = errors.New("invalid destination allowlist configuration")
+
+// ErrGuardRequired reports an omitted destination guard. Callers must pass AllowAll explicitly
+// when policy enforcement is intentionally disabled.
+var ErrGuardRequired = errors.New("destination guard is required")
+
+// RefPrefix marks a value the resolver substitutes: "$name:key" for a Kubernetes Secret,
+// "${vault.x}" for Keycloak's vault. A reference is legitimate only in a credential key.
+// pkg/secretref derives its secret-reference prefix from this constant.
+const RefPrefix = "$"
+
+// maxHostLen is the DNS name limit. Values are truncated to it before reaching a log or a status.
 const maxHostLen = 253
 
-// hostPattern is the character set permitted in a host token. It excludes whitespace and
-// control characters, so a rejected value cannot forge a log line.
+// hostPattern is the character set permitted in a host token. Excludes whitespace and control
+// characters.
 var hostPattern = regexp.MustCompile(`^[a-z0-9.\-_:%\[\]]+$`)
 
-// credentialKeys hold a secret value, so a secret reference is legitimate there. Every other key
-// carrying a reference is a violation: the resolver substitutes references in place regardless of
-// key, so a reference in a destination key would supply a destination that was never checked.
+// credentialKeys are the config keys in which a secret or vault reference is permitted.
+// Entries are lowercase; lookup lowercases the config key.
+// Mirrors Keycloak provider configs; verified against a running Keycloak by
+// TestLists_MatchKeycloakModel. Re-check on KEYCLOAK_VERSION bumps (Makefile).
 var credentialKeys = map[string]struct{}{
-	"clientsecret":   {},
-	"bindcredential": {},
+	"clientsecret":     {},
+	"bindcredential":   {},
+	"privatekey":       {},
+	"certificate":      {},
+	"keystorepassword": {},
+	"keypassword":      {},
+	"secret.key":       {},
+	"api.key":          {},
 }
 
-// destinationKeys are Keycloak configuration keys whose value is an address. A value here that
-// does not reduce to a host is rejected rather than skipped.
+// destinationKeys are Keycloak configuration keys whose value is an address. A bare hostname is
+// accepted here, an empty value is skipped, a non-empty value that does not reduce to a host is
+// rejected, and space-separated addresses are checked individually (LDAP connectionUrl failover).
+// Mirrors Keycloak provider configs; verified against a running Keycloak by
+// TestLists_MatchKeycloakModel. Re-check on KEYCLOAK_VERSION bumps (Makefile).
 var destinationKeys = map[string]struct{}{
-	"tokenurl":                     {},
-	"tokenintrospectionurl":        {},
-	"userinfourl":                  {},
-	"jwksurl":                      {},
-	"logouturl":                    {},
-	"authorizationurl":             {},
-	"metadatadescriptorurl":        {},
-	"baseurl":                      {},
-	"apiurl":                       {},
-	"singlesignonserviceurl":       {},
-	"singlelogoutserviceurl":       {},
-	"artifactresolutionserviceurl": {},
-	"connectionurl":                {},
+	"tokenurl":                          {},
+	"tokenintrospectionurl":             {},
+	"userinfourl":                       {},
+	"jwksurl":                           {},
+	"logouturl":                         {},
+	"authorizationurl":                  {},
+	"metadatadescriptorurl":             {},
+	"baseurl":                           {},
+	"apiurl":                            {},
+	"singlesignonserviceurl":            {},
+	"singlelogoutserviceurl":            {},
+	"artifactresolutionserviceurl":      {},
+	"connectionurl":                     {},
+	"x509-cert-auth.ocsp-responder-uri": {},
+	"sectoridentifieruri":               {},
+	"intent-client-bind-check-endpoint": {},
 }
 
+// Labels are static: field is a spec path, enforced a boolean. Config keys and hosts are
+// author-controlled and unbounded, so they appear in the log line, never in a label.
 var violations = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "keycloak_operator_destination_violations_total",
-		Help: "Destinations named in a custom resource that are absent from allowedDestinationHosts. " +
-			"The host is deliberately not a label: it is author-controlled and would be unbounded cardinality.",
+		Help: "Destinations named in a custom resource that are absent from allowedDestinationHosts.",
 	},
 	[]string{"field", "enforced"},
 )
@@ -79,9 +113,8 @@ type Guard struct {
 
 // New normalises and validates the configured hosts.
 //
-// Entries are bare hostnames: no scheme, no port, no path. An entry that is not is a startup
-// error rather than a silent mismatch, because a list that looks correct but never matches
-// would deny every destination once enforcement is on.
+// Entries are bare hostnames or IP literals (IPv6 optionally bracketed): no scheme, no port,
+// no path. A malformed entry is a startup error, not a skipped entry.
 func New(hosts []string, enforce bool) (*Guard, error) {
 	set := make(map[string]struct{}, len(hosts))
 
@@ -96,7 +129,7 @@ func New(hosts []string, enforce bool) (*Guard, error) {
 			return nil, fmt.Errorf(
 				"%w: allowedDestinationHosts entry %q is not a bare hostname;"+
 					" write the hostname only, without scheme, port or path",
-				ErrNotAllowed, truncate(entry),
+				ErrInvalidConfig, truncate(entry),
 			)
 		}
 
@@ -105,119 +138,164 @@ func New(hosts []string, enforce bool) (*Guard, error) {
 
 	if enforce && len(set) == 0 {
 		return nil, fmt.Errorf(
-			"%w: enforceDestinationAllowlist is true but allowedDestinationHosts is empty, which would deny every destination",
-			ErrNotAllowed,
+			"%w: enforceDestinationAllowlist is true but allowedDestinationHosts is empty,"+
+				" which would deny every destination",
+			ErrInvalidConfig,
 		)
 	}
 
 	return &Guard{hosts: set, enforce: enforce}, nil
 }
 
-// AllowAll returns a guard that permits every destination and records nothing. It is the
-// zero-configuration default, matching operator behaviour before the allowlist existed.
+// AllowAll returns an inactive guard: RequireHost and ScanConfig permit every destination and
+// record nothing.
 func AllowAll() *Guard {
 	return &Guard{hosts: map[string]struct{}{}, enforce: false}
 }
 
-// Hosts returns the normalised register, for logging it once at startup.
+// Hosts returns the normalised register, sorted, for logging it once at startup.
 func (g *Guard) Hosts() []string {
+	if g == nil {
+		return nil
+	}
+
 	out := make([]string, 0, len(g.hosts))
 	for h := range g.hosts {
 		out = append(out, h)
 	}
 
+	slices.Sort(out)
+
 	return out
 }
 
-// RequireHost checks a field whose only legitimate content is an address. A value that does not
-// reduce to a host is a violation, not a skip.
-func (g *Guard) RequireHost(ctx context.Context, field, value string) error {
-	host, ok := hostFromValue(value)
-	if !ok {
-		return g.deny(ctx, field, value, "is not a usable destination host")
-	}
-
-	return g.check(ctx, field, host)
+// Enforcing reports whether a denial fails the reconcile.
+func (g *Guard) Enforcing() bool {
+	return g != nil && g.enforce
 }
 
-// ScanConfig checks a free-form Keycloak configuration map. Values are classified rather than
-// filtered by key, because the map is open and Keycloak adds keys across versions.
+// inactive reports that no policy is configured. With an empty register the guard neither
+// checks nor reports. Populating the list turns reporting on; enforce turns denial on.
+func (g *Guard) inactive() bool {
+	return len(g.hosts) == 0
+}
+
+// RequireHost checks a field whose only legitimate content is one address. Unlike ScanConfig it
+// does not split on whitespace: a space-separated value is rejected whole.
+func (g *Guard) RequireHost(ctx context.Context, field, value string) error {
+	// Nil is a wiring fault, not policy-off; policy-off is AllowAll.
+	if g == nil {
+		return ErrGuardRequired
+	}
+
+	if g.inactive() {
+		return nil
+	}
+
+	return g.checkAddress(ctx, field, field, value)
+}
+
+// ScanConfig checks a free-form Keycloak configuration map. Every address in a destination key
+// is checked; a secret or vault reference is permitted only in a credential key; values in any
+// other key are not judged.
 //
-// It must run before secret references are resolved. Afterwards a resolved secret would be
-// indistinguishable from an author-supplied address.
+// It must run before references are resolved. Afterwards a resolved secret is indistinguishable
+// from an author-supplied address.
 func (g *Guard) ScanConfig(ctx context.Context, field string, config map[string][]string) error {
+	// Nil is a wiring fault, not policy-off; policy-off is AllowAll.
+	if g == nil {
+		return ErrGuardRequired
+	}
+
+	if g.inactive() {
+		return nil
+	}
+
+	// Every violation is reported; report returns nil in warn mode and errors.Join drops nils.
+	errs := make([]error, 0, len(config))
+
 	for key, values := range config {
 		lower := strings.ToLower(key)
 		_, isCredential := credentialKeys[lower]
 		_, isDestination := destinationKeys[lower]
+		path := field + "." + key
 
 		for _, value := range values {
-			if isVaultRef(value) {
-				continue
-			}
-
-			if isSecretRef(value) {
+			if strings.HasPrefix(value, RefPrefix) {
 				if isCredential {
 					continue
 				}
 
-				return g.deny(ctx, field+"."+key, value,
-					"is a secret reference in a key that is not a credential, so it would supply an unchecked destination")
-			}
+				errs = append(errs, g.report(ctx, field, path, value,
+					"is a reference in a key that is not a credential, so it would supply an unchecked destination"))
 
-			if !isDestination && !strings.Contains(value, "://") {
 				continue
 			}
 
-			host, ok := hostFromURL(value)
-			if !ok {
-				return g.deny(ctx, field+"."+key, value, "is not a usable destination host")
-			}
-
-			if err := g.check(ctx, field+"."+key, host); err != nil {
-				return err
+			if isDestination {
+				errs = append(errs, g.scanValue(ctx, field, path, value))
 			}
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
-func (g *Guard) check(ctx context.Context, field, host string) error {
+// scanValue checks one destination-key value. Every whitespace-separated address is checked
+// (LDAP connectionUrl failover). An empty value names no destination and is skipped.
+func (g *Guard) scanValue(ctx context.Context, field, path, value string) error {
+	addresses := strings.Fields(value)
+	errs := make([]error, 0, len(addresses))
+
+	for _, address := range addresses {
+		errs = append(errs, g.checkAddress(ctx, field, path, address))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (g *Guard) checkAddress(ctx context.Context, field, path, address string) error {
+	host, ok := hostFromValue(address)
+	if !ok {
+		return g.report(ctx, field, path, address, "is not a usable destination host")
+	}
+
 	if _, ok := g.hosts[host]; ok {
 		return nil
 	}
 
-	return g.deny(ctx, field, host, "is not in allowedDestinationHosts")
+	return g.report(ctx, field, path, host, "is not in allowedDestinationHosts")
 }
 
-// deny records the violation and, when enforcing, returns it. In warn mode the reconcile
-// continues so an existing installation keeps working while its administrator builds the list.
-func (g *Guard) deny(ctx context.Context, field, value, reason string) error {
-	safe := truncate(value)
+// report records the violation and, when enforcing, returns it as an error; in warn mode it
+// returns nil.
+//
+// field is the static metric label; path carries the author-controlled config key, for humans.
+// path and value are author-controlled: both are sanitized and truncated before any log or error.
+func (g *Guard) report(ctx context.Context, field, path, value, reason string) error {
+	value = sanitizeForLog(truncate(value))
+	path = sanitizeForLog(truncate(path))
 
-	violations.WithLabelValues(field, fmt.Sprintf("%t", g.enforce)).Inc()
-
-	err := fmt.Errorf(
-		"%w: %q (%s) %s; add the host to allowedDestinationHosts in the operator Helm values,"+
-			" or set enforceDestinationAllowlist to false",
-		ErrNotAllowed, safe, field, reason,
-	)
+	violations.WithLabelValues(field, strconv.FormatBool(g.enforce)).Inc()
 
 	if !g.enforce {
 		ctrl.LoggerFrom(ctx).Info(
 			"Destination is not in allowedDestinationHosts. It will be denied once enforceDestinationAllowlist is enabled",
-			"field", field, "destination", safe, "reason", reason,
+			"field", path, "destination", value, "reason", reason,
 		)
 
 		return nil
 	}
 
-	return err
+	return fmt.Errorf(
+		"%w: %q (%s) %s; add the host to allowedDestinationHosts in the operator Helm values,"+
+			" or set enforceDestinationAllowlist to false",
+		ErrNotAllowed, value, path, reason,
+	)
 }
 
-// normalizeEntry accepts only a bare hostname, with an optional trailing dot and optional IPv6
-// brackets. Anything carrying a scheme, port or path is rejected.
+// normalizeEntry accepts only a bare hostname with an optional trailing dot, or an IP literal
+// (IPv6 optionally bracketed). Anything carrying a scheme, port or path is rejected.
 func normalizeEntry(entry string) (string, bool) {
 	if strings.ContainsAny(entry, "/@ ") || strings.Contains(entry, "://") {
 		return "", false
@@ -225,30 +303,30 @@ func normalizeEntry(entry string) (string, bool) {
 
 	host := entry
 
-	// A bracketed literal may carry a port; an unbracketed one is an IPv6 address whose colons
-	// are part of the address.
 	if strings.HasPrefix(host, "[") {
-		h, _, err := net.SplitHostPort(host)
-		if err != nil {
-			h = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+		// SplitHostPort succeeding means a port follows the brackets.
+		if _, _, err := net.SplitHostPort(host); err == nil {
+			return "", false
 		}
 
-		host = h
-	} else if strings.Count(host, ":") == 1 {
-		return "", false // host:port
+		host = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+	}
+
+	// A colon is legitimate only inside an IPv6 literal; host:port and typos are rejected.
+	if strings.Contains(host, ":") && net.ParseIP(host) == nil {
+		return "", false
 	}
 
 	return canonicalHost(host)
 }
 
-// hostFromValue accepts either an absolute URL or a bare host. Used for fields that hold nothing
-// else.
+// hostFromValue accepts either an absolute URL or a bare host.
 func hostFromValue(value string) (string, bool) {
 	if strings.Contains(value, "://") {
 		return hostFromURL(value)
 	}
 
-	if isSecretRef(value) || isVaultRef(value) {
+	if strings.HasPrefix(value, RefPrefix) {
 		return "", false
 	}
 
@@ -284,14 +362,16 @@ func canonicalHost(host string) (string, bool) {
 	return host, true
 }
 
-func isSecretRef(value string) bool {
-	return strings.HasPrefix(value, "$") && !isVaultRef(value)
-}
+// sanitizeForLog keeps printable ASCII only. The console log encoder does not escape control
+// characters; an unescaped author-controlled value could forge log lines.
+func sanitizeForLog(value string) string {
+	return strings.Map(func(r rune) rune {
+		if r > 0x20 && r < 0x7f {
+			return r
+		}
 
-// isVaultRef matches Keycloak's own "${vault.x}" indirection, which the operator forwards
-// untouched and never resolves.
-func isVaultRef(value string) bool {
-	return strings.HasPrefix(value, "${")
+		return '?'
+	}, value)
 }
 
 func truncate(value string) string {

--- a/pkg/destination/guard_test.go
+++ b/pkg/destination/guard_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -68,6 +69,31 @@ func TestNew(t *testing.T) {
 		{
 			name:    "entry with a port is fatal",
 			hosts:   []string{"smtp.example.com:587"},
+			enforce: true,
+			wantErr: require.Error,
+		},
+		{
+			name:    "entry with a double colon typo is fatal",
+			hosts:   []string{"smtp.example.com::587"},
+			enforce: true,
+			wantErr: require.Error,
+		},
+		{
+			name:    "bracketed ipv6 entry with a port is fatal",
+			hosts:   []string{"[2001:db8::1]:636"},
+			enforce: true,
+			wantErr: require.Error,
+		},
+		{
+			name:      "accepts a bracketed IPv6 literal",
+			hosts:     []string{"[2001:db8::1]"},
+			enforce:   true,
+			wantHosts: []string{"2001:db8::1"},
+			wantErr:   require.NoError,
+		},
+		{
+			name:    "colon-separated non-address is fatal",
+			hosts:   []string{"a:b:c"},
 			enforce: true,
 			wantErr: require.Error,
 		},
@@ -233,6 +259,22 @@ func TestGuard_ScanConfig(t *testing.T) {
 			wantErr: require.NoError,
 		},
 		{
+			name: "secret ref in a key provider privateKey is a credential",
+			config: map[string][]string{
+				"privateKey":  {"$realm-key:private"},
+				"certificate": {"$realm-key:cert"},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "empty value in a destination key is skipped",
+			config: map[string][]string{
+				"baseUrl":   {""},
+				"logoutUrl": {"   "},
+			},
+			wantErr: require.NoError,
+		},
+		{
 			name: "known destination key holding a non-host is a violation",
 			config: map[string][]string{
 				"tokenUrl": {"not a url"},
@@ -247,11 +289,11 @@ func TestGuard_ScanConfig(t *testing.T) {
 			wantErr: require.Error,
 		},
 		{
-			name: "any value carrying a scheme is checked",
+			name: "url in an unknown key is not judged",
 			config: map[string][]string{
 				"undocumentedKey": {"https://evil.example.com/collect"},
 			},
-			wantErr: require.Error,
+			wantErr: require.NoError,
 		},
 		{
 			name: "every value in a multivalued key is checked",
@@ -324,4 +366,177 @@ func TestGuard_ErrorMessageIsLengthCapped(t *testing.T) {
 	require.Error(t, err)
 
 	assert.Less(t, len(err.Error()), 512, "a rejected value must not blow up the message")
+}
+
+// Warn mode exists so an administrator can read every host that will later be denied.
+func TestGuard_ScanConfig_WarnModeReportsEveryViolation(t *testing.T) {
+	t.Parallel()
+
+	g, err := New([]string{"keycloak.example.com"}, false)
+	require.NoError(t, err)
+
+	const field = "test.reportsEveryViolation"
+
+	before := warnViolations(field)
+
+	require.NoError(t, g.ScanConfig(context.Background(), field, map[string][]string{
+		"tokenUrl":    {"$victim:url"},
+		"userInfoUrl": {"https://evil.example.com/"},
+	}))
+
+	assert.Equal(t, float64(2), warnViolations(field)-before, "both violations must be recorded")
+}
+
+func TestGuard_ScanConfig_AcceptsBareHostInADestinationKey(t *testing.T) {
+	t.Parallel()
+
+	g, err := New([]string{"keycloak.example.com"}, true)
+	require.NoError(t, err)
+
+	assert.NoError(t, g.ScanConfig(context.Background(), "spec.config", map[string][]string{
+		"baseUrl": {"keycloak.example.com"},
+	}))
+}
+
+func TestGuard_ScanConfig_MultiAddressFailover(t *testing.T) {
+	t.Parallel()
+
+	g, err := New([]string{"ldap1.example.com", "ldap2.example.com"}, true)
+	require.NoError(t, err)
+
+	assert.NoError(t, g.ScanConfig(context.Background(), "spec.config", map[string][]string{
+		"connectionUrl": {"ldap://ldap1.example.com:389 ldap://ldap2.example.com:389"},
+	}))
+
+	assert.Error(t, g.ScanConfig(context.Background(), "spec.config", map[string][]string{
+		"connectionUrl": {"ldap://ldap1.example.com:389 ldap://evil.example.com:389"},
+	}), "one unlisted address in the list must still be denied")
+}
+
+func TestGuard_ScanConfig_VaultRefOutsideACredentialKeyIsDenied(t *testing.T) {
+	t.Parallel()
+
+	g, err := New([]string{"keycloak.example.com"}, true)
+	require.NoError(t, err)
+
+	assert.Error(t, g.ScanConfig(context.Background(), "spec.config", map[string][]string{
+		"tokenUrl": {"${anything"},
+	}))
+}
+
+// Policy-off is AllowAll; nil fails closed.
+func TestGuard_NilReceiverFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	var g *Guard
+
+	assert.ErrorIs(t, g.RequireHost(context.Background(), "spec.url", "https://keycloak.example.com/"), ErrGuardRequired)
+	assert.ErrorIs(t, g.ScanConfig(context.Background(), "spec.config", map[string][]string{
+		"tokenUrl": {"https://keycloak.example.com/"},
+	}), ErrGuardRequired)
+}
+
+func TestSanitizeForLog(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "evil.example.com?forged", sanitizeForLog("evil.example.com\nforged"))
+	assert.Equal(t, "keycloak.example.com", sanitizeForLog("keycloak.example.com"))
+}
+
+// warnViolations reads the counter for a field in warn mode.
+func warnViolations(field string) float64 {
+	return testutil.ToFloat64(violations.WithLabelValues(field, "false"))
+}
+
+// An empty allowlist leaves the guard inactive (see Guard.inactive).
+func TestGuard_EmptyAllowlistIsSilent(t *testing.T) {
+	t.Parallel()
+
+	g, err := New(nil, false)
+	require.NoError(t, err)
+
+	const field = "test.emptyAllowlistIsSilent"
+
+	before := warnViolations(field)
+
+	require.NoError(t, g.RequireHost(context.Background(), field, "https://anything.example.com"))
+	require.NoError(t, g.ScanConfig(context.Background(), field, map[string][]string{
+		"tokenUrl": {"https://anything.example.com"},
+	}))
+
+	assert.Equal(t, float64(0), warnViolations(field)-before, "an unconfigured guard must record nothing")
+}
+
+// A value in an unrecognised key is never judged or reported (see ScanConfig): key semantics
+// are unknown at runtime, and a guess must not deny or flood the warn log.
+func TestGuard_ScanConfig_UnknownKeysAreNotJudged(t *testing.T) {
+	t.Parallel()
+
+	g, err := New([]string{"keycloak.example.com"}, false)
+	require.NoError(t, err)
+
+	const field = "test.unknownKeysNotJudged"
+
+	before := warnViolations(field)
+
+	require.NoError(t, g.ScanConfig(context.Background(), field, map[string][]string{
+		"helpText":        {"see https://evil.example.com for details"},
+		"undocumentedKey": {"evil.example.com:8443"},
+	}))
+
+	assert.Equal(t, float64(0), warnViolations(field)-before,
+		"a value in an unknown key must not be reported")
+}
+
+// Enforce mode reports every violation in one error, so one reconcile surfaces the whole list.
+func TestGuard_ScanConfig_EnforceModeReportsEveryViolation(t *testing.T) {
+	t.Parallel()
+
+	g, err := New([]string{"keycloak.example.com"}, true)
+	require.NoError(t, err)
+
+	err = g.ScanConfig(context.Background(), "spec.config", map[string][]string{
+		"tokenUrl":    {"https://evil-one.example.com/"},
+		"userInfoUrl": {"https://evil-two.example.com/"},
+	})
+	require.Error(t, err)
+
+	assert.ErrorIs(t, err, ErrNotAllowed)
+	assert.Contains(t, err.Error(), "evil-one.example.com")
+	assert.Contains(t, err.Error(), "evil-two.example.com")
+}
+
+// The config key is author-controlled and must not forge lines in the error (see report).
+func TestGuard_ScanConfig_ConfigKeyCannotForgeError(t *testing.T) {
+	t.Parallel()
+
+	g, err := New([]string{"keycloak.example.com"}, true)
+	require.NoError(t, err)
+
+	err = g.ScanConfig(context.Background(), "spec.config", map[string][]string{
+		"evil\nlevel=info msg=forged": {"$attacker-secret:url"},
+	})
+	require.Error(t, err)
+
+	assert.NotContains(t, err.Error(), "\n", "a config key must not inject a newline")
+}
+
+// The config key must never become a metric label (see the violations counter).
+func TestGuard_ScanConfig_MetricLabelIsTheStaticField(t *testing.T) {
+	t.Parallel()
+
+	g, err := New([]string{"keycloak.example.com"}, false)
+	require.NoError(t, err)
+
+	const field = "test.metricLabelIsStatic"
+
+	before := warnViolations(field)
+
+	require.NoError(t, g.ScanConfig(context.Background(), field, map[string][]string{
+		"attackerChosenKeyOne": {"$attacker-secret:url"},
+		"attackerChosenKeyTwo": {"$attacker-secret:url"},
+	}))
+
+	assert.Equal(t, float64(2), warnViolations(field)-before, "both must land on the one static label")
+	assert.Zero(t, warnViolations(field+".attackerChosenKeyOne"), "the key must not create a series")
 }

--- a/pkg/destination/keycloak_model_test.go
+++ b/pkg/destination/keycloak_model_test.go
@@ -1,0 +1,176 @@
+package destination
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// configProperty is the slice of ConfigPropertyRepresentation this test reads. secret is
+// Keycloak's own declaration that the property holds a secret value.
+type configProperty struct {
+	Name   string `json:"name"`
+	Secret bool   `json:"secret"`
+}
+
+type componentType struct {
+	ID         string           `json:"id"`
+	Properties []configProperty `json:"properties"`
+}
+
+type serverInfoRepresentation struct {
+	ComponentTypes map[string][]componentType `json:"componentTypes"`
+}
+
+// TestLists_MatchKeycloakModel verifies the hand-pinned key lists against the provider
+// metadata of a running Keycloak (GET /admin/serverinfo, componentTypes):
+//
+//   - a property Keycloak marks secret:true must be in credentialKeys, or a legitimate
+//     secret reference in it is denied;
+//   - a property with a destination-shaped name must be in destinationKeys, or an address
+//     in it is never checked.
+//
+// The destination-shape suffix match is a heuristic; it informs this test only and never
+// runs at reconcile time. Identity provider config keys (tokenUrl, ...) are exposed by no
+// admin endpoint and stay human-curated.
+//
+// Runs only against the pinned Keycloak (TEST_KEYCLOAK_URL, make start-keycloak). A
+// KEYCLOAK_TEST_VERSION bump that introduces new keys fails here until they are classified.
+func TestLists_MatchKeycloakModel(t *testing.T) {
+	baseURL := os.Getenv("TEST_KEYCLOAK_URL")
+	if baseURL == "" {
+		t.Skip("TEST_KEYCLOAK_URL is not set")
+	}
+
+	info := fetchServerInfo(t, baseURL, adminToken(t, baseURL))
+
+	require.NotEmpty(t, info.ComponentTypes, "serverinfo returned no component types")
+
+	var missingCredentials, missingDestinations []string
+
+	for spi, types := range info.ComponentTypes {
+		for _, ct := range types {
+			for _, prop := range ct.Properties {
+				key := strings.ToLower(prop.Name)
+				id := spi + "/" + ct.ID + "." + prop.Name
+
+				if prop.Secret {
+					if _, ok := credentialKeys[key]; !ok {
+						missingCredentials = append(missingCredentials, id)
+					}
+
+					continue
+				}
+
+				if _, exempt := nonDestinationExceptions[key]; exempt {
+					continue
+				}
+
+				if isDestinationShaped(key) {
+					if _, ok := destinationKeys[key]; !ok {
+						missingDestinations = append(missingDestinations, id)
+					}
+				}
+			}
+		}
+	}
+
+	assert.Empty(t, missingCredentials,
+		"Keycloak marks these properties secret: true; add them to credentialKeys or a valid secret ref in them is denied")
+	assert.Empty(t, missingDestinations,
+		"these properties carry destination-shaped names; classify them in destinationKeys")
+}
+
+// nonDestinationExceptions are destination-shaped property names reviewed to hold no
+// dial-out address. Each entry records why it is exempt.
+var nonDestinationExceptions = map[string]string{
+	"requirevalidurl":             "boolean flag of the uri validator",
+	"allow-ipv4-loopback-address": "boolean flag of secure-redirect-uris-enforcer",
+	"allow-ipv6-loopback-address": "boolean flag of secure-redirect-uris-enforcer",
+	"trusted-hosts":               "inbound ACL for client registration; nothing is dialed",
+}
+
+// isDestinationShaped reports whether a lowercased property name looks like it holds an
+// address. Test-time heuristic only.
+func isDestinationShaped(key string) bool {
+	for _, suffix := range []string{"url", "uri", "host", "hosts", "address", "endpoint"} {
+		if strings.HasSuffix(key, suffix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func httpClient() *http.Client {
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+// adminToken logs in with the credentials of make start-keycloak.
+func adminToken(t *testing.T, baseURL string) string {
+	t.Helper()
+
+	form := url.Values{
+		"grant_type": {"password"},
+		"client_id":  {"admin-cli"},
+		"username":   {"admin"},
+		"password":   {"admin"},
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		baseURL+"/realms/master/protocol/openid-connect/token", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := httpClient().Do(req)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, resp.Body.Close())
+	}()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body struct {
+		AccessToken string `json:"access_token"`
+	}
+
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	require.NotEmpty(t, body.AccessToken)
+
+	return body.AccessToken
+}
+
+// fetchServerInfo reads /admin/serverinfo, which is absent from the published OpenAPI spec
+// and therefore from the generated client.
+func fetchServerInfo(t *testing.T, baseURL, token string) serverInfoRepresentation {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		baseURL+"/admin/serverinfo", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := httpClient().Do(req)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, resp.Body.Close())
+	}()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var info serverInfoRepresentation
+
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&info))
+
+	return info
+}

--- a/pkg/secretref/guard_enforcement_test.go
+++ b/pkg/secretref/guard_enforcement_test.go
@@ -34,7 +34,10 @@ func guardedSecretRef(t *testing.T) *SecretRef {
 	guard, err := destination.New([]string{"keycloak.example.com"}, true)
 	require.NoError(t, err)
 
-	return NewSecretRef(cl, guard)
+	ref, err := NewSecretRef(cl, guard)
+	require.NoError(t, err)
+
+	return ref
 }
 
 // A destination supplied through a secret reference is never checked against the allowlist, so
@@ -49,7 +52,7 @@ func TestMapConfigSecretsRefs_RejectsSecretRefAsDestination(t *testing.T) {
 		"clientSecret": "$victim:key",
 	}
 
-	_, err := s.MapConfigSecretsRefs(context.Background(), config, "default")
+	_, err := s.MapConfigSecretsRefs(context.Background(), "spec.config", config, "default")
 
 	require.ErrorIs(t, err, destination.ErrNotAllowed)
 	assert.Equal(t, "$victim:key", config["clientSecret"], "no secret may be resolved once a destination is rejected")
@@ -65,7 +68,7 @@ func TestMapConfigSecretsRefs_RejectsUnlistedDestination(t *testing.T) {
 		"clientSecret": "$victim:key",
 	}
 
-	_, err := s.MapConfigSecretsRefs(context.Background(), config, "default")
+	_, err := s.MapConfigSecretsRefs(context.Background(), "spec.config", config, "default")
 
 	require.ErrorIs(t, err, destination.ErrNotAllowed)
 	assert.Equal(t, "$victim:key", config["clientSecret"], "no secret may be resolved once a destination is rejected")
@@ -81,7 +84,7 @@ func TestMapConfigSecretsRefs_ResolvesForListedDestination(t *testing.T) {
 		"clientSecret": "$victim:key",
 	}
 
-	_, err := s.MapConfigSecretsRefs(context.Background(), config, "default")
+	_, err := s.MapConfigSecretsRefs(context.Background(), "spec.config", config, "default")
 
 	require.NoError(t, err)
 	assert.Equal(t, "LeakedSecret123!", config["clientSecret"])
@@ -97,7 +100,7 @@ func TestMapComponentConfigSecretsRefs_RejectsUnlistedDestination(t *testing.T) 
 		"bindCredential": {"$victim:key"},
 	}
 
-	_, err := s.MapComponentConfigSecretsRefs(context.Background(), config, "default")
+	_, err := s.MapComponentConfigSecretsRefs(context.Background(), "spec.config", config, "default")
 
 	require.ErrorIs(t, err, destination.ErrNotAllowed)
 	assert.Equal(t, "$victim:key", config["bindCredential"][0], "no secret may be resolved once a destination is rejected")
@@ -113,7 +116,7 @@ func TestMapComponentConfigSecretsRefs_ResolvesForListedDestination(t *testing.T
 		"bindCredential": {"$victim:key"},
 	}
 
-	_, err := s.MapComponentConfigSecretsRefs(context.Background(), config, "default")
+	_, err := s.MapComponentConfigSecretsRefs(context.Background(), "spec.config", config, "default")
 
 	require.NoError(t, err)
 	assert.Equal(t, "LeakedSecret123!", config["bindCredential"][0])

--- a/pkg/secretref/mocks/ref_client_generated.mock.go
+++ b/pkg/secretref/mocks/ref_client_generated.mock.go
@@ -116,8 +116,8 @@ func (_c *MockRefClient_GetSecretFromRef_Call) RunAndReturn(run func(ctx context
 }
 
 // MapComponentConfigSecretsRefs provides a mock function for the type MockRefClient
-func (_mock *MockRefClient) MapComponentConfigSecretsRefs(ctx context.Context, config map[string][]string, namespace string) (map[string][]string, error) {
-	ret := _mock.Called(ctx, config, namespace)
+func (_mock *MockRefClient) MapComponentConfigSecretsRefs(ctx context.Context, field string, config map[string][]string, namespace string) (map[string][]string, error) {
+	ret := _mock.Called(ctx, field, config, namespace)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MapComponentConfigSecretsRefs")
@@ -125,18 +125,18 @@ func (_mock *MockRefClient) MapComponentConfigSecretsRefs(ctx context.Context, c
 
 	var r0 map[string][]string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string][]string, string) (map[string][]string, error)); ok {
-		return returnFunc(ctx, config, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, map[string][]string, string) (map[string][]string, error)); ok {
+		return returnFunc(ctx, field, config, namespace)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string][]string, string) map[string][]string); ok {
-		r0 = returnFunc(ctx, config, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, map[string][]string, string) map[string][]string); ok {
+		r0 = returnFunc(ctx, field, config, namespace)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string][]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, map[string][]string, string) error); ok {
-		r1 = returnFunc(ctx, config, namespace)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, map[string][]string, string) error); ok {
+		r1 = returnFunc(ctx, field, config, namespace)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -150,30 +150,36 @@ type MockRefClient_MapComponentConfigSecretsRefs_Call struct {
 
 // MapComponentConfigSecretsRefs is a helper method to define mock.On call
 //   - ctx context.Context
+//   - field string
 //   - config map[string][]string
 //   - namespace string
-func (_e *MockRefClient_Expecter) MapComponentConfigSecretsRefs(ctx interface{}, config interface{}, namespace interface{}) *MockRefClient_MapComponentConfigSecretsRefs_Call {
-	return &MockRefClient_MapComponentConfigSecretsRefs_Call{Call: _e.mock.On("MapComponentConfigSecretsRefs", ctx, config, namespace)}
+func (_e *MockRefClient_Expecter) MapComponentConfigSecretsRefs(ctx interface{}, field interface{}, config interface{}, namespace interface{}) *MockRefClient_MapComponentConfigSecretsRefs_Call {
+	return &MockRefClient_MapComponentConfigSecretsRefs_Call{Call: _e.mock.On("MapComponentConfigSecretsRefs", ctx, field, config, namespace)}
 }
 
-func (_c *MockRefClient_MapComponentConfigSecretsRefs_Call) Run(run func(ctx context.Context, config map[string][]string, namespace string)) *MockRefClient_MapComponentConfigSecretsRefs_Call {
+func (_c *MockRefClient_MapComponentConfigSecretsRefs_Call) Run(run func(ctx context.Context, field string, config map[string][]string, namespace string)) *MockRefClient_MapComponentConfigSecretsRefs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 map[string][]string
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(map[string][]string)
+			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 map[string][]string
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(map[string][]string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -184,14 +190,14 @@ func (_c *MockRefClient_MapComponentConfigSecretsRefs_Call) Return(stringToStrin
 	return _c
 }
 
-func (_c *MockRefClient_MapComponentConfigSecretsRefs_Call) RunAndReturn(run func(ctx context.Context, config map[string][]string, namespace string) (map[string][]string, error)) *MockRefClient_MapComponentConfigSecretsRefs_Call {
+func (_c *MockRefClient_MapComponentConfigSecretsRefs_Call) RunAndReturn(run func(ctx context.Context, field string, config map[string][]string, namespace string) (map[string][]string, error)) *MockRefClient_MapComponentConfigSecretsRefs_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // MapConfigSecretsRefs provides a mock function for the type MockRefClient
-func (_mock *MockRefClient) MapConfigSecretsRefs(ctx context.Context, config map[string]string, namespace string) (map[string]string, error) {
-	ret := _mock.Called(ctx, config, namespace)
+func (_mock *MockRefClient) MapConfigSecretsRefs(ctx context.Context, field string, config map[string]string, namespace string) (map[string]string, error) {
+	ret := _mock.Called(ctx, field, config, namespace)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MapConfigSecretsRefs")
@@ -199,18 +205,18 @@ func (_mock *MockRefClient) MapConfigSecretsRefs(ctx context.Context, config map
 
 	var r0 map[string]string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]string, string) (map[string]string, error)); ok {
-		return returnFunc(ctx, config, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, map[string]string, string) (map[string]string, error)); ok {
+		return returnFunc(ctx, field, config, namespace)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, map[string]string, string) map[string]string); ok {
-		r0 = returnFunc(ctx, config, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, map[string]string, string) map[string]string); ok {
+		r0 = returnFunc(ctx, field, config, namespace)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, map[string]string, string) error); ok {
-		r1 = returnFunc(ctx, config, namespace)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, map[string]string, string) error); ok {
+		r1 = returnFunc(ctx, field, config, namespace)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -224,30 +230,36 @@ type MockRefClient_MapConfigSecretsRefs_Call struct {
 
 // MapConfigSecretsRefs is a helper method to define mock.On call
 //   - ctx context.Context
+//   - field string
 //   - config map[string]string
 //   - namespace string
-func (_e *MockRefClient_Expecter) MapConfigSecretsRefs(ctx interface{}, config interface{}, namespace interface{}) *MockRefClient_MapConfigSecretsRefs_Call {
-	return &MockRefClient_MapConfigSecretsRefs_Call{Call: _e.mock.On("MapConfigSecretsRefs", ctx, config, namespace)}
+func (_e *MockRefClient_Expecter) MapConfigSecretsRefs(ctx interface{}, field interface{}, config interface{}, namespace interface{}) *MockRefClient_MapConfigSecretsRefs_Call {
+	return &MockRefClient_MapConfigSecretsRefs_Call{Call: _e.mock.On("MapConfigSecretsRefs", ctx, field, config, namespace)}
 }
 
-func (_c *MockRefClient_MapConfigSecretsRefs_Call) Run(run func(ctx context.Context, config map[string]string, namespace string)) *MockRefClient_MapConfigSecretsRefs_Call {
+func (_c *MockRefClient_MapConfigSecretsRefs_Call) Run(run func(ctx context.Context, field string, config map[string]string, namespace string)) *MockRefClient_MapConfigSecretsRefs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 map[string]string
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(map[string]string)
+			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 map[string]string
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(map[string]string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -258,7 +270,7 @@ func (_c *MockRefClient_MapConfigSecretsRefs_Call) Return(stringToString map[str
 	return _c
 }
 
-func (_c *MockRefClient_MapConfigSecretsRefs_Call) RunAndReturn(run func(ctx context.Context, config map[string]string, namespace string) (map[string]string, error)) *MockRefClient_MapConfigSecretsRefs_Call {
+func (_c *MockRefClient_MapConfigSecretsRefs_Call) RunAndReturn(run func(ctx context.Context, field string, config map[string]string, namespace string) (map[string]string, error)) *MockRefClient_MapConfigSecretsRefs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/secretref/secretref.go
+++ b/pkg/secretref/secretref.go
@@ -17,14 +17,20 @@ import (
 )
 
 const (
-	secretRefPrefix         = "$"
-	keycloakSecretRefPrefix = "${"
+	secretRefPrefix         = destination.RefPrefix
+	keycloakSecretRefPrefix = secretRefPrefix + "{"
 )
 
 type RefClient interface {
-	MapConfigSecretsRefs(ctx context.Context, config map[string]string, namespace string) (map[string]string, error)
+	MapConfigSecretsRefs(
+		ctx context.Context,
+		field string,
+		config map[string]string,
+		namespace string,
+	) (map[string]string, error)
 	MapComponentConfigSecretsRefs(
 		ctx context.Context,
+		field string,
 		config map[string][]string,
 		namespace string,
 	) (map[string][]string, error)
@@ -37,21 +43,28 @@ type SecretRef struct {
 	guard  *destination.Guard
 }
 
-// NewSecretRef returns a new instance of SecretRef. The guard is required: the config-map
-// resolvers substitute secret references in place, so the destination check has to happen in the
-// same call that resolves them.
-func NewSecretRef(k8sClient client.Client, guard *destination.Guard) *SecretRef {
-	return &SecretRef{client: k8sClient, guard: guard}
+// NewSecretRef returns a new instance of SecretRef. The resolvers run guard.ScanConfig before
+// resolving any reference. Pass destination.AllowAll explicitly when policy enforcement is
+// intentionally disabled.
+func NewSecretRef(k8sClient client.Client, guard *destination.Guard) (*SecretRef, error) {
+	// Nil is a wiring fault, not policy-off; policy-off is AllowAll.
+	if guard == nil {
+		return nil, destination.ErrGuardRequired
+	}
+
+	return &SecretRef{client: k8sClient, guard: guard}, nil
 }
 
 // MapConfigSecretsRefs maps secret references in config map to actual values. It returns a
-// version token per ref-backed key for status.configSecretsHash.
+// version token per ref-backed key for status.configSecretsHash. field is the spec path of
+// config in the calling CR, used in violation reports.
 func (s *SecretRef) MapConfigSecretsRefs(
 	ctx context.Context,
+	field string,
 	config map[string]string,
 	namespace string,
 ) (map[string]string, error) {
-	if err := s.guard.ScanConfig(ctx, "spec.config", singleToMultiValued(config)); err != nil {
+	if err := s.guard.ScanConfig(ctx, field, singleToMultiValued(config)); err != nil {
 		return nil, err
 	}
 
@@ -75,13 +88,15 @@ func (s *SecretRef) MapConfigSecretsRefs(
 }
 
 // MapComponentConfigSecretsRefs maps secret references in config map to actual values. It
-// returns version tokens per ref-backed key (ref-valued entries only, in spec order).
+// returns version tokens per ref-backed key (ref-valued entries only, in spec order). field is
+// the spec path of config in the calling CR, used in violation reports.
 func (s *SecretRef) MapComponentConfigSecretsRefs(
 	ctx context.Context,
+	field string,
 	config map[string][]string,
 	namespace string,
 ) (map[string][]string, error) {
-	if err := s.guard.ScanConfig(ctx, "spec.config", config); err != nil {
+	if err := s.guard.ScanConfig(ctx, field, config); err != nil {
 		return nil, err
 	}
 
@@ -158,8 +173,6 @@ func HasSecretRef(val string) bool {
 	return strings.HasPrefix(val, secretRefPrefix)
 }
 
-// singleToMultiValued adapts a single-valued config map for the destination guard, which takes
-// the multivalued shape used by component configs.
 func singleToMultiValued(config map[string]string) map[string][]string {
 	out := make(map[string][]string, len(config))
 	for k, v := range config {
@@ -201,13 +214,7 @@ func ValuesHash(cfg map[string][]string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-// ValuesHashSingle is ValuesHash for single-value maps: each value is wrapped as a
-// one-element slice.
+// ValuesHashSingle is ValuesHash for single-value maps.
 func ValuesHashSingle(cfg map[string]string) string {
-	wrapped := make(map[string][]string, len(cfg))
-	for k, v := range cfg {
-		wrapped[k] = []string{v}
-	}
-
-	return ValuesHash(wrapped)
+	return ValuesHash(singleToMultiValued(cfg))
 }

--- a/pkg/secretref/secretref_test.go
+++ b/pkg/secretref/secretref_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/epam/edp-keycloak-operator/pkg/destination"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -12,6 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/epam/edp-keycloak-operator/pkg/destination"
 )
 
 func TestSecretRef_MapComponentConfigSecretsRefs(t *testing.T) {
@@ -145,9 +146,10 @@ func TestSecretRef_MapComponentConfigSecretsRefs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewSecretRef(tt.client(t), destination.AllowAll())
+			s, err := NewSecretRef(tt.client(t), destination.AllowAll())
+			require.NoError(t, err)
 
-			_, err := s.MapComponentConfigSecretsRefs(context.Background(), tt.config, "default")
+			_, err = s.MapComponentConfigSecretsRefs(context.Background(), "spec.config", tt.config, "default")
 			tt.wantErr(t, err)
 			require.Equal(t, tt.wantConfig, tt.config)
 		})
@@ -181,8 +183,10 @@ func TestSecretRef_MapComponentConfigSecretsRefs_ReturnsVersionTokens(t *testing
 		"vaultRef":       {"${vault.ref}"},
 	}
 
-	versions, err := NewSecretRef(cl, destination.AllowAll()).
-		MapComponentConfigSecretsRefs(context.Background(), config, "default")
+	ref, err := NewSecretRef(cl, destination.AllowAll())
+	require.NoError(t, err)
+
+	versions, err := ref.MapComponentConfigSecretsRefs(context.Background(), "spec.config", config, "default")
 	require.NoError(t, err)
 
 	// Plain values yield no version entry; keycloak vault refs pass through literally.
@@ -327,9 +331,10 @@ func TestSecretRef_MapConfigSecretsRefs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewSecretRef(tt.client(t), destination.AllowAll())
+			s, err := NewSecretRef(tt.client(t), destination.AllowAll())
+			require.NoError(t, err)
 
-			_, err := s.MapConfigSecretsRefs(context.Background(), tt.config, "default")
+			_, err = s.MapConfigSecretsRefs(context.Background(), "spec.config", tt.config, "default")
 			tt.wantErr(t, err)
 			require.Equal(t, tt.wantConfig, tt.config)
 		})
@@ -361,7 +366,10 @@ func TestSecretRef_MapConfigSecretsRefs_ReturnsVersionTokens(t *testing.T) {
 		"clientSecret": "$client-secret:data",
 	}
 
-	versions, err := NewSecretRef(cl, destination.AllowAll()).MapConfigSecretsRefs(context.Background(), config, "default")
+	ref, err := NewSecretRef(cl, destination.AllowAll())
+	require.NoError(t, err)
+
+	versions, err := ref.MapConfigSecretsRefs(context.Background(), "spec.config", config, "default")
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]string{
@@ -400,4 +408,13 @@ func TestGenerateSecretRef(t *testing.T) {
 			assert.Equal(t, tt.want, GenerateSecretRef(tt.args.secretName, tt.args.secretFiled))
 		})
 	}
+}
+
+func TestNewSecretRef_RejectsNilGuard(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSecretRef(nil, nil)
+
+	require.ErrorIs(t, err, destination.ErrGuardRequired,
+		"a nil guard must fail at wiring time, not fail open at runtime")
 }


### PR DESCRIPTION
The guard is now deterministic. It judges only the spec fields and config keys it knows; unrecognised keys are never judged, so a heuristic can never deny a resource. An empty allowlist means no policy is configured: the guard stays silent instead of reporting every destination on every reconcile.

The key lists are no longer taken on trust: an integration test verifies them against a running Keycloak's own provider metadata, so a Keycloak version bump that introduces new keys fails the build until a human classifies them. The first run extended both lists.

Hardening around the policy: malformed allowlist entries fail startup, the guard is a required dependency wired once from main and fails loudly when missing, author-controlled strings cannot forge logs or metrics, and a denial reports every violation at once.

Egress control for the Keycloak pod itself belongs to a NetworkPolicy; the allowlist covers only what the operator resolves and forwards.

