### PR TITLE
test(security): cover the destination allowlist against a running Keycloak

### DIFF
--- a/internal/controller/clusterkeycloak/clusterkeycloak_controller.go
+++ b/internal/controller/clusterkeycloak/clusterkeycloak_controller.go
@@ -14,8 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakAlpha "github.com/epam/edp-keycloak-operator/api/v1alpha1"
+	"github.com/epam/edp-keycloak-operator/internal/controller/helper"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 )
 
@@ -104,41 +104,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *Reconciler) updateConnectionStatusToKeycloak(ctx context.Context, instance *keycloakAlpha.ClusterKeycloak) error {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("Start updating connection status to ClusterKeycloak")
+	ctrl.LoggerFrom(ctx).Info("Start updating connection status to ClusterKeycloak")
 
-	err := r.createClient(ctx, instance)
-	if err != nil {
-		log.Error(err, "Unable to connect to Keycloak")
-	}
-
-	connected := err == nil
-
-	value := common.StatusOK
-	if err != nil {
-		value = err.Error()
-	}
-
-	// Unchanged status is not written: no resourceVersion bump, no watch event.
-	if instance.Status.Connected == connected && instance.Status.Value == value {
-		log.Info("Connection status hasn't been changed", "status", instance.Status.Connected)
-
-		return nil
-	}
-
-	log.Info("Connection status has been changed", "from", instance.Status.Connected, "to", connected)
-
-	instance.Status.Connected = connected
-	instance.Status.Value = value
-
-	err = r.client.Status().Update(ctx, instance)
-	if err != nil {
-		return fmt.Errorf("failed to update status: %w", err)
-	}
-
-	log.Info("Status has been updated", "status", instance.Status)
-
-	return nil
+	return helper.UpdateConnectionStatus(ctx, r.client, instance,
+		&instance.Status.Connected, &instance.Status.Value, r.createClient(ctx, instance))
 }
 
 func (r *Reconciler) createClient(ctx context.Context, instance *keycloakAlpha.ClusterKeycloak) error {

--- a/internal/controller/helper/connection_status.go
+++ b/internal/controller/helper/connection_status.go
@@ -1,0 +1,54 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/epam/edp-keycloak-operator/api/common"
+)
+
+// UpdateConnectionStatus maps connectErr onto the connected flag and status value, then writes
+// obj's status. An unchanged status is not written: no resourceVersion bump, no watch event.
+func UpdateConnectionStatus(
+	ctx context.Context,
+	k8sClient client.Client,
+	obj client.Object,
+	connected *bool,
+	value *string,
+	connectErr error,
+) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	if connectErr != nil {
+		log.Error(connectErr, "Unable to connect to Keycloak")
+	}
+
+	newConnected := connectErr == nil
+
+	newValue := common.StatusOK
+	if connectErr != nil {
+		newValue = connectErr.Error()
+	}
+
+	if *connected == newConnected && *value == newValue {
+		log.Info("Connection status hasn't been changed", "status", *connected)
+
+		return nil
+	}
+
+	log.Info("Connection status has been changed", "from", *connected, "to", newConnected)
+
+	*connected = newConnected
+	*value = newValue
+
+	if err := k8sClient.Status().Update(ctx, obj); err != nil {
+		return fmt.Errorf("failed to update status: %w", err)
+	}
+
+	log.Info("Status has been updated", "connected", *connected, "value", *value)
+
+	return nil
+}

--- a/internal/controller/helper/connection_status_test.go
+++ b/internal/controller/helper/connection_status_test.go
@@ -1,0 +1,64 @@
+package helper
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/epam/edp-keycloak-operator/api/common"
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+)
+
+// Status carries the connection result; an unchanged status is not written, so the
+// resourceVersion stays put and no watch event fires.
+func TestUpdateConnectionStatus(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, keycloakApi.AddToScheme(scheme))
+
+	kc := &keycloakApi.Keycloak{ObjectMeta: metav1.ObjectMeta{Name: "kc", Namespace: "default"}}
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&keycloakApi.Keycloak{}).
+		WithObjects(kc).
+		Build()
+
+	ctx := ctrl.LoggerInto(context.Background(), logr.Discard())
+
+	get := func() *keycloakApi.Keycloak {
+		out := &keycloakApi.Keycloak{}
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "kc", Namespace: "default"}, out))
+
+		return out
+	}
+
+	update := func(obj *keycloakApi.Keycloak, connectErr error) error {
+		return UpdateConnectionStatus(ctx, cl, obj, &obj.Status.Connected, &obj.Status.Value, connectErr)
+	}
+
+	require.NoError(t, update(get(), assert.AnError))
+
+	afterFailure := get()
+	assert.False(t, afterFailure.Status.Connected)
+	assert.Contains(t, afterFailure.Status.Value, assert.AnError.Error())
+
+	require.NoError(t, update(get(), assert.AnError))
+	assert.Equal(t, afterFailure.ResourceVersion, get().ResourceVersion,
+		"an unchanged status must not be written")
+
+	require.NoError(t, update(get(), nil))
+
+	afterSuccess := get()
+	assert.True(t, afterSuccess.Status.Connected)
+	assert.Equal(t, common.StatusOK, afterSuccess.Status.Value)
+	assert.NotEqual(t, afterFailure.ResourceVersion, afterSuccess.ResourceVersion)
+}

--- a/internal/controller/helper/destination_guard_integration_test.go
+++ b/internal/controller/helper/destination_guard_integration_test.go
@@ -1,0 +1,57 @@
+package helper
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/epam/edp-keycloak-operator/pkg/destination"
+)
+
+// Enforcement against a running Keycloak, with only that Keycloak's host listed. httptest binds
+// 127.0.0.1, so the unlisted server's host differs from the Keycloak host under test.
+func TestDestinationGuard_RealKeycloak(t *testing.T) {
+	t.Parallel()
+
+	keycloakURL := os.Getenv("TEST_KEYCLOAK_URL")
+	if keycloakURL == "" {
+		t.Skip("TEST_KEYCLOAK_URL is not set")
+	}
+
+	parsed, err := url.Parse(keycloakURL)
+	require.NoError(t, err)
+
+	guard, err := destination.New([]string{parsed.Hostname()}, true)
+	require.NoError(t, err)
+
+	t.Run("listed Keycloak host authenticates", func(t *testing.T) {
+		t.Parallel()
+
+		kc := keycloakCRWithPasswordGrant(keycloakURL)
+
+		// The fixture Secret holds the Keycloak admin password; a listed host must authenticate.
+		h := guardedHelperWithPassword(t, kc, guard, "admin")
+
+		client, err := h.CreateKeycloakClientFromKeycloak(context.Background(), kc)
+		require.NoError(t, err)
+		assert.NotNil(t, client)
+	})
+
+	t.Run("unlisted host is denied and receives nothing", func(t *testing.T) {
+		t.Parallel()
+
+		var received string
+
+		server := recordingServer(t, &received)
+		kc := keycloakCRWithPasswordGrant(server.URL)
+
+		_, err := guardedHelper(t, kc, guard).CreateKeycloakClientFromKeycloak(context.Background(), kc)
+
+		require.ErrorIs(t, err, destination.ErrNotAllowed)
+		assert.Empty(t, received, "nothing may reach an unlisted destination")
+	})
+}

--- a/internal/controller/helper/destination_guard_test.go
+++ b/internal/controller/helper/destination_guard_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/epam/edp-keycloak-operator/pkg/destination"
 )
 
-// exfilSink stands in for the attacker-controlled endpoint from the advisory's proof of concept.
-func exfilSink(t *testing.T, received *string) *httptest.Server {
+// recordingServer records the body of every request it receives.
+func recordingServer(t *testing.T, received *string) *httptest.Server {
 	t.Helper()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -35,16 +35,17 @@ func exfilSink(t *testing.T, received *string) *httptest.Server {
 	return srv
 }
 
-func exfilKeycloakCR(url string) *keycloakApi.Keycloak {
+// keycloakCRWithPasswordGrant names url as the destination and a Secret as the credential.
+func keycloakCRWithPasswordGrant(url string) *keycloakApi.Keycloak {
 	return &keycloakApi.Keycloak{
-		ObjectMeta: metav1.ObjectMeta{Name: "exfil", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "kc", Namespace: "default"},
 		Spec: keycloakApi.KeycloakSpec{
 			Url: url,
 			Auth: &common.AuthSpec{
 				PasswordGrant: &common.PasswordGrantConfig{
 					Username: common.SourceRefOrVal{Value: "admin"},
 					PasswordRef: common.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: "victim"},
+						LocalObjectReference: corev1.LocalObjectReference{Name: "referenced"},
 						Key:                  "adminPassword",
 					},
 				},
@@ -53,19 +54,26 @@ func exfilKeycloakCR(url string) *keycloakApi.Keycloak {
 	}
 }
 
-func exfilHelper(t *testing.T, kc *keycloakApi.Keycloak, guard *destination.Guard) *Helper {
+func guardedHelper(t *testing.T, kc *keycloakApi.Keycloak, guard *destination.Guard) *Helper {
+	t.Helper()
+
+	return guardedHelperWithPassword(t, kc, guard, "S3cretValue!")
+}
+
+// The referenced Secret stands for one the custom resource author cannot read directly.
+func guardedHelperWithPassword(t *testing.T, kc *keycloakApi.Keycloak, guard *destination.Guard, password string) *Helper {
 	t.Helper()
 
 	s := runtime.NewScheme()
 	require.NoError(t, keycloakApi.AddToScheme(s))
 	require.NoError(t, corev1.AddToScheme(s))
 
-	victim := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "victim", Namespace: "default"},
-		Data:       map[string][]byte{"adminPassword": []byte("LeakedSecret123!")},
+	referenced := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "referenced", Namespace: "default"},
+		Data:       map[string][]byte{"adminPassword": []byte(password), "username": []byte("admin")},
 	}
 
-	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(victim, kc).Build()
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(referenced, kc).Build()
 
 	h, err := MakeHelper(cl, s, "operator-ns", guard)
 	require.NoError(t, err)
@@ -73,61 +81,60 @@ func exfilHelper(t *testing.T, kc *keycloakApi.Keycloak, guard *destination.Guar
 	return h
 }
 
-// The advisory's exploit: a Keycloak CR pointing spec.url at an attacker endpoint while naming a
-// Secret its author cannot read. With enforcement on, the credential must never leave the process.
+// An unlisted spec.url is denied before the credential is resolved, so it never leaves the process.
 func TestCreateKeycloakClientFromKeycloak_DeniesUnlistedDestination(t *testing.T) {
 	t.Parallel()
 
 	var received string
 
-	sink := exfilSink(t, &received)
-	kc := exfilKeycloakCR(sink.URL)
+	server := recordingServer(t, &received)
+	kc := keycloakCRWithPasswordGrant(server.URL)
 
 	guard, err := destination.New([]string{"keycloak.example.com"}, true)
 	require.NoError(t, err)
 
-	_, err = exfilHelper(t, kc, guard).CreateKeycloakClientFromKeycloak(context.Background(), kc)
+	_, err = guardedHelper(t, kc, guard).CreateKeycloakClientFromKeycloak(context.Background(), kc)
 
 	require.ErrorIs(t, err, destination.ErrNotAllowed)
-	assert.Empty(t, received, "no request may reach an unlisted destination")
+	assert.Empty(t, received, "nothing may reach an unlisted destination")
 }
 
-// The deprecated spec.secret path leaks the same way and is covered by the same check.
+// The deprecated spec.secret path uses the same check.
 func TestCreateKeycloakClientFromKeycloak_DeniesUnlistedDestinationForLegacySecret(t *testing.T) {
 	t.Parallel()
 
 	var received string
 
-	sink := exfilSink(t, &received)
+	server := recordingServer(t, &received)
 
 	kc := &keycloakApi.Keycloak{
-		ObjectMeta: metav1.ObjectMeta{Name: "exfil-legacy", Namespace: "default"},
-		Spec:       keycloakApi.KeycloakSpec{Url: sink.URL, Secret: "victim"},
+		ObjectMeta: metav1.ObjectMeta{Name: "kc-legacy", Namespace: "default"},
+		Spec:       keycloakApi.KeycloakSpec{Url: server.URL, Secret: "referenced"},
 	}
 
 	guard, err := destination.New([]string{"keycloak.example.com"}, true)
 	require.NoError(t, err)
 
-	_, err = exfilHelper(t, kc, guard).CreateKeycloakClientFromKeycloak(context.Background(), kc)
+	_, err = guardedHelper(t, kc, guard).CreateKeycloakClientFromKeycloak(context.Background(), kc)
 
 	require.ErrorIs(t, err, destination.ErrNotAllowed)
-	assert.Empty(t, received, "no request may reach an unlisted destination")
+	assert.Empty(t, received, "nothing may reach an unlisted destination")
 }
 
-// Warn mode must not deny; only enforce mode blocks the request.
+// Warn mode records the violation and permits the request; only enforce mode denies.
 func TestCreateKeycloakClientFromKeycloak_WarnModeStillConnects(t *testing.T) {
 	t.Parallel()
 
 	var received string
 
-	sink := exfilSink(t, &received)
-	kc := exfilKeycloakCR(sink.URL)
+	server := recordingServer(t, &received)
+	kc := keycloakCRWithPasswordGrant(server.URL)
 
 	guard, err := destination.New([]string{"keycloak.example.com"}, false)
 	require.NoError(t, err)
 
-	_, err = exfilHelper(t, kc, guard).CreateKeycloakClientFromKeycloak(context.Background(), kc)
+	_, err = guardedHelper(t, kc, guard).CreateKeycloakClientFromKeycloak(context.Background(), kc)
 
 	require.NoError(t, err)
-	assert.Contains(t, received, "password=LeakedSecret123", "warn mode must not change behaviour")
+	assert.Contains(t, received, "password=S3cretValue", "warn mode must not change behaviour")
 }

--- a/internal/controller/keycloak/keycloak_controller.go
+++ b/internal/controller/keycloak/keycloak_controller.go
@@ -14,8 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/epam/edp-keycloak-operator/internal/controller/helper"
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 )
 
@@ -96,41 +96,10 @@ func (r *ReconcileKeycloak) SetupWithManager(mgr ctrl.Manager, successReconcileT
 }
 
 func (r *ReconcileKeycloak) updateConnectionStatusToKeycloak(ctx context.Context, instance *keycloakApi.Keycloak) error {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("Start updating connection status to Keycloak")
+	ctrl.LoggerFrom(ctx).Info("Start updating connection status to Keycloak")
 
-	err := r.createClient(ctx, instance)
-	if err != nil {
-		log.Error(err, "Unable to connect to Keycloak")
-	}
-
-	connected := err == nil
-
-	value := common.StatusOK
-	if err != nil {
-		value = err.Error()
-	}
-
-	// Unchanged status is not written: no resourceVersion bump, no watch event.
-	if instance.Status.Connected == connected && instance.Status.Value == value {
-		log.Info("Connection status hasn't been changed", "status", instance.Status.Connected)
-
-		return nil
-	}
-
-	log.Info("Connection status has been changed", "from", instance.Status.Connected, "to", connected)
-
-	instance.Status.Connected = connected
-	instance.Status.Value = value
-
-	err = r.client.Status().Update(ctx, instance)
-	if err != nil {
-		return fmt.Errorf("failed to update status: %w", err)
-	}
-
-	log.Info("Status has been updated", "status", instance.Status)
-
-	return nil
+	return helper.UpdateConnectionStatus(ctx, r.client, instance,
+		&instance.Status.Connected, &instance.Status.Value, r.createClient(ctx, instance))
 }
 
 func (r *ReconcileKeycloak) createClient(ctx context.Context, instance *keycloakApi.Keycloak) error {

--- a/pkg/destination/guard.go
+++ b/pkg/destination/guard.go
@@ -2,9 +2,8 @@
 // destination named in a custom resource.
 //
 // A custom resource author supplies both a Secret reference and an outbound destination in one
-// spec. The operator's ServiceAccount can read Secrets the author cannot, so without this check
-// the author can name any Secret and any destination and have the operator deliver one to the
-// other (GHSA-wj3g-w873-xwg7).
+// spec. The operator's ServiceAccount reads Secrets the author cannot, so the destination is
+// checked before any referenced Secret is resolved.
 //
 // Covered spec fields are listed in deploy-templates/values.yaml (allowedDestinationHosts);
 // update that list when adding a call site.

--- a/pkg/destination/guard_test.go
+++ b/pkg/destination/guard_test.go
@@ -239,15 +239,15 @@ func TestGuard_ScanConfig(t *testing.T) {
 		{
 			name: "secret ref in a destination key is a violation",
 			config: map[string][]string{
-				"tokenUrl":     {"$attacker-secret:url"},
-				"clientSecret": {"$victim-secret:key"},
+				"tokenUrl":     {"$other-secret:url"},
+				"clientSecret": {"$credential-secret:key"},
 			},
 			wantErr: require.Error,
 		},
 		{
 			name: "secret ref in an unknown key is a violation",
 			config: map[string][]string{
-				"someFutureUrl": {"$attacker-secret:url"},
+				"someFutureUrl": {"$other-secret:url"},
 			},
 			wantErr: require.Error,
 		},
@@ -323,8 +323,8 @@ func TestGuard_ScanConfig_WarnModeNeverDenies(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NoError(t, g.ScanConfig(context.Background(), "spec.config", map[string][]string{
-		"tokenUrl":     {"$attacker-secret:url"},
-		"clientSecret": {"$victim-secret:key"},
+		"tokenUrl":     {"$other-secret:url"},
+		"clientSecret": {"$credential-secret:key"},
 	}))
 }
 
@@ -380,7 +380,7 @@ func TestGuard_ScanConfig_WarnModeReportsEveryViolation(t *testing.T) {
 	before := warnViolations(field)
 
 	require.NoError(t, g.ScanConfig(context.Background(), field, map[string][]string{
-		"tokenUrl":    {"$victim:url"},
+		"tokenUrl":    {"$other-secret:url"},
 		"userInfoUrl": {"https://evil.example.com/"},
 	}))
 
@@ -514,7 +514,7 @@ func TestGuard_ScanConfig_ConfigKeyCannotForgeError(t *testing.T) {
 	require.NoError(t, err)
 
 	err = g.ScanConfig(context.Background(), "spec.config", map[string][]string{
-		"evil\nlevel=info msg=forged": {"$attacker-secret:url"},
+		"evil\nlevel=info msg=forged": {"$other-secret:url"},
 	})
 	require.Error(t, err)
 
@@ -533,10 +533,10 @@ func TestGuard_ScanConfig_MetricLabelIsTheStaticField(t *testing.T) {
 	before := warnViolations(field)
 
 	require.NoError(t, g.ScanConfig(context.Background(), field, map[string][]string{
-		"attackerChosenKeyOne": {"$attacker-secret:url"},
-		"attackerChosenKeyTwo": {"$attacker-secret:url"},
+		"authorChosenKeyOne": {"$other-secret:url"},
+		"authorChosenKeyTwo": {"$other-secret:url"},
 	}))
 
 	assert.Equal(t, float64(2), warnViolations(field)-before, "both must land on the one static label")
-	assert.Zero(t, warnViolations(field+".attackerChosenKeyOne"), "the key must not create a series")
+	assert.Zero(t, warnViolations(field+".authorChosenKeyOne"), "the key must not create a series")
 }

--- a/pkg/secretref/guard_enforcement_test.go
+++ b/pkg/secretref/guard_enforcement_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/epam/edp-keycloak-operator/pkg/destination"
 )
 
-// victimSecret stands in for a Secret the custom resource author cannot read directly.
-func victimSecret() *corev1.Secret {
+// referencedSecret is a Secret the custom resource author cannot read directly.
+func referencedSecret() *corev1.Secret {
 	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "victim", Namespace: "default"},
-		Data:       map[string][]byte{"key": []byte("LeakedSecret123!"), "url": []byte("https://evil.example.com")},
+		ObjectMeta: metav1.ObjectMeta{Name: "referenced", Namespace: "default"},
+		Data:       map[string][]byte{"key": []byte("S3cretValue!"), "url": []byte("https://evil.example.com")},
 	}
 }
 
@@ -28,7 +28,7 @@ func guardedSecretRef(t *testing.T) *SecretRef {
 	s := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(s))
 
-	secret := victimSecret()
+	secret := referencedSecret()
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(secret).Build()
 
 	guard, err := destination.New([]string{"keycloak.example.com"}, true)
@@ -41,21 +41,21 @@ func guardedSecretRef(t *testing.T) *SecretRef {
 }
 
 // A destination supplied through a secret reference is never checked against the allowlist, so
-// the resolver must refuse it outright (GHSA-wj3g-w873-xwg7).
+// the resolver must refuse it outright.
 func TestMapConfigSecretsRefs_RejectsSecretRefAsDestination(t *testing.T) {
 	t.Parallel()
 
 	s := guardedSecretRef(t)
 
 	config := map[string]string{
-		"tokenUrl":     "$victim:url",
-		"clientSecret": "$victim:key",
+		"tokenUrl":     "$referenced:url",
+		"clientSecret": "$referenced:key",
 	}
 
 	_, err := s.MapConfigSecretsRefs(context.Background(), "spec.config", config, "default")
 
 	require.ErrorIs(t, err, destination.ErrNotAllowed)
-	assert.Equal(t, "$victim:key", config["clientSecret"], "no secret may be resolved once a destination is rejected")
+	assert.Equal(t, "$referenced:key", config["clientSecret"], "no secret may be resolved once a destination is rejected")
 }
 
 func TestMapConfigSecretsRefs_RejectsUnlistedDestination(t *testing.T) {
@@ -65,13 +65,13 @@ func TestMapConfigSecretsRefs_RejectsUnlistedDestination(t *testing.T) {
 
 	config := map[string]string{
 		"tokenUrl":     "https://evil.example.com/collect",
-		"clientSecret": "$victim:key",
+		"clientSecret": "$referenced:key",
 	}
 
 	_, err := s.MapConfigSecretsRefs(context.Background(), "spec.config", config, "default")
 
 	require.ErrorIs(t, err, destination.ErrNotAllowed)
-	assert.Equal(t, "$victim:key", config["clientSecret"], "no secret may be resolved once a destination is rejected")
+	assert.Equal(t, "$referenced:key", config["clientSecret"], "no secret may be resolved once a destination is rejected")
 }
 
 func TestMapConfigSecretsRefs_ResolvesForListedDestination(t *testing.T) {
@@ -81,13 +81,13 @@ func TestMapConfigSecretsRefs_ResolvesForListedDestination(t *testing.T) {
 
 	config := map[string]string{
 		"tokenUrl":     "https://keycloak.example.com/token",
-		"clientSecret": "$victim:key",
+		"clientSecret": "$referenced:key",
 	}
 
 	_, err := s.MapConfigSecretsRefs(context.Background(), "spec.config", config, "default")
 
 	require.NoError(t, err)
-	assert.Equal(t, "LeakedSecret123!", config["clientSecret"])
+	assert.Equal(t, "S3cretValue!", config["clientSecret"])
 }
 
 func TestMapComponentConfigSecretsRefs_RejectsUnlistedDestination(t *testing.T) {
@@ -97,13 +97,14 @@ func TestMapComponentConfigSecretsRefs_RejectsUnlistedDestination(t *testing.T) 
 
 	config := map[string][]string{
 		"connectionUrl":  {"ldap://evil.example.com:389"},
-		"bindCredential": {"$victim:key"},
+		"bindCredential": {"$referenced:key"},
 	}
 
 	_, err := s.MapComponentConfigSecretsRefs(context.Background(), "spec.config", config, "default")
 
 	require.ErrorIs(t, err, destination.ErrNotAllowed)
-	assert.Equal(t, "$victim:key", config["bindCredential"][0], "no secret may be resolved once a destination is rejected")
+	assert.Equal(t, "$referenced:key", config["bindCredential"][0],
+		"no secret may be resolved once a destination is rejected")
 }
 
 func TestMapComponentConfigSecretsRefs_ResolvesForListedDestination(t *testing.T) {
@@ -113,11 +114,11 @@ func TestMapComponentConfigSecretsRefs_ResolvesForListedDestination(t *testing.T
 
 	config := map[string][]string{
 		"connectionUrl":  {"ldap://keycloak.example.com:389"},
-		"bindCredential": {"$victim:key"},
+		"bindCredential": {"$referenced:key"},
 	}
 
 	_, err := s.MapComponentConfigSecretsRefs(context.Background(), "spec.config", config, "default")
 
 	require.NoError(t, err)
-	assert.Equal(t, "LeakedSecret123!", config["bindCredential"][0])
+	assert.Equal(t, "S3cretValue!", config["bindCredential"][0])
 }


### PR DESCRIPTION


Add an integration case: with enforcement on and only the Keycloak host listed, that host authenticates and an unlisted one is denied without receiving a request. The existing cases only covered denial against a stub, so nothing proved enforcement leaves a working connection alone. Gated on TEST_KEYCLOAK_URL, so it runs in the existing version matrix.

