### PR TITLE
fix(KeycloakRealmUser): treat an unset role list as unmanaged, not empty

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,11 @@ KEYCLOAK_VERSION=26.5.2 make generate-keycloak-go-client   # regenerate oapi cli
 ### Reconciliation idempotency
 Skip Keycloak writes when actual state matches the spec; track `status.observedGeneration` and force writes on generation change so spec removals propagate. Never delete-and-recreate child resources — diff by name (reference: `internal/controller/keycloakclientscope/chain/`).
 
+### Optional list fields
+`absent` = the resource does not manage that facet, leave Keycloak alone. `[]` = managed, clear every entry. `[a,b]` = managed, exactly a and b. Type such a field `*[]T`; a plain `[]T` cannot express the distinction, and the operator's own full-object `Update` erases an explicit `[]` from etcd. Older plain-slice fields still clear on omission — convert one when you touch it.
+
+A sweep is a two-way diff and cannot tell "not mentioned" from "remove". Check nil before reading live state. Key an orphan sweep off "mentioned in spec", not "has a list", or the sweep undoes the nil check.
+
 ### Never edit generated code
 `pkg/client/keycloakapi/generated/client_generated.go` is auto-generated — do not edit manually.
 Edit `pkg/client/keycloakapi/openapi.yaml` then re-run `make generate-keycloak-go-client`.

--- a/api/v1/keycloakclient_types.go
+++ b/api/v1/keycloakclient_types.go
@@ -217,9 +217,11 @@ type ServiceAccount struct {
 	Enabled bool `json:"enabled,omitempty"`
 
 	// RealmRoles is a list of realm roles assigned to service account.
+	// Omit the field to leave the service account's realm roles unmanaged; set it to an empty
+	// list to remove every realm role.
 	// +nullable
 	// +optional
-	RealmRoles []string `json:"realmRoles"`
+	RealmRoles *[]string `json:"realmRoles,omitempty"`
 
 	// ClientRoles is a list of client roles assigned to service account.
 	// +nullable
@@ -249,9 +251,11 @@ type UserClientRole struct {
 	ClientID string `json:"clientId"`
 
 	// Roles is a list of client roles names assigned to user.
+	// Omit the field to leave this client's role mappings unmanaged; set it to an empty list to
+	// remove every mapping for the client.
 	// +nullable
 	// +optional
-	Roles []string `json:"roles,omitempty"`
+	Roles *[]string `json:"roles,omitempty"`
 }
 
 type ClientRole struct {

--- a/api/v1/keycloakrealmuser_types.go
+++ b/api/v1/keycloakrealmuser_types.go
@@ -40,10 +40,12 @@ type KeycloakRealmUserSpec struct {
 	// +optional
 	RequiredUserActions []string `json:"requiredUserActions,omitempty"`
 
-	// Roles is a list of roles assigned to user.
+	// Roles is a list of realm roles assigned to user.
+	// Omit the field to leave the user's realm roles unmanaged; set it to an empty list to
+	// remove every realm role.
 	// +nullable
 	// +optional
-	Roles []string `json:"roles,omitempty"`
+	Roles *[]string `json:"roles,omitempty"`
 
 	// ClientRoles is a list of client roles assigned to user.
 	// +nullable

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1601,8 +1601,12 @@ func (in *KeycloakRealmUserSpec) DeepCopyInto(out *KeycloakRealmUserSpec) {
 	}
 	if in.Roles != nil {
 		in, out := &in.Roles, &out.Roles
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
+		}
 	}
 	if in.ClientRoles != nil {
 		in, out := &in.ClientRoles, &out.ClientRoles
@@ -2115,8 +2119,12 @@ func (in *ServiceAccount) DeepCopyInto(out *ServiceAccount) {
 	*out = *in
 	if in.RealmRoles != nil {
 		in, out := &in.RealmRoles, &out.RealmRoles
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
+		}
 	}
 	if in.ClientRoles != nil {
 		in, out := &in.ClientRoles, &out.ClientRoles
@@ -2205,8 +2213,12 @@ func (in *UserClientRole) DeepCopyInto(out *UserClientRole) {
 	*out = *in
 	if in.Roles != nil {
 		in, out := &in.Roles, &out.Roles
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
+		}
 	}
 }
 

--- a/config/crd/bases/v1.edp.epam.com_keycloakclients.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakclients.yaml
@@ -648,8 +648,10 @@ spec:
                           description: ClientID is a client ID.
                           type: string
                         roles:
-                          description: Roles is a list of client roles names assigned
-                            to user.
+                          description: |-
+                            Roles is a list of client roles names assigned to user.
+                            Omit the field to leave this client's role mappings unmanaged; set it to an empty list to
+                            remove every mapping for the client.
                           items:
                             type: string
                           nullable: true
@@ -669,8 +671,10 @@ spec:
                     nullable: true
                     type: array
                   realmRoles:
-                    description: RealmRoles is a list of realm roles assigned to service
-                      account.
+                    description: |-
+                      RealmRoles is a list of realm roles assigned to service account.
+                      Omit the field to leave the service account's realm roles unmanaged; set it to an empty
+                      list to remove every realm role.
                     items:
                       type: string
                     nullable: true

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealmgroups.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealmgroups.yaml
@@ -66,8 +66,10 @@ spec:
                       description: ClientID is a client ID.
                       type: string
                     roles:
-                      description: Roles is a list of client roles names assigned
-                        to user.
+                      description: |-
+                        Roles is a list of client roles names assigned to user.
+                        Omit the field to leave this client's role mappings unmanaged; set it to an empty list to
+                        remove every mapping for the client.
                       items:
                         type: string
                       nullable: true

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml
@@ -70,8 +70,10 @@ spec:
                       description: ClientID is a client ID.
                       type: string
                     roles:
-                      description: Roles is a list of client roles names assigned
-                        to user.
+                      description: |-
+                        Roles is a list of client roles names assigned to user.
+                        Omit the field to leave this client's role mappings unmanaged; set it to an empty list to
+                        remove every mapping for the client.
                       items:
                         type: string
                       nullable: true
@@ -177,7 +179,10 @@ spec:
                 nullable: true
                 type: array
               roles:
-                description: Roles is a list of roles assigned to user.
+                description: |-
+                  Roles is a list of realm roles assigned to user.
+                  Omit the field to leave the user's realm roles unmanaged; set it to an empty list to
+                  remove every realm role.
                 items:
                   type: string
                 nullable: true

--- a/deploy-templates/_crd_examples/keycloakclient.yaml
+++ b/deploy-templates/_crd_examples/keycloakclient.yaml
@@ -44,6 +44,19 @@ spec:
   authorizationServicesEnabled: true
   serviceAccount:
     enabled: true
+    # realmRoles and clientRoles[].roles have three states.
+    #   omitted    the operator does not manage them; Keycloak keeps what it has,
+    #              including the default-roles-<realm> mapping it assigns at creation
+    #   []         the operator manages them and removes every mapping
+    #   [a, b]     the operator manages them; exactly a and b remain
+    # Helm: write [] in values.yaml or pass --set-json 'realmRoles=[]'.
+    # `--set realmRoles={}` yields [""], and a {{ if }} guard drops [] entirely.
+    realmRoles:
+      - offline_access
+    clientRoles:
+      - clientId: realm-management
+        roles:
+          - view-users
   authorization:
     scopes:
       - scope1

--- a/deploy-templates/_crd_examples/keycloakrealmuser.yaml
+++ b/deploy-templates/_crd_examples/keycloakrealmuser.yaml
@@ -19,6 +19,21 @@ spec:
     temporary: true
   requiredUserActions:
     - UPDATE_PROFILE
+  # roles and clientRoles have three states.
+  #   omitted    the operator does not manage them; Keycloak keeps what it has,
+  #              including the default-roles-<realm> mapping it assigns at creation
+  #   []         the operator manages them and removes every mapping
+  #   [a, b]     the operator manages them; the user ends up with exactly a and b
+  # Helm: write [] in values.yaml or pass --set-json 'roles=[]'. `--set roles={}`
+  # yields [""], and a {{ if .Values.roles }} guard drops [] entirely.
+  roles:
+    - offline_access
+  clientRoles:
+    - clientId: account
+      roles:
+        - view-profile
+    # No roles key: this client's mappings are left untouched.
+    - clientId: broker
   groups:
     - developers
     - /parent/child

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakclients.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakclients.yaml
@@ -648,8 +648,10 @@ spec:
                           description: ClientID is a client ID.
                           type: string
                         roles:
-                          description: Roles is a list of client roles names assigned
-                            to user.
+                          description: |-
+                            Roles is a list of client roles names assigned to user.
+                            Omit the field to leave this client's role mappings unmanaged; set it to an empty list to
+                            remove every mapping for the client.
                           items:
                             type: string
                           nullable: true
@@ -669,8 +671,10 @@ spec:
                     nullable: true
                     type: array
                   realmRoles:
-                    description: RealmRoles is a list of realm roles assigned to service
-                      account.
+                    description: |-
+                      RealmRoles is a list of realm roles assigned to service account.
+                      Omit the field to leave the service account's realm roles unmanaged; set it to an empty
+                      list to remove every realm role.
                     items:
                       type: string
                     nullable: true

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealmgroups.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealmgroups.yaml
@@ -66,8 +66,10 @@ spec:
                       description: ClientID is a client ID.
                       type: string
                     roles:
-                      description: Roles is a list of client roles names assigned
-                        to user.
+                      description: |-
+                        Roles is a list of client roles names assigned to user.
+                        Omit the field to leave this client's role mappings unmanaged; set it to an empty list to
+                        remove every mapping for the client.
                       items:
                         type: string
                       nullable: true

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml
@@ -70,8 +70,10 @@ spec:
                       description: ClientID is a client ID.
                       type: string
                     roles:
-                      description: Roles is a list of client roles names assigned
-                        to user.
+                      description: |-
+                        Roles is a list of client roles names assigned to user.
+                        Omit the field to leave this client's role mappings unmanaged; set it to an empty list to
+                        remove every mapping for the client.
                       items:
                         type: string
                       nullable: true
@@ -177,7 +179,10 @@ spec:
                 nullable: true
                 type: array
               roles:
-                description: Roles is a list of roles assigned to user.
+                description: |-
+                  Roles is a list of realm roles assigned to user.
+                  Omit the field to leave the user's realm roles unmanaged; set it to an empty list to
+                  remove every realm role.
                 items:
                   type: string
                 nullable: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -4380,7 +4380,9 @@ Each attribute can have multiple values.<br/>
         <td><b>realmRoles</b></td>
         <td>[]string</td>
         <td>
-          RealmRoles is a list of realm roles assigned to service account.<br/>
+          RealmRoles is a list of realm roles assigned to service account.
+Omit the field to leave the service account's realm roles unmanaged; set it to an empty
+list to remove every realm role.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4414,7 +4416,9 @@ Each attribute can have multiple values.<br/>
         <td><b>roles</b></td>
         <td>[]string</td>
         <td>
-          Roles is a list of client roles names assigned to user.<br/>
+          Roles is a list of client roles names assigned to user.
+Omit the field to leave this client's role mappings unmanaged; set it to an empty list to
+remove every mapping for the client.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5275,7 +5279,9 @@ RealmRef is reference to Realm custom resource.
         <td><b>roles</b></td>
         <td>[]string</td>
         <td>
-          Roles is a list of client roles names assigned to user.<br/>
+          Roles is a list of client roles names assigned to user.
+Omit the field to leave this client's role mappings unmanaged; set it to an empty list to
+remove every mapping for the client.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8253,7 +8259,9 @@ If set to full, user will be created if it does not exist, or updated if it exis
         <td><b>roles</b></td>
         <td>[]string</td>
         <td>
-          Roles is a list of roles assigned to user.<br/>
+          Roles is a list of realm roles assigned to user.
+Omit the field to leave the user's realm roles unmanaged; set it to an empty list to
+remove every realm role.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8324,7 +8332,9 @@ RealmRef is reference to Realm custom resource.
         <td><b>roles</b></td>
         <td>[]string</td>
         <td>
-          Roles is a list of client roles names assigned to user.<br/>
+          Roles is a list of client roles names assigned to user.
+Omit the field to leave this client's role mappings unmanaged; set it to an empty list to
+remove every mapping for the client.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/internal/controller/keycloakclient/chain/service_account.go
+++ b/internal/controller/keycloakclient/chain/service_account.go
@@ -57,10 +57,15 @@ func (h *ServiceAccount) Serve(ctx context.Context, keycloakClient *keycloakApi.
 		return fmt.Errorf("unable to sync service account realm roles: %w", err)
 	}
 
-	// Sync client roles
+	// Entries with a nil role list are not managed and never reach the map.
 	clientRoles := make(map[string][]string)
+
 	for _, v := range keycloakClient.Spec.ServiceAccount.ClientRoles {
-		clientRoles[v.ClientID] = v.Roles
+		if v.Roles == nil {
+			continue
+		}
+
+		clientRoles[v.ClientID] = *v.Roles
 	}
 
 	if err := h.syncClientRoles(ctx, realmName, saUserID, clientRoles, addOnly); err != nil {
@@ -120,9 +125,17 @@ func (h *ServiceAccount) setSuccessCondition(ctx context.Context, keycloakClient
 func (h *ServiceAccount) syncRealmRoles(
 	ctx context.Context,
 	realmName, saUserID string,
-	desiredRoleNames []string,
+	desired *[]string,
 	addOnly bool,
 ) error {
+	// nil: field omitted, not managed. Empty non-nil: managed, clears every mapping.
+	// Keycloak seeds default-roles-<realm> on the service-account user at creation.
+	if desired == nil {
+		return nil
+	}
+
+	desiredRoleNames := *desired
+
 	// Get current realm role mappings
 	currentRoles, _, err := h.kClient.Users.GetUserRealmRoleMappings(ctx, realmName, saUserID)
 	if err != nil {

--- a/internal/controller/keycloakclient/chain/service_account_test.go
+++ b/internal/controller/keycloakclient/chain/service_account_test.go
@@ -32,6 +32,31 @@ func TestServiceAccount_Serve(t *testing.T) {
 		expectedError  string
 	}{
 		{
+			// No role-mapping expectations on the mocks: any Keycloak read fails this case.
+			name: "unmanaged - omitted realm roles and role-less client entries are left alone",
+			keycloakClient: &keycloakApi.KeycloakClient{
+				Spec: keycloakApi.KeycloakClientSpec{
+					ClientId: "test-client-id",
+					ServiceAccount: &keycloakApi.ServiceAccount{
+						Enabled:     true,
+						ClientRoles: []keycloakApi.UserClientRole{{ClientID: "unmanaged-client"}},
+					},
+				},
+				Status: keycloakApi.KeycloakClientStatus{ClientID: "client-123"},
+			},
+			kClient: func(t *testing.T) *keycloakapi.KeycloakClient {
+				clientsMock := keycloakapiMocks.NewMockClientsClient(t)
+				clientsMock.On("GetServiceAccountUser", mock.Anything, "test-realm", "client-uuid").
+					Return(&keycloakapi.UserRepresentation{Id: ptr.To("sa-user-id")}, (*keycloakapi.Response)(nil), nil)
+
+				return &keycloakapi.KeycloakClient{
+					Clients: clientsMock,
+					Users:   keycloakapiMocks.NewMockUsersClient(t),
+				}
+			},
+			realmName: "test-realm",
+		},
+		{
 			name: "success - service account disabled (nil)",
 			keycloakClient: &keycloakApi.KeycloakClient{
 				ObjectMeta: metav1.ObjectMeta{
@@ -108,15 +133,15 @@ func TestServiceAccount_Serve(t *testing.T) {
 					ReconciliationStrategy: keycloakApi.ReconciliationStrategyFull,
 					ServiceAccount: &keycloakApi.ServiceAccount{
 						Enabled:    true,
-						RealmRoles: []string{"realm-role1", "realm-role2"},
+						RealmRoles: ptr.To([]string{"realm-role1", "realm-role2"}),
 						ClientRoles: []keycloakApi.UserClientRole{
 							{
 								ClientID: "client1",
-								Roles:    []string{"role1", "role2"},
+								Roles:    ptr.To([]string{"role1", "role2"}),
 							},
 							{
 								ClientID: "client2",
-								Roles:    []string{"role3"},
+								Roles:    ptr.To([]string{"role3"}),
 							},
 						},
 					},
@@ -187,11 +212,11 @@ func TestServiceAccount_Serve(t *testing.T) {
 					ReconciliationStrategy: keycloakApi.ReconciliationStrategyAddOnly,
 					ServiceAccount: &keycloakApi.ServiceAccount{
 						Enabled:    true,
-						RealmRoles: []string{"realm-role1"},
+						RealmRoles: ptr.To([]string{"realm-role1"}),
 						ClientRoles: []keycloakApi.UserClientRole{
 							{
 								ClientID: "client1",
-								Roles:    []string{"role1"},
+								Roles:    ptr.To([]string{"role1"}),
 							},
 						},
 					},
@@ -244,7 +269,7 @@ func TestServiceAccount_Serve(t *testing.T) {
 					ClientId: "test-client-id",
 					ServiceAccount: &keycloakApi.ServiceAccount{
 						Enabled:    true,
-						RealmRoles: []string{"realm-role1"},
+						RealmRoles: ptr.To([]string{"realm-role1"}),
 						Groups:     []string{"group1", "group2"},
 					},
 				},
@@ -303,7 +328,7 @@ func TestServiceAccount_Serve(t *testing.T) {
 					ClientId: "test-client-id",
 					ServiceAccount: &keycloakApi.ServiceAccount{
 						Enabled:    true,
-						RealmRoles: []string{"realm-role1"},
+						RealmRoles: ptr.To([]string{"realm-role1"}),
 						AttributesV2: map[string][]string{
 							"attr1": {"value1", "value2"},
 							"attr2": {"value3"},
@@ -355,11 +380,11 @@ func TestServiceAccount_Serve(t *testing.T) {
 					ReconciliationStrategy: keycloakApi.ReconciliationStrategyAddOnly,
 					ServiceAccount: &keycloakApi.ServiceAccount{
 						Enabled:    true,
-						RealmRoles: []string{"realm-role1", "realm-role2"},
+						RealmRoles: ptr.To([]string{"realm-role1", "realm-role2"}),
 						ClientRoles: []keycloakApi.UserClientRole{
 							{
 								ClientID: "client1",
-								Roles:    []string{"role1", "role2"},
+								Roles:    ptr.To([]string{"role1", "role2"}),
 							},
 						},
 						Groups: []string{"group1", "group2"},
@@ -442,7 +467,7 @@ func TestServiceAccount_Serve(t *testing.T) {
 					ClientId: "test-client-id",
 					ServiceAccount: &keycloakApi.ServiceAccount{
 						Enabled:    true,
-						RealmRoles: []string{"realm-role1"},
+						RealmRoles: ptr.To([]string{"realm-role1"}),
 					},
 				},
 				Status: keycloakApi.KeycloakClientStatus{
@@ -470,7 +495,7 @@ func TestServiceAccount_Serve(t *testing.T) {
 					ClientId: "test-client-id",
 					ServiceAccount: &keycloakApi.ServiceAccount{
 						Enabled:    true,
-						RealmRoles: []string{"realm-role1"},
+						RealmRoles: ptr.To([]string{"realm-role1"}),
 					},
 				},
 				Status: keycloakApi.KeycloakClientStatus{
@@ -502,7 +527,7 @@ func TestServiceAccount_Serve(t *testing.T) {
 					ClientId: "test-client-id",
 					ServiceAccount: &keycloakApi.ServiceAccount{
 						Enabled:    true,
-						RealmRoles: []string{"realm-role1"},
+						RealmRoles: ptr.To([]string{"realm-role1"}),
 						Groups:     []string{"group1"},
 					},
 				},
@@ -550,7 +575,7 @@ func TestServiceAccount_Serve(t *testing.T) {
 					ClientId: "test-client-id",
 					ServiceAccount: &keycloakApi.ServiceAccount{
 						Enabled:    true,
-						RealmRoles: []string{"realm-role1"},
+						RealmRoles: ptr.To([]string{"realm-role1"}),
 						AttributesV2: map[string][]string{
 							"attr1": {"value1"},
 						},
@@ -600,7 +625,7 @@ func TestServiceAccount_Serve(t *testing.T) {
 					ClientId: "test-client-id",
 					ServiceAccount: &keycloakApi.ServiceAccount{
 						Enabled:     true,
-						RealmRoles:  []string{"realm-role1"},
+						RealmRoles:  ptr.To([]string{"realm-role1"}),
 						ClientRoles: []keycloakApi.UserClientRole{},
 					},
 				},
@@ -633,6 +658,40 @@ func TestServiceAccount_Serve(t *testing.T) {
 			expectedError: "",
 		},
 		{
+			name: "explicit empty client role list clears that client's mappings",
+			keycloakClient: &keycloakApi.KeycloakClient{
+				Spec: keycloakApi.KeycloakClientSpec{
+					ClientId: "test-client-id",
+					ServiceAccount: &keycloakApi.ServiceAccount{
+						Enabled: true,
+						ClientRoles: []keycloakApi.UserClientRole{
+							{ClientID: "client1", Roles: ptr.To([]string{})},
+						},
+					},
+				},
+				Status: keycloakApi.KeycloakClientStatus{ClientID: "client-123"},
+			},
+			kClient: func(t *testing.T) *keycloakapi.KeycloakClient {
+				clientsMock := keycloakapiMocks.NewMockClientsClient(t)
+				usersMock := keycloakapiMocks.NewMockUsersClient(t)
+
+				clientsMock.On("GetServiceAccountUser", mock.Anything, "test-realm", "client-uuid").
+					Return(&keycloakapi.UserRepresentation{Id: ptr.To("sa-user-id")}, (*keycloakapi.Response)(nil), nil)
+				clientsMock.On("GetClientByClientID", mock.Anything, "test-realm", "client1").
+					Return(&keycloakapi.ClientRepresentation{Id: ptr.To("client1-uuid")}, (*keycloakapi.Response)(nil), nil)
+				usersMock.On("GetUserClientRoleMappings", mock.Anything, "test-realm", "sa-user-id", "client1-uuid").
+					Return([]keycloakapi.RoleRepresentation{
+						{Id: ptr.To("cr1-id"), Name: ptr.To("role1")},
+					}, (*keycloakapi.Response)(nil), nil)
+				usersMock.On("DeleteUserClientRoles", mock.Anything, "test-realm", "sa-user-id", "client1-uuid",
+					[]keycloakapi.RoleRepresentation{{Id: ptr.To("cr1-id"), Name: ptr.To("role1")}}).
+					Return((*keycloakapi.Response)(nil), nil)
+
+				return &keycloakapi.KeycloakClient{Clients: clientsMock, Users: usersMock}
+			},
+			realmName: "test-realm",
+		},
+		{
 			name: "success - empty realm roles",
 			keycloakClient: &keycloakApi.KeycloakClient{
 				ObjectMeta: metav1.ObjectMeta{
@@ -643,11 +702,11 @@ func TestServiceAccount_Serve(t *testing.T) {
 					ClientId: "test-client-id",
 					ServiceAccount: &keycloakApi.ServiceAccount{
 						Enabled:    true,
-						RealmRoles: []string{},
+						RealmRoles: ptr.To([]string{}),
 						ClientRoles: []keycloakApi.UserClientRole{
 							{
 								ClientID: "client1",
-								Roles:    []string{"role1"},
+								Roles:    ptr.To([]string{"role1"}),
 							},
 						},
 					},
@@ -717,9 +776,7 @@ func TestServiceAccount_Serve(t *testing.T) {
 						Attributes: &existingAttrs,
 					}, (*keycloakapi.Response)(nil), nil)
 
-				// syncRealmRoles: empty desired, empty current => no-op
-				usersMock.On("GetUserRealmRoleMappings", mock.Anything, "test-realm", "sa-user-id").
-					Return([]keycloakapi.RoleRepresentation{}, (*keycloakapi.Response)(nil), nil)
+				// realmRoles unset: the mappings are never read.
 
 				// setAttributes: must contain both existing and new attributes
 				usersMock.On("UpdateUser", mock.Anything, "test-realm", "sa-user-id",
@@ -756,7 +813,7 @@ func TestServiceAccount_Serve(t *testing.T) {
 					ClientId: "test-client-id",
 					ServiceAccount: &keycloakApi.ServiceAccount{
 						Enabled:    true,
-						RealmRoles: []string{"realm-role1"},
+						RealmRoles: ptr.To([]string{"realm-role1"}),
 					},
 				},
 				Status: keycloakApi.KeycloakClientStatus{

--- a/internal/controller/keycloakclient/keycloakclient_controller_integration_test.go
+++ b/internal/controller/keycloakclient/keycloakclient_controller_integration_test.go
@@ -439,11 +439,11 @@ var _ = Describe("KeycloakClient controller", Ordered, func() {
 				Secret: secretref.GenerateSecretRef(clientSecret.Name, "secretKey"),
 				ServiceAccount: &keycloakApi.ServiceAccount{
 					Enabled:    true,
-					RealmRoles: []string{"default-roles-" + KeycloakRealmCR},
+					RealmRoles: ptr.To([]string{"default-roles-" + KeycloakRealmCR}),
 					ClientRoles: []keycloakApi.UserClientRole{
 						{
 							ClientID: "account",
-							Roles:    []string{"view-profile"},
+							Roles:    ptr.To([]string{"view-profile"}),
 						},
 					},
 					Groups: []string{"test-sa-group"},

--- a/internal/controller/keycloakrealmgroup/chain/sync_client_roles.go
+++ b/internal/controller/keycloakrealmgroup/chain/sync_client_roles.go
@@ -33,9 +33,19 @@ func (h *SyncClientRoles) Serve(
 		return fmt.Errorf("unable to get role mappings for group %s: %w", groupID, err)
 	}
 
+	// claimedClientRoles drives the sync; mentionedClients gates the sweep below. An entry with a
+	// nil role list lands only in mentionedClients: not synced, not swept.
 	claimedClientRoles := make(map[string][]string, len(group.Spec.ClientRoles))
+	mentionedClients := make(map[string]struct{}, len(group.Spec.ClientRoles))
+
 	for _, cr := range group.Spec.ClientRoles {
-		claimedClientRoles[cr.ClientID] = cr.Roles
+		mentionedClients[cr.ClientID] = struct{}{}
+
+		if cr.Roles == nil {
+			continue
+		}
+
+		claimedClientRoles[cr.ClientID] = *cr.Roles
 	}
 
 	// Extract client mappings to avoid redundant API calls in syncOneClientRoles.
@@ -53,7 +63,7 @@ func (h *SyncClientRoles) Serve(
 	// Remove roles for clients no longer in spec.
 	if roleMappings != nil && roleMappings.ClientMappings != nil {
 		for clientName, clientMapping := range *roleMappings.ClientMappings {
-			if _, claimed := claimedClientRoles[clientName]; claimed {
+			if _, mentioned := mentionedClients[clientName]; mentioned {
 				continue
 			}
 

--- a/internal/controller/keycloakrealmgroup/chain/sync_client_roles_test.go
+++ b/internal/controller/keycloakrealmgroup/chain/sync_client_roles_test.go
@@ -30,7 +30,7 @@ func TestSyncClientRoles_Serve_AddRoles(t *testing.T) {
 
 	group := &keycloakApi.KeycloakRealmGroup{}
 	group.Spec.ClientRoles = []keycloakApi.UserClientRole{
-		{ClientID: "test-client", Roles: []string{"role1", "role2"}},
+		{ClientID: "test-client", Roles: ptr.To([]string{"role1", "role2"})},
 	}
 
 	// Empty role mappings (no clients have roles yet)
@@ -92,7 +92,7 @@ func TestSyncClientRoles_Serve_RemoveRoles(t *testing.T) {
 
 	group := &keycloakApi.KeycloakRealmGroup{}
 	group.Spec.ClientRoles = []keycloakApi.UserClientRole{
-		{ClientID: "test-client", Roles: []string{}}, // Empty - remove all
+		{ClientID: "test-client", Roles: ptr.To([]string{})}, // Empty - remove all
 	}
 
 	// Role mappings with existing client roles
@@ -170,6 +170,48 @@ func TestSyncClientRoles_Serve_RemoveUnclaimedClient(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// A client named with no role list is neither synced nor swept.
+func TestSyncClientRoles_Serve_MentionedClientWithoutRolesIsLeftAlone(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+	mockClients := mocks.NewMockClientsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{
+		Groups:  mockGroups,
+		Clients: mockClients,
+	}
+
+	groupCtx := &GroupContext{
+		RealmName: "test-realm",
+		GroupID:   "group-123",
+	}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.ClientRoles = []keycloakApi.UserClientRole{
+		{ClientID: "unmanaged-client"},
+	}
+
+	clientMappings := map[string]keycloakapi.ClientMappingsRepresentation{
+		"unmanaged-client": {
+			Id:     ptr.To("unmanaged-client-uuid"),
+			Client: ptr.To("unmanaged-client"),
+			Mappings: &[]keycloakapi.RoleRepresentation{
+				{Id: ptr.To("kept-role-id"), Name: ptr.To("kept-role")},
+			},
+		},
+	}
+	mockGroups.EXPECT().GetRoleMappings(
+		context.Background(), "test-realm", "group-123",
+	).Return(&keycloakapi.MappingsRepresentation{
+		ClientMappings: &clientMappings,
+	}, nil, nil)
+
+	// No DeleteClientRoleMappings expectation: any delete fails this test.
+
+	h := NewSyncClientRoles()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	require.NoError(t, err)
+}
+
 func TestSyncClientRoles_Serve_MultipleClients(t *testing.T) {
 	mockGroups := mocks.NewMockGroupsClient(t)
 	mockClients := mocks.NewMockClientsClient(t)
@@ -186,8 +228,8 @@ func TestSyncClientRoles_Serve_MultipleClients(t *testing.T) {
 
 	group := &keycloakApi.KeycloakRealmGroup{}
 	group.Spec.ClientRoles = []keycloakApi.UserClientRole{
-		{ClientID: "client1", Roles: []string{"role1"}},
-		{ClientID: "client2", Roles: []string{"role2"}},
+		{ClientID: "client1", Roles: ptr.To([]string{"role1"})},
+		{ClientID: "client2", Roles: ptr.To([]string{"role2"})},
 	}
 
 	// Empty role mappings
@@ -258,7 +300,7 @@ func TestSyncClientRoles_Serve_ErrorGettingRoleMappings(t *testing.T) {
 
 	group := &keycloakApi.KeycloakRealmGroup{}
 	group.Spec.ClientRoles = []keycloakApi.UserClientRole{
-		{ClientID: "test-client", Roles: []string{"role1"}},
+		{ClientID: "test-client", Roles: ptr.To([]string{"role1"})},
 	}
 
 	mockGroups.EXPECT().GetRoleMappings(
@@ -286,7 +328,7 @@ func TestSyncClientRoles_Serve_ErrorResolvingClientUUID(t *testing.T) {
 
 	group := &keycloakApi.KeycloakRealmGroup{}
 	group.Spec.ClientRoles = []keycloakApi.UserClientRole{
-		{ClientID: "nonexistent-client", Roles: []string{"role1"}},
+		{ClientID: "nonexistent-client", Roles: ptr.To([]string{"role1"})},
 	}
 
 	mockGroups.EXPECT().GetRoleMappings(
@@ -320,7 +362,7 @@ func TestSyncClientRoles_Serve_ErrorGettingClientRoleMappings(t *testing.T) {
 
 	group := &keycloakApi.KeycloakRealmGroup{}
 	group.Spec.ClientRoles = []keycloakApi.UserClientRole{
-		{ClientID: "test-client", Roles: []string{"role1"}},
+		{ClientID: "test-client", Roles: ptr.To([]string{"role1"})},
 	}
 
 	mockGroups.EXPECT().GetRoleMappings(
@@ -361,7 +403,7 @@ func TestSyncClientRoles_Serve_ErrorGettingClientRole(t *testing.T) {
 
 	group := &keycloakApi.KeycloakRealmGroup{}
 	group.Spec.ClientRoles = []keycloakApi.UserClientRole{
-		{ClientID: "test-client", Roles: []string{"nonexistent-role"}},
+		{ClientID: "test-client", Roles: ptr.To([]string{"nonexistent-role"})},
 	}
 
 	mockGroups.EXPECT().GetRoleMappings(
@@ -401,7 +443,7 @@ func TestSyncClientRoles_Serve_ErrorAddingClientRoleMappings(t *testing.T) {
 
 	group := &keycloakApi.KeycloakRealmGroup{}
 	group.Spec.ClientRoles = []keycloakApi.UserClientRole{
-		{ClientID: "test-client", Roles: []string{"role1"}},
+		{ClientID: "test-client", Roles: ptr.To([]string{"role1"})},
 	}
 
 	mockGroups.EXPECT().GetRoleMappings(
@@ -450,7 +492,7 @@ func TestSyncClientRoles_Serve_ErrorDeletingClientRoleMappings(t *testing.T) {
 
 	group := &keycloakApi.KeycloakRealmGroup{}
 	group.Spec.ClientRoles = []keycloakApi.UserClientRole{
-		{ClientID: "test-client", Roles: []string{}}, // Remove all
+		{ClientID: "test-client", Roles: ptr.To([]string{})}, // Remove all
 	}
 
 	// Role mappings with existing client roles

--- a/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller_integration_test.go
+++ b/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller_integration_test.go
@@ -10,6 +10,7 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	"github.com/epam/edp-keycloak-operator/api/common"
 	keycloakApi "github.com/epam/edp-keycloak-operator/api/v1"
@@ -456,7 +457,7 @@ var _ = Describe("KeycloakRealmGroup controller", Ordered, func() {
 				ClientRoles: []keycloakApi.UserClientRole{
 					{
 						ClientID: clientID,
-						Roles:    []string{"group-client-role-1", "group-client-role-2"},
+						Roles:    ptr.To([]string{"group-client-role-1", "group-client-role-2"}),
 					},
 				},
 			},
@@ -496,7 +497,7 @@ var _ = Describe("KeycloakRealmGroup controller", Ordered, func() {
 		updatableGroup.Spec.ClientRoles = []keycloakApi.UserClientRole{
 			{
 				ClientID: clientID,
-				Roles:    []string{"group-client-role-2", "group-client-role-3"},
+				Roles:    ptr.To([]string{"group-client-role-2", "group-client-role-3"}),
 			},
 		}
 		Expect(k8sClient.Update(ctx, updatableGroup)).Should(Succeed())

--- a/internal/controller/keycloakrealmuser/chain/sync_user_roles.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_roles.go
@@ -46,9 +46,17 @@ func (h *SyncUserRoles) Serve(
 func (h *SyncUserRoles) syncRealmRoles(
 	ctx context.Context,
 	realmName, userID string,
-	desiredRoleNames []string,
+	desired *[]string,
 	addOnly bool,
 ) error {
+	// nil: field omitted, not managed. Empty non-nil: managed, clears every mapping.
+	// Keycloak seeds default-roles-<realm> on every user at creation.
+	if desired == nil {
+		return nil
+	}
+
+	desiredRoleNames := *desired
+
 	currentRoles, _, err := h.kClient.Users.GetUserRealmRoleMappings(ctx, realmName, userID)
 	if err != nil {
 		return fmt.Errorf("unable to get user realm role mappings: %w", err)
@@ -113,6 +121,14 @@ func (h *SyncUserRoles) syncClientRoles(
 	addOnly bool,
 ) error {
 	for _, cr := range clientRoles {
+		// Unmanaged entry: skip before the client lookup. A stale clientId here must not fail
+		// the reconcile.
+		if cr.Roles == nil {
+			continue
+		}
+
+		desiredRoleNames := *cr.Roles
+
 		clients, _, err := h.kClient.Clients.GetClients(ctx, realmName, &keycloakapi.GetClientsParams{ClientId: &cr.ClientID})
 		if err != nil {
 			return fmt.Errorf("unable to get client %q: %w", cr.ClientID, err)
@@ -140,7 +156,7 @@ func (h *SyncUserRoles) syncClientRoles(
 		// Add missing roles
 		var toAdd []keycloakapi.RoleRepresentation
 
-		for _, roleName := range cr.Roles {
+		for _, roleName := range desiredRoleNames {
 			if _, exists := currentByName[roleName]; exists {
 				continue
 			}
@@ -167,7 +183,7 @@ func (h *SyncUserRoles) syncClientRoles(
 		var toRemove []keycloakapi.RoleRepresentation
 
 		for _, r := range currentRoles {
-			if r.Name != nil && !slices.Contains(cr.Roles, *r.Name) {
+			if r.Name != nil && !slices.Contains(desiredRoleNames, *r.Name) {
 				toRemove = append(toRemove, r)
 			}
 		}

--- a/internal/controller/keycloakrealmuser/chain/sync_user_roles_test.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_roles_test.go
@@ -33,7 +33,7 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
 				Spec: keycloakApi.KeycloakRealmUserSpec{
-					Roles: []string{"role1", "role2"},
+					Roles: ptr.To([]string{"role1", "role2"}),
 				},
 			},
 			userCtx: &UserContext{UserID: "user-1"},
@@ -56,7 +56,7 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
 				Spec: keycloakApi.KeycloakRealmUserSpec{
-					Roles: []string{"role1"},
+					Roles: ptr.To([]string{"role1"}),
 				},
 			},
 			userCtx: &UserContext{UserID: "user-2"},
@@ -78,7 +78,7 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
 				Spec: keycloakApi.KeycloakRealmUserSpec{
-					Roles:                  []string{"role1"},
+					Roles:                  ptr.To([]string{"role1"}),
 					ReconciliationStrategy: keycloakApi.ReconciliationStrategyAddOnly,
 				},
 			},
@@ -103,15 +103,12 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
 				Spec: keycloakApi.KeycloakRealmUserSpec{
 					ClientRoles: []keycloakApi.UserClientRole{
-						{ClientID: "client1", Roles: []string{"crole1"}},
+						{ClientID: "client1", Roles: ptr.To([]string{"crole1"})},
 					},
 				},
 			},
 			userCtx: &UserContext{UserID: "user-4"},
 			mockSetup: func(u *v2mocks.MockUsersClient, r *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
-				// no realm roles
-				u.EXPECT().GetUserRealmRoleMappings(context.Background(), "test-realm", "user-4").
-					Return(nil, nil, nil)
 				// client lookup
 				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakapi.GetClientsParams{ClientId: ptr.To("client1")}).
 					Return([]keycloakapi.ClientRepresentation{{Id: ptr.To("client-uuid-1")}}, nil, nil)
@@ -135,14 +132,12 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
 				Spec: keycloakApi.KeycloakRealmUserSpec{
 					ClientRoles: []keycloakApi.UserClientRole{
-						{ClientID: "client1", Roles: []string{"crole1"}},
+						{ClientID: "client1", Roles: ptr.To([]string{"crole1"})},
 					},
 				},
 			},
 			userCtx: &UserContext{UserID: "user-5"},
 			mockSetup: func(u *v2mocks.MockUsersClient, r *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
-				u.EXPECT().GetUserRealmRoleMappings(context.Background(), "test-realm", "user-5").
-					Return(nil, nil, nil)
 				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakapi.GetClientsParams{ClientId: ptr.To("client1")}).
 					Return([]keycloakapi.ClientRepresentation{{Id: ptr.To("client-uuid-1")}}, nil, nil)
 				u.EXPECT().GetUserClientRoleMappings(context.Background(), "test-realm", "user-5", "client-uuid-1").
@@ -162,7 +157,7 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
 				Spec: keycloakApi.KeycloakRealmUserSpec{
-					Roles: []string{"role1"},
+					Roles: ptr.To([]string{"role1"}),
 				},
 			},
 			userCtx: &UserContext{UserID: "user-err"},
@@ -180,7 +175,7 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
 				Spec: keycloakApi.KeycloakRealmUserSpec{
-					Roles: []string{"missing-role"},
+					Roles: ptr.To([]string{"missing-role"}),
 				},
 			},
 			userCtx: &UserContext{UserID: "user-err2"},
@@ -201,14 +196,12 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
 				Spec: keycloakApi.KeycloakRealmUserSpec{
 					ClientRoles: []keycloakApi.UserClientRole{
-						{ClientID: "no-such-client", Roles: []string{"role1"}},
+						{ClientID: "no-such-client", Roles: ptr.To([]string{"role1"})},
 					},
 				},
 			},
 			userCtx: &UserContext{UserID: "user-err3"},
 			mockSetup: func(u *v2mocks.MockUsersClient, r *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
-				u.EXPECT().GetUserRealmRoleMappings(context.Background(), "test-realm", "user-err3").
-					Return(nil, nil, nil)
 				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakapi.GetClientsParams{ClientId: ptr.To("no-such-client")}).
 					Return(nil, nil, nil)
 			},
@@ -216,6 +209,74 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to sync user client roles")
 			},
+		},
+		{
+			// No expectations on the mocks: any Keycloak call fails this case.
+			name: "unmanaged - omitted realm roles leave every mapping alone",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{},
+			},
+			userCtx:   &UserContext{UserID: "user-unmanaged"},
+			mockSetup: func(_ *v2mocks.MockUsersClient, _ *v2mocks.MockRolesClient, _ *v2mocks.MockClientsClient) {},
+			wantErr:   require.NoError,
+		},
+		{
+			name: "explicit empty realm roles remove every mapping",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec: keycloakApi.KeycloakRealmUserSpec{
+					Roles: ptr.To([]string{}),
+				},
+			},
+			userCtx: &UserContext{UserID: "user-clear"},
+			mockSetup: func(u *v2mocks.MockUsersClient, _ *v2mocks.MockRolesClient, _ *v2mocks.MockClientsClient) {
+				u.EXPECT().GetUserRealmRoleMappings(context.Background(), "test-realm", "user-clear").
+					Return([]keycloakapi.RoleRepresentation{
+						{Id: ptr.To("d1"), Name: ptr.To("default-roles-test-realm")},
+					}, nil, nil)
+				u.EXPECT().DeleteUserRealmRoles(context.Background(), "test-realm", "user-clear",
+					[]keycloakapi.RoleRepresentation{{Id: ptr.To("d1"), Name: ptr.To("default-roles-test-realm")}}).
+					Return(nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "explicit empty client role list clears that client's mappings",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec: keycloakApi.KeycloakRealmUserSpec{
+					ClientRoles: []keycloakApi.UserClientRole{
+						{ClientID: "client1", Roles: ptr.To([]string{})},
+					},
+				},
+			},
+			userCtx: &UserContext{UserID: "user-clear-client"},
+			mockSetup: func(u *v2mocks.MockUsersClient, _ *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
+				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakapi.GetClientsParams{ClientId: ptr.To("client1")}).
+					Return([]keycloakapi.ClientRepresentation{{Id: ptr.To("client-uuid-1")}}, nil, nil)
+				u.EXPECT().GetUserClientRoleMappings(context.Background(), "test-realm", "user-clear-client", "client-uuid-1").
+					Return([]keycloakapi.RoleRepresentation{{Id: ptr.To("crid1"), Name: ptr.To("crole1")}}, nil, nil)
+				u.EXPECT().DeleteUserClientRoles(context.Background(), "test-realm", "user-clear-client", "client-uuid-1",
+					[]keycloakapi.RoleRepresentation{{Id: ptr.To("crid1"), Name: ptr.To("crole1")}}).
+					Return(nil, nil)
+			},
+			wantErr: require.NoError,
+		},
+		{
+			// The stale clientId is never resolved: the entry is skipped before the lookup.
+			name: "unmanaged - client entry without a role list is skipped before the client lookup",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec: keycloakApi.KeycloakRealmUserSpec{
+					ClientRoles: []keycloakApi.UserClientRole{
+						{ClientID: "no-such-client"},
+					},
+				},
+			},
+			userCtx:   &UserContext{UserID: "user-unmanaged-client"},
+			mockSetup: func(_ *v2mocks.MockUsersClient, _ *v2mocks.MockRolesClient, _ *v2mocks.MockClientsClient) {},
+			wantErr:   require.NoError,
 		},
 	}
 

--- a/internal/controller/keycloakrealmuser/keycloakrealmuser_controller_integration_test.go
+++ b/internal/controller/keycloakrealmuser/keycloakrealmuser_controller_integration_test.go
@@ -119,23 +119,23 @@ var _ = Describe("KeycloakRealmUser controller", Ordered, func() {
 				RequiredUserActions: []string{
 					"VERIFY_EMAIL",
 				},
-				Roles: []string{
+				Roles: ptr.To([]string{
 					"offline_access",
 					"uma_authorization",
-				},
+				}),
 				ClientRoles: []keycloakApi.UserClientRole{
 					{
 						ClientID: "account",
-						Roles: []string{
+						Roles: ptr.To([]string{
 							"view-profile",
 							"view-groups",
-						},
+						}),
 					},
 					{
 						ClientID: "realm-management",
-						Roles: []string{
+						Roles: ptr.To([]string{
 							"create-client",
-						},
+						}),
 					},
 				},
 				Groups: []string{
@@ -376,15 +376,15 @@ var _ = Describe("KeycloakRealmUser controller", Ordered, func() {
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: userCR}, user)).Should(Succeed())
 
 		By("Updating KeycloakRealmUser roles")
-		user.Spec.Roles = []string{
+		user.Spec.Roles = ptr.To([]string{
 			"offline_access",
-		}
+		})
 		user.Spec.ClientRoles = []keycloakApi.UserClientRole{
 			{
 				ClientID: "account",
-				Roles: []string{
+				Roles: ptr.To([]string{
 					"view-profile",
-				},
+				}),
 			},
 		}
 
@@ -582,7 +582,7 @@ var _ = Describe("KeycloakRealmUser controller", Ordered, func() {
 					Name: KeycloakRealmCR,
 				},
 				Username: "test-user-invalid-role",
-				Roles:    []string{"invalid-role"},
+				Roles:    ptr.To([]string{"invalid-role"}),
 			},
 		}
 		Expect(k8sClient.Create(ctx, user)).Should(Succeed())
@@ -643,6 +643,72 @@ var _ = Describe("KeycloakRealmUser controller", Ordered, func() {
 			deletedUser := &keycloakApi.KeycloakRealmUser{}
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: user.Name, Namespace: ns}, deletedUser)
 			g.Expect(k8sErrors.IsNotFound(err)).Should(BeTrue())
+		}, timeout, interval).Should(Succeed())
+	})
+})
+
+// Under the default full strategy an omitted spec.roles must revoke nothing. The user is created
+// outside the operator, so the default-roles-<realm> mapping under test is Keycloak's own.
+var _ = Describe("KeycloakRealmUser unmanaged roles", Ordered, func() {
+	const (
+		crName   = "unmanaged-roles-user"
+		username = "unmanaged-roles-user"
+	)
+
+	defaultRole := "default-roles-" + KeycloakRealmCR
+
+	realmRoleNames := func() []string {
+		found, _, err := keycloakApiClient.Users.FindUserByUsername(ctx, KeycloakRealmCR, username)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(found).ShouldNot(BeNil())
+
+		mappings, _, err := keycloakApiClient.Users.GetUserRealmRoleMappings(ctx, KeycloakRealmCR, *found.Id)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		names := make([]string, 0, len(mappings))
+		for _, r := range mappings {
+			names = append(names, ptr.Deref(r.Name, ""))
+		}
+
+		return names
+	}
+
+	It("Should keep the Keycloak default role when spec.roles is omitted", func() {
+		_, err := keycloakApiClient.Users.CreateUser(ctx, KeycloakRealmCR, keycloakapi.UserRepresentation{
+			Username: ptr.To(username),
+			Enabled:  ptr.To(true),
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(realmRoleNames()).To(ContainElement(defaultRole), "Keycloak must seed the default role")
+
+		Expect(k8sClient.Create(ctx, &keycloakApi.KeycloakRealmUser{
+			ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: ns},
+			Spec: keycloakApi.KeycloakRealmUserSpec{
+				RealmRef:     common.RealmRef{Kind: keycloakApi.KeycloakRealmKind, Name: KeycloakRealmCR},
+				Username:     username,
+				Enabled:      true,
+				KeepResource: true,
+			},
+		})).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			got := &keycloakApi.KeycloakRealmUser{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, got)).Should(Succeed())
+			g.Expect(got.Status.Value).Should(Equal(common.StatusOK))
+		}, timeout, interval).Should(Succeed())
+
+		Expect(realmRoleNames()).To(ContainElement(defaultRole),
+			"omitting spec.roles must not revoke the role Keycloak assigned")
+	})
+
+	It("Should remove every realm role when spec.roles is an explicit empty list", func() {
+		cr := &keycloakApi.KeycloakRealmUser{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).Should(Succeed())
+		cr.Spec.Roles = ptr.To([]string{})
+		Expect(k8sClient.Update(ctx, cr)).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(realmRoleNames()).ShouldNot(ContainElement(defaultRole))
 		}, timeout, interval).Should(Succeed())
 	})
 })


### PR DESCRIPTION
Under the default `reconciliationStrategy: full`, a resource that never sets `spec.roles` had every realm role removed from the Keycloak user. The nil list read as "the desired set is empty", so the removal pass deleted everything it found, `default-roles-<realm>` included, and with it `offline_access`, `uma_authorization` and the `account` client roles Keycloak assigns at user creation. `spec.clientRoles` entries without a `roles` list did the same to that client's mappings, as did `spec.serviceAccount.realmRoles` on KeycloakClient.

Neither strategy was a way out: `addOnly` skips group removal entirely, so a consumer that only wants to manage group membership could not revoke a group.

An omitted or null list now means the resource does not manage those mappings and Keycloak is left alone. `roles: []` still means "no roles" and clears them all.

- `KeycloakRealmUser.Spec.Roles`, `UserClientRole.Roles` and `ServiceAccount.RealmRoles` become `*[]string`, so the type carries the distinction instead of a doc comment. Kubernetes API conventions call for a pointer exactly when unset and empty must differ. The CRD schemas are unchanged; only the descriptions move.
- `UserClientRole` is embedded by KeycloakRealmUser, KeycloakClient service accounts and KeycloakRealmGroup. All three honour the same rule, so one type does not mean two things depending on its embedder.
- the group sweep keys off "client mentioned in spec", not "client has a role list". Keying it off the latter deleted the mappings of an unmanaged entry through the unclaimed-client path, undoing the nil rule in the same function that implements it.
- an unmanaged `clientRoles` entry is skipped before the client lookup, so a stale `clientId` on an entry the resource does not manage no longer fails the reconcile.

The KeycloakRealmUser and KeycloakClient examples now show all three states. Note for chart authors: write `[]` in values.yaml or pass `--set-json 'roles=[]'`. `--set roles={}` yields `[""]`, and a `{{ if .Values.roles }}` guard drops `[]`.

Anyone who omitted `roles` to strip a user down to nothing must write `roles: []` instead.

Closes #371
