### PR TITLE
fix(KeycloakClient): stop deleting authorization permissions as orphaned policies

### DIFF
--- a/internal/controller/keycloakclient/keycloakclient_authz_idempotency_integration_test.go
+++ b/internal/controller/keycloakclient/keycloakclient_authz_idempotency_integration_test.go
@@ -1,0 +1,305 @@
+package keycloakclient
+
+import (
+	"slices"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/epam/edp-keycloak-operator/api/common"
+	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
+	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
+	"github.com/epam/edp-keycloak-operator/pkg/secretref"
+	"github.com/epam/edp-keycloak-operator/pkg/testutils"
+)
+
+// Idempotency suite for the KeycloakClient authorization block. Keycloak's admin event log is
+// the write oracle.
+//
+// The handlers still update matching policies, permissions and resources on every reconcile, so
+// a steady-state window holds UPDATE events. Only CREATE and DELETE are asserted absent: those
+// are the operations that churn Keycloak IDs. Each is anchored by a spec that provokes it, since
+// an absence assertion is evidence only while the log records that operation.
+var _ = Describe("KeycloakClient authz idempotent reconcile", Ordered, func() {
+	const (
+		crName         = "authz-client"
+		clientID       = "authz-client"
+		secretName     = "authz-client-secret"
+		secretKey      = "clientSecret"
+		policyName     = "authz-policy"
+		permissionName = "authz-permission"
+		permissionDesc = "authz permission v1"
+		settle         = testutils.Settle
+		longWait       = testutils.LongWait
+	)
+
+	var (
+		recorder   *testutils.AdminEventRecorder
+		clientUUID string
+	)
+
+	// eventsMatching returns the events whose operation is one of ops and whose resourcePath
+	// contains pathPart. An empty pathPart matches every event, including one with no path.
+	// A non-empty pathPart drops pathless events: an anchor must name the object it proves.
+	eventsMatching := func(events testutils.AdminEvents, pathPart string, ops ...string) testutils.AdminEvents {
+		matched := make(testutils.AdminEvents, 0, len(events))
+
+		for _, e := range events {
+			if !strings.Contains(ptr.Deref(e.ResourcePath, ""), pathPart) {
+				continue
+			}
+
+			if slices.Contains(ops, ptr.Deref(e.OperationType, "")) {
+				matched = append(matched, e)
+			}
+		}
+
+		return matched
+	}
+
+	nudge := func() {
+		Expect(testutils.Nudge(ctx, k8sClient,
+			types.NamespacedName{Name: crName, Namespace: ns}, &keycloakApi.KeycloakClient{})).To(Succeed())
+	}
+
+	waitReady := func() {
+		Eventually(func(g Gomega) {
+			cr := &keycloakApi.KeycloakClient{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).To(Succeed())
+			g.Expect(cr.Status.Value).To(Equal(common.StatusOK))
+		}, longWait, interval).Should(Succeed())
+	}
+
+	idsByName := func(entries []keycloakapi.AbstractPolicyRepresentation) map[string]string {
+		ids := make(map[string]string, len(entries))
+		for _, e := range entries {
+			ids[ptr.Deref(e.Name, "")] = ptr.Deref(e.Id, "")
+		}
+
+		return ids
+	}
+
+	permissions := func() []keycloakapi.AbstractPolicyRepresentation {
+		perms, _, err := keycloakAdmin.Authorization.GetPermissions(ctx, KeycloakRealmCR, clientUUID)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		return perms
+	}
+
+	policies := func() []keycloakapi.AbstractPolicyRepresentation {
+		pols, _, err := keycloakAdmin.Authorization.GetPolicies(ctx, KeycloakRealmCR, clientUUID)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		return pols
+	}
+
+	permission := func(name string) keycloakapi.AbstractPolicyRepresentation {
+		for _, p := range permissions() {
+			if ptr.Deref(p.Name, "") == name {
+				return p
+			}
+		}
+
+		Fail("permission " + name + " is missing from Keycloak")
+
+		return keycloakapi.AbstractPolicyRepresentation{}
+	}
+
+	BeforeAll(func() {
+		recorder = testutils.NewAdminEventRecorder(keycloakAdmin, KeycloakRealmCR)
+		Expect(recorder.Enable(ctx)).To(Succeed())
+
+		Expect(k8sClient.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: ns},
+			Data:       map[string][]byte{secretKey: []byte("authz-v1")},
+		})).To(Succeed())
+	})
+
+	// Sibling Describes in this package share the namespace and the realm, and Ginkgo randomizes
+	// top-level container order. Leave nothing behind.
+	AfterAll(func() {
+		cr := &keycloakApi.KeycloakClient{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr); err == nil {
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+
+			Eventually(func() bool {
+				return k8sErrors.IsNotFound(k8sClient.Get(ctx,
+					types.NamespacedName{Name: crName, Namespace: ns}, &keycloakApi.KeycloakClient{}))
+			}, longWait, interval).Should(BeTrue())
+		}
+
+		secret := &corev1.Secret{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: ns}, secret); err == nil {
+			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+		}
+	})
+
+	It("Should create the client with authorization scopes, resources, policies and permissions", func() {
+		cr := &keycloakApi.KeycloakClient{
+			ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: ns},
+			Spec: keycloakApi.KeycloakClientSpec{
+				ClientId:                     clientID,
+				RealmRef:                     common.RealmRef{Name: KeycloakRealmCR, Kind: keycloakApi.KeycloakRealmKind},
+				Secret:                       secretref.GenerateSecretRef(secretName, secretKey),
+				Enabled:                      true,
+				StandardFlowEnabled:          true,
+				AuthorizationServicesEnabled: true,
+				ClientAuthenticatorType:      "client-secret",
+				// Mappers and service-account attributes are inert here: they emit no CREATE or
+				// DELETE once converged.
+				ProtocolMappers: &[]keycloakApi.ProtocolMapper{
+					{
+						Name:           "authz-pm-a",
+						Protocol:       "openid-connect",
+						ProtocolMapper: "oidc-hardcoded-claim-mapper",
+						Config: map[string]string{
+							"claim.name": "authz-a", "claim.value": "v1",
+							"access.token.claim": "true", "id.token.claim": "true",
+							"jsonType.label": "String",
+						},
+					},
+				},
+				ServiceAccount: &keycloakApi.ServiceAccount{
+					Enabled:      true,
+					AttributesV2: map[string][]string{"authz-attr": {"one"}},
+				},
+				Authorization: &keycloakApi.Authorization{
+					Scopes: []string{"authz-scope"},
+					Resources: []keycloakApi.Resource{{
+						Name:        "authz-resource",
+						DisplayName: "Authz Resource",
+						Type:        "urn:authz:resource",
+						Scopes:      []string{"authz-scope"},
+					}},
+					Policies: []keycloakApi.Policy{{
+						Name:         policyName,
+						Type:         keycloakApi.PolicyTypeClient,
+						ClientPolicy: &keycloakApi.ClientPolicyData{Clients: []string{clientID}},
+					}},
+					Permissions: []keycloakApi.Permission{{
+						Name:        permissionName,
+						Type:        keycloakApi.PermissionTypeResource,
+						Description: permissionDesc,
+						Policies:    []string{policyName},
+						Resources:   []string{"authz-resource"},
+					}},
+				},
+			},
+		}
+
+		// The client UUID does not exist yet, so the window cannot be scoped in advance.
+		events, err := recorder.WritesDuring(ctx, 0, func() {
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			waitReady()
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		clientUUID, err = keycloakAdmin.Clients.GetClientUUID(ctx, KeycloakRealmCR, clientID)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(clientUUID).ShouldNot(BeEmpty())
+
+		Expect(eventsMatching(events, clientUUID, "CREATE")).ShouldNot(BeEmpty(),
+			"admin event log recorded no CREATE for a client it just created")
+
+		Expect(idsByName(permissions())).To(HaveKey(permissionName))
+		Expect(idsByName(policies())).To(HaveKey(policyName))
+
+		// Sibling specs share the realm; report only this client's events from here on.
+		recorder = recorder.Scoped(clientUUID)
+	})
+
+	// Must run before the drift and orphan specs: they mutate Keycloak, and a failure in an
+	// Ordered suite skips every later spec.
+	It("Should keep policy and permission IDs stable and not create or delete authorization objects on a forced reconcile", func() {
+		permissionsBefore := idsByName(permissions())
+		policiesBefore := idsByName(policies())
+
+		events, err := recorder.WritesDuring(ctx, settle, nudge)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// Nudge returns before the reconcile lands and WritesDuring only sleeps, so an empty
+		// window means either "no writes" or "nothing ran". The policy and permission handlers
+		// write on every reconcile, so this UPDATE proves the reconcile reached Keycloak inside
+		// the settle window and the assertions below are not vacuous.
+		Expect(eventsMatching(events, "", "UPDATE")).ShouldNot(BeEmpty(),
+			"no UPDATE recorded for a forced reconcile: the reconcile did not reach Keycloak within %s", settle)
+
+		Expect(idsByName(permissions())).To(Equal(permissionsBefore),
+			"permissions must be updated in place, not deleted and recreated")
+		Expect(idsByName(policies())).To(Equal(policiesBefore),
+			"policies must be updated in place, not deleted and recreated")
+
+		// UPDATE is expected here; see the suite comment for why only CREATE and DELETE are
+		// asserted absent.
+		Expect(eventsMatching(events, "", "CREATE", "DELETE")).To(BeEmpty())
+	})
+
+	It("Should heal external drift on the permission", func() {
+		drifted := permission(permissionName)
+		permID := ptr.Deref(drifted.Id, "")
+		Expect(permID).ShouldNot(BeEmpty())
+
+		events, err := recorder.WritesDuring(ctx, 0, func() {
+			_, updateErr := keycloakAdmin.Authorization.UpdatePermission(
+				ctx, KeycloakRealmCR, clientUUID, keycloakApi.PermissionTypeResource, permID,
+				keycloakapi.PolicyRepresentation{
+					Id:               drifted.Id,
+					Name:             drifted.Name,
+					Type:             drifted.Type,
+					Description:      ptr.To("drifted-by-hand"),
+					DecisionStrategy: drifted.DecisionStrategy,
+					Logic:            drifted.Logic,
+					Policies:         drifted.Policies,
+					Resources:        drifted.Resources,
+				})
+			Expect(updateErr).ShouldNot(HaveOccurred())
+
+			nudge()
+
+			Eventually(func(g Gomega) {
+				g.Expect(ptr.Deref(permission(permissionName).Description, "")).To(Equal(permissionDesc))
+			}, longWait, interval).Should(Succeed())
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(events).ShouldNot(BeEmpty(), "admin event log recorded nothing for a known write")
+	})
+
+	It("Should delete a policy that is not in the spec", func() {
+		// GetPolicies excludes permissions but must still return real orphan policies, so the
+		// sweep can delete them.
+		strayType := keycloakApi.PolicyTypeTime
+		stray, _, err := keycloakAdmin.Authorization.CreatePolicy(
+			ctx, KeycloakRealmCR, clientUUID, strayType,
+			keycloakapi.PolicyRepresentation{
+				Name:             ptr.To("stray-policy"),
+				Type:             ptr.To(strayType),
+				Logic:            ptr.To(keycloakapi.Logic("POSITIVE")),
+				DecisionStrategy: ptr.To(keycloakapi.DecisionStrategy("UNANIMOUS")),
+			})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(stray).ShouldNot(BeNil())
+
+		strayID := ptr.Deref(stray.Id, "")
+		Expect(strayID).ShouldNot(BeEmpty())
+
+		events, err := recorder.WritesDuring(ctx, 0, func() {
+			nudge()
+
+			Eventually(func(g Gomega) {
+				g.Expect(idsByName(policies())).ShouldNot(HaveKey("stray-policy"))
+			}, longWait, interval).Should(Succeed())
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Expect(eventsMatching(events, strayID, "DELETE")).ShouldNot(BeEmpty(),
+			"admin event log recorded no DELETE for the orphan policy it just removed")
+	})
+
+})

--- a/pkg/client/keycloakapi/authorization.go
+++ b/pkg/client/keycloakapi/authorization.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"k8s.io/utils/ptr"
+
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi/generated"
 )
 
@@ -314,8 +316,13 @@ func (a *authorizationClient) GetPolicies(
 	realm string,
 	clientUUID string,
 ) ([]AbstractPolicyRepresentation, *Response, error) {
+	// permission=false is required: Keycloak returns permissions from this endpoint when the
+	// filter is absent.
 	res, err := a.client.GetAdminRealmsRealmClientsClientUuidAuthzResourceServerPolicyWithResponse(
-		ctx, realm, clientUUID, nil,
+		ctx, realm, clientUUID,
+		&generated.GetAdminRealmsRealmClientsClientUuidAuthzResourceServerPolicyParams{
+			Permission: ptr.To(false),
+		},
 	)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/client/keycloakapi/authorization_test.go
+++ b/pkg/client/keycloakapi/authorization_test.go
@@ -7,10 +7,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 	"github.com/epam/edp-keycloak-operator/pkg/testutils"
-	"github.com/stretchr/testify/require"
 )
+
+// permissionTypeScope is the Keycloak permission type keyed on authorization scopes.
+const permissionTypeScope = "scope"
 
 // createAuthzClient sets up a Keycloak client with Authorization Services enabled and returns
 // the keycloak client, the realm name, and the client UUID.
@@ -698,7 +703,7 @@ func TestAuthorizationClient_PermissionCRUD(t *testing.T) {
 	baseline := len(permissions)
 
 	permName := fmt.Sprintf("test-permission-%d", time.Now().UnixNano())
-	permType := "scope"
+	permType := permissionTypeScope
 	decisionStrategy := keycloakapi.DecisionStrategy("UNANIMOUS")
 
 	perm := keycloakapi.PolicyRepresentation{
@@ -742,6 +747,86 @@ func TestAuthorizationClient_PermissionCRUD(t *testing.T) {
 			t.Fatal("deleted permission should not be in the list")
 		}
 	}
+}
+
+// TestAuthorizationClient_PoliciesAndPermissionsAreSeparateLists asserts GetPolicies excludes
+// permissions and GetPermissions excludes policies. Both endpoints accept the same permission
+// filter; only a live Keycloak says which one applies it by default, so both are checked.
+func TestAuthorizationClient_PoliciesAndPermissionsAreSeparateLists(t *testing.T) {
+	keycloakURL := testutils.GetKeycloakURLOrSkip(t)
+	t.Parallel()
+
+	kc, err := keycloakapi.NewKeycloakClient(
+		context.Background(),
+		keycloakURL,
+		keycloakapi.DefaultAdminClientID,
+		keycloakapi.WithPasswordGrant(keycloakapi.DefaultAdminUsername, keycloakapi.DefaultAdminPassword),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	realmName := fmt.Sprintf("test-realm-authz-split-%d", time.Now().UnixNano())
+	enabled := true
+
+	t.Cleanup(func() {
+		_, _ = kc.Realms.DeleteRealm(context.Background(), realmName)
+	})
+
+	_, err = kc.Realms.CreateRealm(ctx, keycloakapi.RealmRepresentation{
+		Realm:   &realmName,
+		Enabled: &enabled,
+	})
+	require.NoError(t, err)
+
+	clientUUID := createAuthzClient(t, kc, ctx, realmName)
+
+	decisionStrategy := keycloakapi.DecisionStrategy("UNANIMOUS")
+	logic := keycloakapi.Logic("POSITIVE")
+
+	policyName := fmt.Sprintf("split-policy-%d", time.Now().UnixNano())
+	policyType := "time"
+
+	_, _, err = kc.Authorization.CreatePolicy(ctx, realmName, clientUUID, policyType, keycloakapi.PolicyRepresentation{
+		Name:             &policyName,
+		Type:             &policyType,
+		Logic:            &logic,
+		DecisionStrategy: &decisionStrategy,
+	})
+	require.NoError(t, err)
+
+	permName := fmt.Sprintf("split-permission-%d", time.Now().UnixNano())
+	permType := permissionTypeScope
+
+	_, _, err = kc.Authorization.CreatePermission(ctx, realmName, clientUUID, permType, keycloakapi.PolicyRepresentation{
+		Name:             &permName,
+		Type:             &permType,
+		DecisionStrategy: &decisionStrategy,
+	})
+	require.NoError(t, err)
+
+	policies, _, err := kc.Authorization.GetPolicies(ctx, realmName, clientUUID)
+	require.NoError(t, err)
+
+	policyNames := abstractPolicyNames(policies)
+	require.Contains(t, policyNames, policyName, "GetPolicies must return the policy")
+	require.NotContains(t, policyNames, permName, "GetPolicies must not return permissions")
+
+	permissions, _, err := kc.Authorization.GetPermissions(ctx, realmName, clientUUID)
+	require.NoError(t, err)
+
+	permissionNames := abstractPolicyNames(permissions)
+	require.Contains(t, permissionNames, permName, "GetPermissions must return the permission")
+	require.NotContains(t, permissionNames, policyName, "GetPermissions must not return policies")
+}
+
+func abstractPolicyNames(entries []keycloakapi.AbstractPolicyRepresentation) []string {
+	names := make([]string, 0, len(entries))
+
+	for _, e := range entries {
+		names = append(names, ptr.Deref(e.Name, ""))
+	}
+
+	return names
 }
 
 func TestAuthorizationClient_GetResource(t *testing.T) {

--- a/pkg/client/keycloakapi/contracts.go
+++ b/pkg/client/keycloakapi/contracts.go
@@ -409,7 +409,9 @@ type AuthorizationClient interface {
 	// DeleteResource deletes an authorization resource by ID.
 	DeleteResource(ctx context.Context, realm, clientUUID, resourceID string) (*Response, error)
 	// Policies
-	// GetPolicies returns all authorization policies for a resource server.
+	// GetPolicies returns the authorization policies for a resource server. Permissions are
+	// excluded: Keycloak stores them in the same table and returns them from this endpoint
+	// unless permission=false is passed. Use GetPermissions for permissions.
 	GetPolicies(ctx context.Context, realm, clientUUID string) ([]AbstractPolicyRepresentation, *Response, error)
 	// CreatePolicy creates a new authorization policy of the given type.
 	CreatePolicy(


### PR DESCRIPTION


Keycloak stores permissions in the policy table and returns them from GET .../authz/resource-server/policy unless permission=false is passed. The policy sync listed that endpoint, found every permission missing from spec.authorization.policies, and deleted it as orphaned. The permission step runs later in the chain and recreated it. Each permission changed its Keycloak id every reconcile and was absent in between.

Observed on a quiet reconcile before the fix:

  CREATE clients/<uuid>/authz/resource-server/permission/resource/<id>
  DELETE clients/<uuid>/authz/resource-server/policy/<id>

- GetPolicies passes permission=false; both callers are fixed by it, the policy sync and the permission-to-policy name resolution
- an aggregate policy naming a permission in aggregatedPolicy.policies now fails with "policy <name> does not exist"; Keycloak cannot aggregate a permission, so such a spec was already invalid
- the suite asserts no CREATE and no DELETE, not an empty window; process_policy.go and process_permissions.go still update unconditionally

Every asserted absence is anchored: creation must emit a CREATE, and an orphan policy planted in Keycloak must be swept and emit a DELETE. The orphan spec also covers the filter's other direction. The stable-id spec runs first so an Ordered abort cannot leave it unrun.

