### PR TITLE
chore(keycloak): surface the connection result in Keycloak and ClusterKeycloak status

### DIFF
--- a/api/v1/keycloak_types.go
+++ b/api/v1/keycloak_types.go
@@ -55,12 +55,17 @@ func (in *Keycloak) GetAdminType() string {
 type KeycloakStatus struct {
 	// Connected shows if keycloak service is up and running.
 	Connected bool `json:"connected"`
+
+	// Value is the status message: OK, or the error of the last connection attempt.
+	// +optional
+	Value string `json:"value,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Connected",type="boolean",JSONPath=".status.connected",description="Is connected to keycloak"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.value"
 
 // Keycloak is the Schema for the keycloaks API.
 type Keycloak struct {

--- a/api/v1alpha1/clusterkeycloak_types.go
+++ b/api/v1alpha1/clusterkeycloak_types.go
@@ -55,6 +55,10 @@ func (in *ClusterKeycloak) GetAdminType() string {
 type ClusterKeycloakStatus struct {
 	// Connected shows if keycloak service is up and running.
 	Connected bool `json:"connected"`
+
+	// Value is the status message: OK, or the error of the last connection attempt.
+	// +optional
+	Value string `json:"value,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -62,6 +66,7 @@ type ClusterKeycloakStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:printcolumn:name="Connected",type="boolean",JSONPath=".status.connected",description="Is connected to keycloak"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.value"
 
 // ClusterKeycloak is the Schema for the clusterkeycloaks API.
 type ClusterKeycloak struct {

--- a/bundle/manifests/edp-keycloak-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/edp-keycloak-operator.clusterserviceversion.yaml
@@ -839,8 +839,8 @@ metadata:
       ]
     capabilities: Deep Insights
     categories: Security
-    containerImage: docker.io/epamedp/keycloak-operator:1.35.0
-    createdAt: "2026-08-31T14:27:29Z"
+    containerImage: docker.io/epamedp/keycloak-operator:1.36.0
+    createdAt: "2026-09-01T07:06:45Z"
     description: An Operator for managing Keycloak
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -857,7 +857,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/epam/edp-keycloak-operator
     support: KubeRocketCI
-  name: edp-keycloak-operator.v1.35.0
+  name: edp-keycloak-operator.v1.36.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1099,7 +1099,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: docker.io/epamedp/keycloak-operator:1.35.0
+                image: docker.io/epamedp/keycloak-operator:1.36.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -1281,7 +1281,7 @@ spec:
   provider:
     name: KubeRocketCI
     url: https://docs.kuberocketci.io/
-  version: 1.35.0
+  version: 1.36.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/v1.edp.epam.com_clusterkeycloaks.yaml
+++ b/bundle/manifests/v1.edp.epam.com_clusterkeycloaks.yaml
@@ -19,6 +19,9 @@ spec:
       jsonPath: .status.connected
       name: Connected
       type: boolean
+    - jsonPath: .status.value
+      name: Status
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -286,6 +289,10 @@ spec:
               connected:
                 description: Connected shows if keycloak service is up and running.
                 type: boolean
+              value:
+                description: 'Value is the status message: OK, or the error of the
+                  last connection attempt.'
+                type: string
             required:
             - connected
             type: object

--- a/bundle/manifests/v1.edp.epam.com_keycloaks.yaml
+++ b/bundle/manifests/v1.edp.epam.com_keycloaks.yaml
@@ -19,6 +19,9 @@ spec:
       jsonPath: .status.connected
       name: Connected
       type: boolean
+    - jsonPath: .status.value
+      name: Status
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -283,6 +286,10 @@ spec:
               connected:
                 description: Connected shows if keycloak service is up and running.
                 type: boolean
+              value:
+                description: 'Value is the status message: OK, or the error of the
+                  last connection attempt.'
+                type: string
             required:
             - connected
             type: object

--- a/config/crd/bases/v1.edp.epam.com_clusterkeycloaks.yaml
+++ b/config/crd/bases/v1.edp.epam.com_clusterkeycloaks.yaml
@@ -19,6 +19,9 @@ spec:
       jsonPath: .status.connected
       name: Connected
       type: boolean
+    - jsonPath: .status.value
+      name: Status
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -286,6 +289,10 @@ spec:
               connected:
                 description: Connected shows if keycloak service is up and running.
                 type: boolean
+              value:
+                description: 'Value is the status message: OK, or the error of the
+                  last connection attempt.'
+                type: string
             required:
             - connected
             type: object

--- a/config/crd/bases/v1.edp.epam.com_keycloaks.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloaks.yaml
@@ -19,6 +19,9 @@ spec:
       jsonPath: .status.connected
       name: Connected
       type: boolean
+    - jsonPath: .status.value
+      name: Status
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -283,6 +286,10 @@ spec:
               connected:
                 description: Connected shows if keycloak service is up and running.
                 type: boolean
+              value:
+                description: 'Value is the status message: OK, or the error of the
+                  last connection attempt.'
+                type: string
             required:
             - connected
             type: object

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: docker.io/epamedp/keycloak-operator
-  newTag: 1.35.0
+  newTag: 1.36.0

--- a/deploy-templates/crds/v1.edp.epam.com_clusterkeycloaks.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_clusterkeycloaks.yaml
@@ -19,6 +19,9 @@ spec:
       jsonPath: .status.connected
       name: Connected
       type: boolean
+    - jsonPath: .status.value
+      name: Status
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -286,6 +289,10 @@ spec:
               connected:
                 description: Connected shows if keycloak service is up and running.
                 type: boolean
+              value:
+                description: 'Value is the status message: OK, or the error of the
+                  last connection attempt.'
+                type: string
             required:
             - connected
             type: object

--- a/deploy-templates/crds/v1.edp.epam.com_keycloaks.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloaks.yaml
@@ -19,6 +19,9 @@ spec:
       jsonPath: .status.connected
       name: Connected
       type: boolean
+    - jsonPath: .status.value
+      name: Status
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -283,6 +286,10 @@ spec:
               connected:
                 description: Connected shows if keycloak service is up and running.
                 type: boolean
+              value:
+                description: 'Value is the status message: OK, or the error of the
+                  last connection attempt.'
+                type: string
             required:
             - connected
             type: object

--- a/docs/api.md
+++ b/docs/api.md
@@ -2432,6 +2432,13 @@ ClusterKeycloakStatus defines the observed state of ClusterKeycloak.
           Connected shows if keycloak service is up and running.<br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b>value</b></td>
+        <td>string</td>
+        <td>
+          Value is the status message: OK, or the error of the last connection attempt.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -9190,5 +9197,12 @@ KeycloakStatus defines the observed state of Keycloak.
           Connected shows if keycloak service is up and running.<br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b>value</b></td>
+        <td>string</td>
+        <td>
+          Value is the status message: OK, or the error of the last connection attempt.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>

--- a/internal/controller/clusterkeycloak/clusterkeycloak_controller.go
+++ b/internal/controller/clusterkeycloak/clusterkeycloak_controller.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 )
@@ -113,7 +114,13 @@ func (r *Reconciler) updateConnectionStatusToKeycloak(ctx context.Context, insta
 
 	connected := err == nil
 
-	if instance.Status.Connected == connected {
+	value := common.StatusOK
+	if err != nil {
+		value = err.Error()
+	}
+
+	// Unchanged status is not written: no resourceVersion bump, no watch event.
+	if instance.Status.Connected == connected && instance.Status.Value == value {
 		log.Info("Connection status hasn't been changed", "status", instance.Status.Connected)
 
 		return nil
@@ -122,6 +129,7 @@ func (r *Reconciler) updateConnectionStatusToKeycloak(ctx context.Context, insta
 	log.Info("Connection status has been changed", "from", instance.Status.Connected, "to", connected)
 
 	instance.Status.Connected = connected
+	instance.Status.Value = value
 
 	err = r.client.Status().Update(ctx, instance)
 	if err != nil {

--- a/internal/controller/clusterkeycloak/clusterkeycloak_controller_integration_test.go
+++ b/internal/controller/clusterkeycloak/clusterkeycloak_controller_integration_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
 )
 
@@ -54,7 +55,7 @@ var _ = Describe("ClusterKeycloak controller", func() {
 			if err != nil {
 				return false
 			}
-			return createdKeycloak.Status.Connected
+			return createdKeycloak.Status.Connected && createdKeycloak.Status.Value == common.StatusOK
 		}, timeout, interval).Should(BeTrue())
 	})
 })

--- a/internal/controller/clusterkeycloak/clusterkeycloak_controller_test.go
+++ b/internal/controller/clusterkeycloak/clusterkeycloak_controller_test.go
@@ -1,0 +1,72 @@
+package clusterkeycloak
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/epam/edp-keycloak-operator/api/common"
+	keycloakAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+)
+
+type stubHelper struct{ err error }
+
+func (s stubHelper) CreateKeycloakClientFromClusterKeycloak(
+	context.Context,
+	*keycloakAlpha.ClusterKeycloak,
+) (*keycloakapi.KeycloakClient, error) {
+	return nil, s.err
+}
+
+// Status carries the connection result; an unchanged status is not written, so the
+// resourceVersion stays put and no watch event fires.
+func TestUpdateConnectionStatusToKeycloak(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, keycloakAlpha.AddToScheme(scheme))
+
+	kc := &keycloakAlpha.ClusterKeycloak{ObjectMeta: metav1.ObjectMeta{Name: "kc"}}
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&keycloakAlpha.ClusterKeycloak{}).
+		WithObjects(kc).
+		Build()
+
+	ctx := ctrl.LoggerInto(context.Background(), logr.Discard())
+
+	get := func() *keycloakAlpha.ClusterKeycloak {
+		out := &keycloakAlpha.ClusterKeycloak{}
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "kc"}, out))
+
+		return out
+	}
+
+	failing := NewReconcile(cl, scheme, stubHelper{err: assert.AnError})
+	require.NoError(t, failing.updateConnectionStatusToKeycloak(ctx, get()))
+
+	afterFailure := get()
+	assert.False(t, afterFailure.Status.Connected)
+	assert.Contains(t, afterFailure.Status.Value, assert.AnError.Error())
+
+	require.NoError(t, failing.updateConnectionStatusToKeycloak(ctx, get()))
+	assert.Equal(t, afterFailure.ResourceVersion, get().ResourceVersion,
+		"an unchanged status must not be written")
+
+	succeeding := NewReconcile(cl, scheme, stubHelper{})
+	require.NoError(t, succeeding.updateConnectionStatusToKeycloak(ctx, get()))
+
+	afterSuccess := get()
+	assert.True(t, afterSuccess.Status.Connected)
+	assert.Equal(t, common.StatusOK, afterSuccess.Status.Value)
+	assert.NotEqual(t, afterFailure.ResourceVersion, afterSuccess.ResourceVersion)
+}

--- a/internal/controller/keycloak/keycloak_controller.go
+++ b/internal/controller/keycloak/keycloak_controller.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 )
@@ -105,7 +106,13 @@ func (r *ReconcileKeycloak) updateConnectionStatusToKeycloak(ctx context.Context
 
 	connected := err == nil
 
-	if instance.Status.Connected == connected {
+	value := common.StatusOK
+	if err != nil {
+		value = err.Error()
+	}
+
+	// Unchanged status is not written: no resourceVersion bump, no watch event.
+	if instance.Status.Connected == connected && instance.Status.Value == value {
 		log.Info("Connection status hasn't been changed", "status", instance.Status.Connected)
 
 		return nil
@@ -114,6 +121,7 @@ func (r *ReconcileKeycloak) updateConnectionStatusToKeycloak(ctx context.Context
 	log.Info("Connection status has been changed", "from", instance.Status.Connected, "to", connected)
 
 	instance.Status.Connected = connected
+	instance.Status.Value = value
 
 	err = r.client.Status().Update(ctx, instance)
 	if err != nil {

--- a/internal/controller/keycloak/keycloak_controller_integration_test.go
+++ b/internal/controller/keycloak/keycloak_controller_integration_test.go
@@ -3,6 +3,7 @@ package keycloak
 import (
 	"context"
 	"os"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -54,9 +55,34 @@ var _ = Describe("Keycloak controller", Ordered, func() {
 				return false
 			}
 
-			return kc.Status.Connected
+			return kc.Status.Connected && kc.Status.Value == common.StatusOK
 		}, timeout, interval).Should(BeTrue())
 	}
+
+	It("Should report a connection failure in status", func() {
+		kc := &keycloakApi.Keycloak{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kc-missing-secret",
+				Namespace: testNamespace,
+			},
+			Spec: keycloakApi.KeycloakSpec{
+				Url:    keycloakURL,
+				Secret: "absent-auth-secret",
+			},
+		}
+		Expect(k8sClient.Create(ctx, kc)).Should(Succeed())
+
+		Eventually(func() bool {
+			out := &keycloakApi.Keycloak{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: kc.Name, Namespace: testNamespace}, out); err != nil {
+				return false
+			}
+
+			return !out.Status.Connected && strings.Contains(out.Status.Value, "failed")
+		}, timeout, interval).Should(BeTrue())
+
+		Expect(k8sClient.Delete(ctx, kc)).Should(Succeed())
+	})
 
 	It("Should connect with legacy secret auth", func() {
 		secret := &corev1.Secret{

--- a/internal/controller/keycloak/keycloak_controller_test.go
+++ b/internal/controller/keycloak/keycloak_controller_test.go
@@ -1,0 +1,69 @@
+package keycloak
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/epam/edp-keycloak-operator/api/common"
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+)
+
+type stubHelper struct{ err error }
+
+func (s stubHelper) CreateKeycloakClientFromKeycloak(context.Context, *keycloakApi.Keycloak) (*keycloakapi.KeycloakClient, error) {
+	return nil, s.err
+}
+
+// Status carries the connection result; an unchanged status is not written, so the
+// resourceVersion stays put and no watch event fires.
+func TestUpdateConnectionStatusToKeycloak(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, keycloakApi.AddToScheme(scheme))
+
+	kc := &keycloakApi.Keycloak{ObjectMeta: metav1.ObjectMeta{Name: "kc", Namespace: "default"}}
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&keycloakApi.Keycloak{}).
+		WithObjects(kc).
+		Build()
+
+	ctx := ctrl.LoggerInto(context.Background(), logr.Discard())
+
+	get := func() *keycloakApi.Keycloak {
+		out := &keycloakApi.Keycloak{}
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "kc", Namespace: "default"}, out))
+
+		return out
+	}
+
+	failing := NewReconcileKeycloak(cl, scheme, stubHelper{err: assert.AnError})
+	require.NoError(t, failing.updateConnectionStatusToKeycloak(ctx, get()))
+
+	afterFailure := get()
+	assert.False(t, afterFailure.Status.Connected)
+	assert.Contains(t, afterFailure.Status.Value, assert.AnError.Error())
+
+	require.NoError(t, failing.updateConnectionStatusToKeycloak(ctx, get()))
+	assert.Equal(t, afterFailure.ResourceVersion, get().ResourceVersion,
+		"an unchanged status must not be written")
+
+	succeeding := NewReconcileKeycloak(cl, scheme, stubHelper{})
+	require.NoError(t, succeeding.updateConnectionStatusToKeycloak(ctx, get()))
+
+	afterSuccess := get()
+	assert.True(t, afterSuccess.Status.Connected)
+	assert.Equal(t, common.StatusOK, afterSuccess.Status.Value)
+	assert.NotEqual(t, afterFailure.ResourceVersion, afterSuccess.ResourceVersion)
+}


### PR DESCRIPTION


- Add the Value status field and a Status printer column, the shape the other kinds already use: the error text on failure, OK on success. A denied destination was visible only in the operator log.
- An unchanged status is not written: no resourceVersion bump, no watch event, no extra reconcile. Unit tests assert the resourceVersion does not move.

