### PR TITLE
Fix/unmanaged groups and group realm roles

### DIFF
--- a/api/v1/keycloakrealmgroup_types.go
+++ b/api/v1/keycloakrealmgroup_types.go
@@ -20,6 +20,8 @@ type KeycloakRealmGroupSpec struct {
 	RealmRef common.RealmRef `json:"realmRef"`
 
 	// Path is a group path.
+	// Read-only. Keycloak derives the path from the group name and its parent, and ignores
+	// this field on both create and update.
 	// +optional
 	Path string `json:"path,omitempty"`
 

--- a/api/v1/keycloakrealmgroup_types.go
+++ b/api/v1/keycloakrealmgroup_types.go
@@ -34,9 +34,11 @@ type KeycloakRealmGroupSpec struct {
 	Access map[string]bool `json:"access,omitempty"`
 
 	// RealmRoles is a list of realm roles assigned to group.
+	// Omit the field to leave the group's realm roles unmanaged; set it to an empty list to
+	// remove every realm role.
 	// +nullable
 	// +optional
-	RealmRoles []string `json:"realmRoles,omitempty"`
+	RealmRoles *[]string `json:"realmRoles,omitempty"`
 
 	// SubGroups is a list of subgroups assigned to group.
 	// Deprecated: This filed doesn't allow to fully support child groups. Use ParentGroup approach instead.

--- a/api/v1/keycloakrealmuser_types.go
+++ b/api/v1/keycloakrealmuser_types.go
@@ -56,6 +56,8 @@ type KeycloakRealmUserSpec struct {
 	// Each entry is either a plain group name (e.g. "developers") or a slash-separated
 	// path (e.g. "/developers", "/parent/child"), where each segment represents a level
 	// in the group hierarchy.
+	// A plain name resolves against top-level groups only, because the Keycloak name search
+	// returns the top-level ancestor of a match. Use a path to reference a nested group.
 	// Omit the field to leave the user's group memberships unmanaged; set it to an empty list
 	// to remove every membership.
 	// +nullable

--- a/api/v1/keycloakrealmuser_types.go
+++ b/api/v1/keycloakrealmuser_types.go
@@ -56,10 +56,12 @@ type KeycloakRealmUserSpec struct {
 	// Each entry is either a plain group name (e.g. "developers") or a slash-separated
 	// path (e.g. "/developers", "/parent/child"), where each segment represents a level
 	// in the group hierarchy.
+	// Omit the field to leave the user's group memberships unmanaged; set it to an empty list
+	// to remove every membership.
 	// +nullable
 	// +optional
 	// +kubebuilder:example={"developers","/parent/child"}
-	Groups []string `json:"groups,omitempty"`
+	Groups *[]string `json:"groups,omitempty"`
 
 	// Attributes is a map of user attributes.
 	// Deprecated: Use AttributesV2 instead.

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -990,8 +990,12 @@ func (in *KeycloakRealmGroupSpec) DeepCopyInto(out *KeycloakRealmGroupSpec) {
 	}
 	if in.RealmRoles != nil {
 		in, out := &in.RealmRoles, &out.RealmRoles
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
+		}
 	}
 	if in.SubGroups != nil {
 		in, out := &in.SubGroups, &out.SubGroups
@@ -1617,8 +1621,12 @@ func (in *KeycloakRealmUserSpec) DeepCopyInto(out *KeycloakRealmUserSpec) {
 	}
 	if in.Groups != nil {
 		in, out := &in.Groups, &out.Groups
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
+		}
 	}
 	if in.Attributes != nil {
 		in, out := &in.Attributes, &out.Attributes

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealmgroups.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealmgroups.yaml
@@ -119,7 +119,10 @@ spec:
                 - name
                 type: object
               realmRoles:
-                description: RealmRoles is a list of realm roles assigned to group.
+                description: |-
+                  RealmRoles is a list of realm roles assigned to group.
+                  Omit the field to leave the group's realm roles unmanaged; set it to an empty list to
+                  remove every realm role.
                 items:
                   type: string
                 nullable: true

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealmgroups.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealmgroups.yaml
@@ -100,7 +100,10 @@ spec:
                 - name
                 type: object
               path:
-                description: Path is a group path.
+                description: |-
+                  Path is a group path.
+                  Read-only. Keycloak derives the path from the group name and its parent, and ignores
+                  this field on both create and update.
                 type: string
               realmRef:
                 description: RealmRef is reference to Realm custom resource.

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml
@@ -101,6 +101,8 @@ spec:
                   Each entry is either a plain group name (e.g. "developers") or a slash-separated
                   path (e.g. "/developers", "/parent/child"), where each segment represents a level
                   in the group hierarchy.
+                  A plain name resolves against top-level groups only, because the Keycloak name search
+                  returns the top-level ancestor of a match. Use a path to reference a nested group.
                   Omit the field to leave the user's group memberships unmanaged; set it to an empty list
                   to remove every membership.
                 example:

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml
@@ -101,6 +101,8 @@ spec:
                   Each entry is either a plain group name (e.g. "developers") or a slash-separated
                   path (e.g. "/developers", "/parent/child"), where each segment represents a level
                   in the group hierarchy.
+                  Omit the field to leave the user's group memberships unmanaged; set it to an empty list
+                  to remove every membership.
                 example:
                 - developers
                 - /parent/child

--- a/deploy-templates/_crd_examples/keycloakrealmgroup.yaml
+++ b/deploy-templates/_crd_examples/keycloakrealmgroup.yaml
@@ -7,6 +7,15 @@ spec:
     name: keycloakrealm-sample
     kind: KeycloakRealm
   name: ArgoCDAdmins
+  # realmRoles has three states. KeycloakRealmGroup has no reconciliationStrategy,
+  # so omitting the field is the only way to leave the group's realm roles alone.
+  #   omitted    the operator does not manage them; Keycloak keeps what it has
+  #   []         the operator manages them and removes every mapping
+  #   [a, b]     the operator manages them; the group ends up with exactly a and b
+  # Helm: write [] in values.yaml or pass --set-json 'realmRoles=[]'.
+  # `--set realmRoles={}` yields [""], and a {{ if .Values.realmRoles }} guard drops [].
+  realmRoles:
+    - argocd-admin
 ---
 # Example of a child group using parentGroup
 apiVersion: v1.edp.epam.com/v1

--- a/deploy-templates/_crd_examples/keycloakrealmuser.yaml
+++ b/deploy-templates/_crd_examples/keycloakrealmuser.yaml
@@ -19,7 +19,7 @@ spec:
     temporary: true
   requiredUserActions:
     - UPDATE_PROFILE
-  # roles and clientRoles have three states.
+  # roles, clientRoles and groups have three states.
   #   omitted    the operator does not manage them; Keycloak keeps what it has,
   #              including the default-roles-<realm> mapping it assigns at creation
   #   []         the operator manages them and removes every mapping

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealmgroups.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealmgroups.yaml
@@ -119,7 +119,10 @@ spec:
                 - name
                 type: object
               realmRoles:
-                description: RealmRoles is a list of realm roles assigned to group.
+                description: |-
+                  RealmRoles is a list of realm roles assigned to group.
+                  Omit the field to leave the group's realm roles unmanaged; set it to an empty list to
+                  remove every realm role.
                 items:
                   type: string
                 nullable: true

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealmgroups.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealmgroups.yaml
@@ -100,7 +100,10 @@ spec:
                 - name
                 type: object
               path:
-                description: Path is a group path.
+                description: |-
+                  Path is a group path.
+                  Read-only. Keycloak derives the path from the group name and its parent, and ignores
+                  this field on both create and update.
                 type: string
               realmRef:
                 description: RealmRef is reference to Realm custom resource.

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml
@@ -101,6 +101,8 @@ spec:
                   Each entry is either a plain group name (e.g. "developers") or a slash-separated
                   path (e.g. "/developers", "/parent/child"), where each segment represents a level
                   in the group hierarchy.
+                  A plain name resolves against top-level groups only, because the Keycloak name search
+                  returns the top-level ancestor of a match. Use a path to reference a nested group.
                   Omit the field to leave the user's group memberships unmanaged; set it to an empty list
                   to remove every membership.
                 example:

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml
@@ -101,6 +101,8 @@ spec:
                   Each entry is either a plain group name (e.g. "developers") or a slash-separated
                   path (e.g. "/developers", "/parent/child"), where each segment represents a level
                   in the group hierarchy.
+                  Omit the field to leave the user's group memberships unmanaged; set it to an empty list
+                  to remove every membership.
                 example:
                 - developers
                 - /parent/child

--- a/docs/api.md
+++ b/docs/api.md
@@ -8199,6 +8199,8 @@ Each attribute can have multiple values.<br/>
 Each entry is either a plain group name (e.g. "developers") or a slash-separated
 path (e.g. "/developers", "/parent/child"), where each segment represents a level
 in the group hierarchy.
+A plain name resolves against top-level groups only, because the Keycloak name search
+returns the top-level ancestor of a match. Use a path to reference a nested group.
 Omit the field to leave the user's group memberships unmanaged; set it to an empty list
 to remove every membership.<br/>
         </td>

--- a/docs/api.md
+++ b/docs/api.md
@@ -5193,7 +5193,9 @@ The parent KeycloakRealmGroup must exist in the same namespace.<br/>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          Path is a group path.<br/>
+          Path is a group path.
+Read-only. Keycloak derives the path from the group name and its parent, and ignores
+this field on both create and update.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/api.md
+++ b/docs/api.md
@@ -5200,7 +5200,9 @@ The parent KeycloakRealmGroup must exist in the same namespace.<br/>
         <td><b>realmRoles</b></td>
         <td>[]string</td>
         <td>
-          RealmRoles is a list of realm roles assigned to group.<br/>
+          RealmRoles is a list of realm roles assigned to group.
+Omit the field to leave the group's realm roles unmanaged; set it to an empty list to
+remove every realm role.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -8196,7 +8198,9 @@ Each attribute can have multiple values.<br/>
           Groups is a list of groups assigned to user.
 Each entry is either a plain group name (e.g. "developers") or a slash-separated
 path (e.g. "/developers", "/parent/child"), where each segment represents a level
-in the group hierarchy.<br/>
+in the group hierarchy.
+Omit the field to leave the user's group memberships unmanaged; set it to an empty list
+to remove every membership.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/internal/controller/keycloakclient/chain/put_realm_role.go
+++ b/internal/controller/keycloakclient/chain/put_realm_role.go
@@ -100,7 +100,12 @@ func (h *PutRealmRole) putRealmRoles(ctx context.Context, keycloakClient *keyclo
 				return fmt.Errorf("error getting composite realm role %s: %w", role.Composite, err)
 			}
 
-			if _, err := h.kClient.Roles.AddRealmRoleComposites(ctx, realmName, role.Name, []keycloakapi.RoleRepresentation{*compositeRole}); err != nil {
+			composable, err := keycloakapi.RequireRealmRoleWithID(compositeRole, realmName, role.Composite)
+			if err != nil {
+				return fmt.Errorf("composite of realm role %q: %w", role.Name, err)
+			}
+
+			if _, err := h.kClient.Roles.AddRealmRoleComposites(ctx, realmName, role.Name, []keycloakapi.RoleRepresentation{composable}); err != nil {
 				return fmt.Errorf("error adding composite to realm role %s: %w", role.Name, err)
 			}
 		}

--- a/internal/controller/keycloakclient/chain/put_realm_role_test.go
+++ b/internal/controller/keycloakclient/chain/put_realm_role_test.go
@@ -34,6 +34,34 @@ func TestPutRealmRole_Serve(t *testing.T) {
 		expectedError  string
 	}{
 		{
+			name: "error - composite realm role has no id",
+			keycloakClient: &keycloakApi.KeycloakClient{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-client",
+					Namespace: "default",
+				},
+				Spec: keycloakApi.KeycloakClientSpec{
+					RealmRoles: &[]keycloakApi.RealmRole{
+						{
+							Name:      "test-role",
+							Composite: "composite-role",
+						},
+					},
+				},
+			},
+			mockSetup: func(m *keycloakapiMocks.MockRolesClient) {
+				m.On("GetRealmRole", mock.Anything, "test-realm", "test-role").
+					Return((*keycloakapi.RoleRepresentation)(nil), (*keycloakapi.Response)(nil), keycloakapi.ErrNotFound).Once()
+				m.On("CreateRealmRole", mock.Anything, "test-realm", mock.Anything).
+					Return((*keycloakapi.Response)(nil), nil)
+				// Keycloak resolves a composite by id alone, so no AddRealmRoleComposites may follow.
+				m.On("GetRealmRole", mock.Anything, "test-realm", "composite-role").
+					Return(&keycloakapi.RoleRepresentation{Name: ptr.To("composite-role")}, (*keycloakapi.Response)(nil), nil)
+			},
+			realmName:     "test-realm",
+			expectedError: `composite of realm role "test-role": realm role "composite-role" has no id`,
+		},
+		{
 			name: "success - create single realm role with composite",
 			keycloakClient: &keycloakApi.KeycloakClient{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/keycloakclient/chain/service_account.go
+++ b/internal/controller/keycloakclient/chain/service_account.go
@@ -161,7 +161,12 @@ func (h *ServiceAccount) syncRealmRoles(
 				return fmt.Errorf("unable to get realm role %s: %w", roleName, err)
 			}
 
-			toAdd = append(toAdd, *role)
+			mappable, err := keycloakapi.RequireRealmRoleWithID(role, realmName, roleName)
+			if err != nil {
+				return err
+			}
+
+			toAdd = append(toAdd, mappable)
 		}
 	}
 

--- a/internal/controller/keycloakclient/chain/service_account_test.go
+++ b/internal/controller/keycloakclient/chain/service_account_test.go
@@ -32,6 +32,40 @@ func TestServiceAccount_Serve(t *testing.T) {
 		expectedError  string
 	}{
 		{
+			name: "error - realm role has no id",
+			keycloakClient: &keycloakApi.KeycloakClient{
+				Spec: keycloakApi.KeycloakClientSpec{
+					ClientId: "test-client-id",
+					ServiceAccount: &keycloakApi.ServiceAccount{
+						Enabled:    true,
+						RealmRoles: ptr.To([]string{"realm-role1"}),
+					},
+				},
+				Status: keycloakApi.KeycloakClientStatus{ClientID: "client-123"},
+			},
+			kClient: func(t *testing.T) *keycloakapi.KeycloakClient {
+				clientsMock := keycloakapiMocks.NewMockClientsClient(t)
+				usersMock := keycloakapiMocks.NewMockUsersClient(t)
+				rolesMock := keycloakapiMocks.NewMockRolesClient(t)
+
+				clientsMock.On("GetServiceAccountUser", mock.Anything, "test-realm", "client-uuid").
+					Return(&keycloakapi.UserRepresentation{Id: ptr.To("sa-user-id")}, (*keycloakapi.Response)(nil), nil)
+				usersMock.On("GetUserRealmRoleMappings", mock.Anything, "test-realm", "sa-user-id").
+					Return([]keycloakapi.RoleRepresentation{}, (*keycloakapi.Response)(nil), nil)
+				// Keycloak matches on name and id together, so no AddUserRealmRoles may follow.
+				rolesMock.On("GetRealmRole", mock.Anything, "test-realm", "realm-role1").
+					Return(&keycloakapi.RoleRepresentation{Name: ptr.To("realm-role1")}, (*keycloakapi.Response)(nil), nil)
+
+				return &keycloakapi.KeycloakClient{
+					Clients: clientsMock,
+					Users:   usersMock,
+					Roles:   rolesMock,
+				}
+			},
+			realmName:     "test-realm",
+			expectedError: `realm role "realm-role1" has no id`,
+		},
+		{
 			// No role-mapping expectations on the mocks: any Keycloak read fails this case.
 			name: "unmanaged - omitted realm roles and role-less client entries are left alone",
 			keycloakClient: &keycloakApi.KeycloakClient{

--- a/internal/controller/keycloakclientscope/chain/create_or_update_scope.go
+++ b/internal/controller/keycloakclientscope/chain/create_or_update_scope.go
@@ -53,6 +53,9 @@ func (h *CreateOrUpdateScope) Serve(
 		}
 
 		scope.Status.ID = keycloakapi.GetResourceIDFromResponse(resp)
+		if scope.Status.ID == "" {
+			return fmt.Errorf("client scope %q created but Location header missing or empty", spec.Name)
+		}
 	} else {
 		if existingScope.Id != nil {
 			scope.Status.ID = *existingScope.Id

--- a/internal/controller/keycloakclientscope/chain/create_or_update_scope_test.go
+++ b/internal/controller/keycloakclientscope/chain/create_or_update_scope_test.go
@@ -231,6 +231,41 @@ func TestCreateOrUpdateScope_Serve_CreateError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to create client scope")
 }
 
+func TestCreateOrUpdateScope_Serve_CreateWithoutLocationHeader(t *testing.T) {
+	mockScopes := mocks.NewMockClientScopesClient(t)
+	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}
+
+	scope := &keycloakApi.KeycloakClientScope{}
+	scope.Spec.Name = testScopeName
+	scope.Spec.Protocol = testProtocolOIDC
+
+	mockScopes.EXPECT().GetClientScopes(
+		context.Background(), testRealmName,
+	).Return([]keycloakapi.ClientScopeRepresentation{}, nil, nil)
+
+	var nilAttrs map[string]string
+
+	protocol := testProtocolOIDC
+
+	// Keycloak reports the new id in the Location header only. Without it status.ID would
+	// stay empty and every later update would address an empty scope id.
+	mockScopes.EXPECT().CreateClientScope(
+		context.Background(), testRealmName,
+		keycloakapi.ClientScopeRepresentation{
+			Name:        ptr.To(testScopeName),
+			Protocol:    &protocol,
+			Description: ptr.To(""),
+			Attributes:  &nilAttrs,
+		},
+	).Return(&keycloakapi.Response{HTTPResponse: &http.Response{Header: http.Header{}}}, nil)
+
+	h := NewCreateOrUpdateScope(kClient)
+	err := h.Serve(context.Background(), scope, testRealmName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Location header missing or empty")
+	assert.Empty(t, scope.Status.ID)
+}
+
 func TestCreateOrUpdateScope_Serve_UpdateError(t *testing.T) {
 	mockScopes := mocks.NewMockClientScopesClient(t)
 	kClient := &keycloakapi.KeycloakClient{ClientScopes: mockScopes}

--- a/internal/controller/keycloakrealm/chain/users_roles.go
+++ b/internal/controller/keycloakrealm/chain/users_roles.go
@@ -73,7 +73,12 @@ func putOneRealmRoleToOneUser(ctx context.Context, realmName, username, role str
 		return fmt.Errorf("unable to get realm role: %w", err)
 	}
 
-	if _, err := kClient.Users.AddUserRealmRoles(ctx, realmName, *user.Id, []keycloakapi.RoleRepresentation{*realmRole}); err != nil {
+	mappable, err := keycloakapi.RequireRealmRoleWithID(realmRole, realmName, role)
+	if err != nil {
+		return err
+	}
+
+	if _, err := kClient.Users.AddUserRealmRoles(ctx, realmName, *user.Id, []keycloakapi.RoleRepresentation{mappable}); err != nil {
 		return fmt.Errorf("unable to add realm role to user: %w", err)
 	}
 

--- a/internal/controller/keycloakrealm/chain/users_roles_test.go
+++ b/internal/controller/keycloakrealm/chain/users_roles_test.go
@@ -103,7 +103,7 @@ func TestPutUsersRoles_ServeRequest(t *testing.T) {
 				mockUsers.EXPECT().GetUserRealmRoleMappings(mock.Anything, "test-realm", uid).
 					Return([]keycloakapi.RoleRepresentation{}, nil, nil)
 				mockRoles.EXPECT().GetRealmRole(mock.Anything, "test-realm", "role1").
-					Return(&keycloakapi.RoleRepresentation{Name: &roleName}, nil, nil)
+					Return(&keycloakapi.RoleRepresentation{Id: ptr.To("role1-id"), Name: &roleName}, nil, nil)
 				mockUsers.EXPECT().AddUserRealmRoles(mock.Anything, "test-realm", uid, mock.Anything).
 					Return(nil, nil)
 				nextHandler.EXPECT().ServeRequest(mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -193,6 +193,30 @@ func TestPutUsersRoles_ServeRequest(t *testing.T) {
 			errorContains: "unable to get realm role",
 		},
 		{
+			name: "error - GetRealmRole returns a role without an id",
+			setupRealm: func() *keycloakApi.KeycloakRealm {
+				return &keycloakApi.KeycloakRealm{
+					Spec: keycloakApi.KeycloakRealmSpec{
+						RealmName: "test-realm",
+						Users: []keycloakApi.User{
+							{Username: "user1", RealmRoles: []string{"role1"}},
+						},
+					},
+				}
+			},
+			setupMocks: func(mockUsers *v2mocks.MockUsersClient, mockRoles *v2mocks.MockRolesClient, _ *handlermocks.MockRealmHandler) {
+				mockUsers.EXPECT().FindUserByUsername(mock.Anything, "test-realm", "user1").
+					Return(&keycloakapi.UserRepresentation{Id: ptr.To(uid)}, nil, nil)
+				mockUsers.EXPECT().GetUserRealmRoleMappings(mock.Anything, "test-realm", uid).
+					Return([]keycloakapi.RoleRepresentation{}, nil, nil)
+				// Keycloak matches on name and id together, so no AddUserRealmRoles may follow.
+				mockRoles.EXPECT().GetRealmRole(mock.Anything, "test-realm", "role1").
+					Return(&keycloakapi.RoleRepresentation{Name: ptr.To(testRole1)}, nil, nil)
+			},
+			expectError:   true,
+			errorContains: `realm role "role1" has no id`,
+		},
+		{
 			name: "error - AddUserRealmRoles fails",
 			setupRealm: func() *keycloakApi.KeycloakRealm {
 				return &keycloakApi.KeycloakRealm{
@@ -211,7 +235,7 @@ func TestPutUsersRoles_ServeRequest(t *testing.T) {
 				mockUsers.EXPECT().GetUserRealmRoleMappings(mock.Anything, "test-realm", uid).
 					Return([]keycloakapi.RoleRepresentation{}, nil, nil)
 				mockRoles.EXPECT().GetRealmRole(mock.Anything, "test-realm", "role1").
-					Return(&keycloakapi.RoleRepresentation{Name: &roleName}, nil, nil)
+					Return(&keycloakapi.RoleRepresentation{Id: ptr.To("role1-id"), Name: &roleName}, nil, nil)
 				mockUsers.EXPECT().AddUserRealmRoles(mock.Anything, "test-realm", uid, mock.Anything).
 					Return(nil, errors.New("failed to add role"))
 			},
@@ -254,7 +278,7 @@ func TestPutUsersRoles_ServeRequest(t *testing.T) {
 				mockUsers.EXPECT().GetUserRealmRoleMappings(mock.Anything, "test-realm", uid).
 					Return([]keycloakapi.RoleRepresentation{}, nil, nil)
 				mockRoles.EXPECT().GetRealmRole(mock.Anything, "test-realm", "role1").
-					Return(&keycloakapi.RoleRepresentation{Name: &roleName}, nil, nil)
+					Return(&keycloakapi.RoleRepresentation{Id: ptr.To("role1-id"), Name: &roleName}, nil, nil)
 				mockUsers.EXPECT().AddUserRealmRoles(mock.Anything, "test-realm", uid, mock.Anything).
 					Return(nil, nil)
 			},

--- a/internal/controller/keycloakrealmcomponent/chain/create_or_update_component.go
+++ b/internal/controller/keycloakrealmcomponent/chain/create_or_update_component.go
@@ -90,6 +90,9 @@ func (h *CreateOrUpdateComponent) Serve(
 		}
 
 		component.Status.ID = keycloakapi.GetResourceIDFromResponse(resp)
+		if component.Status.ID == "" {
+			return fmt.Errorf("realm component %q created but Location header missing or empty", spec.Name)
+		}
 
 		log.Info("Realm component created")
 	} else {

--- a/internal/controller/keycloakrealmcomponent/chain/create_or_update_component_test.go
+++ b/internal/controller/keycloakrealmcomponent/chain/create_or_update_component_test.go
@@ -398,6 +398,35 @@ func TestCreateOrUpdateComponent_Serve_CreateError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to create realm component")
 }
 
+func TestCreateOrUpdateComponent_Serve_CreateWithoutLocationHeader(t *testing.T) {
+	mockComponents := mocks.NewMockRealmComponentsClient(t)
+	kClient := &keycloakapi.KeycloakClient{RealmComponents: mockComponents}
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+
+	component := baseComponent()
+
+	mockComponents.EXPECT().
+		FindComponentByName(context.Background(), testRealmName, testComponentName).
+		Return(nil, nil)
+
+	// Keycloak reports the new id in the Location header only. Without it status.ID would
+	// stay empty and every later update would address an empty component id.
+	mockComponents.EXPECT().
+		CreateComponent(context.Background(), testRealmName, keycloakapi.ComponentRepresentation{
+			Name:         ptr.To(testComponentName),
+			ProviderId:   ptr.To(testProviderID),
+			ProviderType: ptr.To(testProviderType),
+			Config:       ptr.To(keycloakapi.MultivaluedHashMapStringString{}),
+		}).
+		Return(&keycloakapi.Response{HTTPResponse: &http.Response{Header: http.Header{}}}, nil)
+
+	h := NewCreateOrUpdateComponent(fakeClient, kClient, &fakeSecretRefClient{})
+	err := h.Serve(context.Background(), component, testRealmName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Location header missing or empty")
+	assert.Empty(t, component.Status.ID)
+}
+
 func TestCreateOrUpdateComponent_Serve_UpdateError(t *testing.T) {
 	mockComponents := mocks.NewMockRealmComponentsClient(t)
 	kClient := &keycloakapi.KeycloakClient{RealmComponents: mockComponents}

--- a/internal/controller/keycloakrealmgroup/chain/create_or_update_group.go
+++ b/internal/controller/keycloakrealmgroup/chain/create_or_update_group.go
@@ -68,12 +68,25 @@ func (h *CreateOrUpdateGroup) Serve(
 		foundByName = existingGroup != nil
 	}
 
+	// GroupsClient guarantees a non-nil group and id on success; the generated mock is a
+	// second implementation of the same interface and does not. Resolve the id once here so
+	// the ownership check and the update branch below work on a plain string.
+	existingGroupID := ""
+
+	if existingGroup != nil {
+		if existingGroup.Id == nil {
+			return fmt.Errorf("group %q has no id", spec.Name)
+		}
+
+		existingGroupID = *existingGroup.Id
+	}
+
 	// A group found by name search (as opposed to by our own status.ID) may already be
 	// managed by a different KeycloakRealmGroup resource, e.g. another CR using the same
 	// spec.name/parentGroup combination. Adopting it would make two CRs share one Keycloak
 	// group ID and fight over its children on every reconcile. Refuse instead of adopting.
-	if foundByName && existingGroup.Id != nil {
-		owner, ownerErr := findOwnerCR(ctx, h.k8sClient, group, *existingGroup.Id)
+	if foundByName {
+		owner, ownerErr := findOwnerCR(ctx, h.k8sClient, group, existingGroupID)
 		if ownerErr != nil {
 			return fmt.Errorf("unable to check group ownership for %q: %w", spec.Name, ownerErr)
 		}
@@ -82,7 +95,7 @@ func (h *CreateOrUpdateGroup) Serve(
 			return fmt.Errorf(
 				"group %q (id %s) is already managed by KeycloakRealmGroup %s/%s; "+
 					"refusing to adopt it - check for a duplicate spec.name/parentGroup combination",
-				spec.Name, *existingGroup.Id, owner.Namespace, owner.Name,
+				spec.Name, existingGroupID, owner.Namespace, owner.Name,
 			)
 		}
 	}
@@ -108,9 +121,13 @@ func (h *CreateOrUpdateGroup) Serve(
 		}
 
 		groupCtx.GroupID = keycloakapi.GetResourceIDFromResponse(resp)
+		if groupCtx.GroupID == "" {
+			return fmt.Errorf("group %q created but Location header missing or empty", spec.Name)
+		}
+
 		log.Info("Group created", "groupID", groupCtx.GroupID)
 	} else {
-		groupCtx.GroupID = *existingGroup.Id
+		groupCtx.GroupID = existingGroupID
 		existingGroup.Name = &spec.Name
 		existingGroup.Description = &spec.Description
 		existingGroup.Path = &spec.Path

--- a/internal/controller/keycloakrealmgroup/chain/create_or_update_group.go
+++ b/internal/controller/keycloakrealmgroup/chain/create_or_update_group.go
@@ -68,9 +68,8 @@ func (h *CreateOrUpdateGroup) Serve(
 		foundByName = existingGroup != nil
 	}
 
-	// GroupsClient guarantees a non-nil group and id on success; the generated mock is a
-	// second implementation of the same interface and does not. Resolve the id once here so
-	// the ownership check and the update branch below work on a plain string.
+	// GroupsClient returns a non-nil id on success. Guard anyway, and resolve the id once
+	// so the ownership check and the update branch below work on a plain string.
 	existingGroupID := ""
 
 	if existingGroup != nil {

--- a/internal/controller/keycloakrealmgroup/chain/create_or_update_group_test.go
+++ b/internal/controller/keycloakrealmgroup/chain/create_or_update_group_test.go
@@ -346,6 +346,79 @@ func TestCreateOrUpdateGroup_Serve_RenameByID(t *testing.T) {
 	assert.Equal(t, "existing-id", groupCtx.GroupID)
 }
 
+func TestCreateOrUpdateGroup_Serve_ExistingGroupWithoutID(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+	groupCtx := &GroupContext{RealmName: "test-realm", GroupID: "existing-id"}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.Name = testGroupName
+
+	mockGroups.EXPECT().GetGroup(
+		context.Background(), "test-realm", "existing-id",
+	).Return(&keycloakapi.GroupRepresentation{Name: ptr.To(testGroupName)}, nil, nil)
+
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.ErrorContains(t, err, "has no id")
+}
+
+func TestCreateOrUpdateGroup_Serve_GroupFoundByNameWithoutID(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+	groupCtx := &GroupContext{RealmName: "test-realm"}
+
+	group := &keycloakApi.KeycloakRealmGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: testCRNameA, Namespace: testNamespace},
+	}
+	group.Spec.Name = testGroupName
+
+	// The ownership check and the update both need the id, so neither may run.
+	mockGroups.EXPECT().FindGroupByName(
+		context.Background(), "test-realm", testGroupName,
+	).Return(&keycloakapi.GroupRepresentation{Name: ptr.To(testGroupName)}, nil, nil)
+
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.ErrorContains(t, err, "has no id")
+	assert.Empty(t, groupCtx.GroupID)
+}
+
+func TestCreateOrUpdateGroup_Serve_CreateWithoutLocationHeader(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+	groupCtx := &GroupContext{RealmName: "test-realm"}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.Name = testGroupName
+	group.Spec.Path = testGroupPath
+	group.Spec.Attributes = map[string][]string{"key": {"val"}}
+
+	mockGroups.EXPECT().FindGroupByName(
+		context.Background(), "test-realm", testGroupName,
+	).Return(nil, nil, keycloakapi.ErrNotFound)
+
+	// Keycloak reports the new id in the Location header only. Without it the chain would
+	// carry an empty group id into every later handler.
+	mockGroups.EXPECT().CreateGroup(
+		context.Background(), "test-realm",
+		keycloakapi.GroupRepresentation{
+			Name:        ptr.To(testGroupName),
+			Description: ptr.To(""),
+			Path:        ptr.To(testGroupPath),
+			Attributes:  &map[string][]string{"key": {"val"}},
+		},
+	).Return(&keycloakapi.Response{HTTPResponse: &http.Response{Header: http.Header{}}}, nil)
+
+	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.ErrorContains(t, err, "Location header missing or empty")
+	assert.Empty(t, groupCtx.GroupID)
+}
+
 func TestCreateOrUpdateGroup_Serve_ExistingIDNotFound_FallsBackToName(t *testing.T) {
 	mockGroups := mocks.NewMockGroupsClient(t)
 

--- a/internal/controller/keycloakrealmgroup/chain/sync_realm_roles.go
+++ b/internal/controller/keycloakrealmgroup/chain/sync_realm_roles.go
@@ -25,6 +25,16 @@ func (h *SyncRealmRoles) Serve(
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Syncing group realm roles")
 
+	// nil: field omitted, not managed. Empty non-nil: managed, clears every mapping.
+	// KeycloakRealmGroup has no reconciliationStrategy field; this guard is the only escape hatch.
+	if group.Spec.RealmRoles == nil {
+		log.Info("Realm roles are not managed by the resource, skipping")
+
+		return nil
+	}
+
+	desiredRoleNames := *group.Spec.RealmRoles
+
 	realm := groupCtx.RealmName
 	groupID := groupCtx.GroupID
 
@@ -41,14 +51,14 @@ func (h *SyncRealmRoles) Serve(
 		}
 	}
 
-	claimedSet := make(map[string]struct{}, len(group.Spec.RealmRoles))
-	for _, r := range group.Spec.RealmRoles {
+	claimedSet := make(map[string]struct{}, len(desiredRoleNames))
+	for _, r := range desiredRoleNames {
 		claimedSet[r] = struct{}{}
 	}
 
 	var rolesToAdd []keycloakapi.RoleRepresentation
 
-	for _, claimedName := range group.Spec.RealmRoles {
+	for _, claimedName := range desiredRoleNames {
 		if _, exists := currentMap[claimedName]; !exists {
 			role, _, err := kClient.Roles.GetRealmRole(ctx, realm, claimedName)
 			if err != nil {

--- a/internal/controller/keycloakrealmgroup/chain/sync_realm_roles.go
+++ b/internal/controller/keycloakrealmgroup/chain/sync_realm_roles.go
@@ -25,8 +25,8 @@ func (h *SyncRealmRoles) Serve(
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Syncing group realm roles")
 
-	// nil: field omitted, not managed. Empty non-nil: managed, clears every mapping.
-	// KeycloakRealmGroup has no reconciliationStrategy field; this guard is the only escape hatch.
+	// nil: not managed, leave Keycloak alone. Empty non-nil: managed, clear every mapping.
+	// KeycloakRealmGroup has no reconciliationStrategy; this is the only opt-out.
 	if group.Spec.RealmRoles == nil {
 		log.Info("Realm roles are not managed by the resource, skipping")
 
@@ -67,6 +67,12 @@ func (h *SyncRealmRoles) Serve(
 
 			if role == nil {
 				return fmt.Errorf("realm role %q not found in realm %q", claimedName, realm)
+			}
+
+			// Keycloak matches a role-mapping payload on name and id together and answers a
+			// mismatch with 404. A role without an id cannot be mapped.
+			if role.Id == nil {
+				return fmt.Errorf("realm role %q has no id", claimedName)
 			}
 
 			rolesToAdd = append(rolesToAdd, *role)

--- a/internal/controller/keycloakrealmgroup/chain/sync_realm_roles.go
+++ b/internal/controller/keycloakrealmgroup/chain/sync_realm_roles.go
@@ -65,17 +65,12 @@ func (h *SyncRealmRoles) Serve(
 				return fmt.Errorf("unable to get realm role %q: %w", claimedName, err)
 			}
 
-			if role == nil {
-				return fmt.Errorf("realm role %q not found in realm %q", claimedName, realm)
+			mappable, err := keycloakapi.RequireRealmRoleWithID(role, realm, claimedName)
+			if err != nil {
+				return err
 			}
 
-			// Keycloak matches a role-mapping payload on name and id together and answers a
-			// mismatch with 404. A role without an id cannot be mapped.
-			if role.Id == nil {
-				return fmt.Errorf("realm role %q has no id", claimedName)
-			}
-
-			rolesToAdd = append(rolesToAdd, *role)
+			rolesToAdd = append(rolesToAdd, mappable)
 		}
 	}
 

--- a/internal/controller/keycloakrealmgroup/chain/sync_realm_roles_test.go
+++ b/internal/controller/keycloakrealmgroup/chain/sync_realm_roles_test.go
@@ -14,6 +14,28 @@ import (
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi/mocks"
 )
 
+func TestSyncRealmRoles_Serve_UnmanagedOmittedRolesLeftAlone(t *testing.T) {
+	// Strict mocks with no expectations: any Keycloak call fails this test.
+	mockGroups := mocks.NewMockGroupsClient(t)
+	mockRoles := mocks.NewMockRolesClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{
+		Groups: mockGroups,
+		Roles:  mockRoles,
+	}
+
+	groupCtx := &GroupContext{
+		RealmName: "test-realm",
+		GroupID:   "group-123",
+	}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+
+	h := NewSyncRealmRoles()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	require.NoError(t, err)
+}
+
 func TestSyncRealmRoles_Serve_AddRoles(t *testing.T) {
 	mockGroups := mocks.NewMockGroupsClient(t)
 	mockRoles := mocks.NewMockRolesClient(t)
@@ -29,7 +51,7 @@ func TestSyncRealmRoles_Serve_AddRoles(t *testing.T) {
 	}
 
 	group := &keycloakApi.KeycloakRealmGroup{}
-	group.Spec.RealmRoles = []string{"role1", "role2"}
+	group.Spec.RealmRoles = ptr.To([]string{"role1", "role2"})
 
 	// No existing roles
 	mockGroups.EXPECT().GetRealmRoleMappings(
@@ -81,7 +103,7 @@ func TestSyncRealmRoles_Serve_RemoveRoles(t *testing.T) {
 	}
 
 	group := &keycloakApi.KeycloakRealmGroup{}
-	group.Spec.RealmRoles = []string{} // Empty - remove all
+	group.Spec.RealmRoles = ptr.To([]string{}) // Empty - remove all
 
 	// Current roles
 	mockGroups.EXPECT().GetRealmRoleMappings(
@@ -103,6 +125,35 @@ func TestSyncRealmRoles_Serve_RemoveRoles(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSyncRealmRoles_Serve_EmptyListWithNoCurrentRoles(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+	mockRoles := mocks.NewMockRolesClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{
+		Groups: mockGroups,
+		Roles:  mockRoles,
+	}
+
+	groupCtx := &GroupContext{
+		RealmName: "test-realm",
+		GroupID:   "group-123",
+	}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.RealmRoles = ptr.To([]string{}) // Managed, nothing to keep
+
+	mockGroups.EXPECT().GetRealmRoleMappings(
+		context.Background(), "test-realm", "group-123",
+	).Return([]keycloakapi.RoleRepresentation{}, nil, nil)
+
+	// No AddRealmRoleMappings or DeleteRealmRoleMappings: an empty list over an empty
+	// mapping set must not issue a write.
+
+	h := NewSyncRealmRoles()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	require.NoError(t, err)
+}
+
 func TestSyncRealmRoles_Serve_AddAndRemove(t *testing.T) {
 	mockGroups := mocks.NewMockGroupsClient(t)
 	mockRoles := mocks.NewMockRolesClient(t)
@@ -118,7 +169,7 @@ func TestSyncRealmRoles_Serve_AddAndRemove(t *testing.T) {
 	}
 
 	group := &keycloakApi.KeycloakRealmGroup{}
-	group.Spec.RealmRoles = []string{"role1", "role2"}
+	group.Spec.RealmRoles = ptr.To([]string{"role1", "role2"})
 
 	// Current roles: role1 (keep), old-role (remove)
 	mockGroups.EXPECT().GetRealmRoleMappings(
@@ -172,7 +223,7 @@ func TestSyncRealmRoles_Serve_NoChanges(t *testing.T) {
 	}
 
 	group := &keycloakApi.KeycloakRealmGroup{}
-	group.Spec.RealmRoles = []string{"role1"}
+	group.Spec.RealmRoles = ptr.To([]string{"role1"})
 
 	// Current roles match spec
 	mockGroups.EXPECT().GetRealmRoleMappings(
@@ -203,7 +254,7 @@ func TestSyncRealmRoles_Serve_ErrorGettingRoleMappings(t *testing.T) {
 	}
 
 	group := &keycloakApi.KeycloakRealmGroup{}
-	group.Spec.RealmRoles = []string{"role1"}
+	group.Spec.RealmRoles = ptr.To([]string{"role1"})
 
 	mockGroups.EXPECT().GetRealmRoleMappings(
 		context.Background(), "test-realm", "group-123",
@@ -229,7 +280,7 @@ func TestSyncRealmRoles_Serve_ErrorGettingRole(t *testing.T) {
 	}
 
 	group := &keycloakApi.KeycloakRealmGroup{}
-	group.Spec.RealmRoles = []string{"nonexistent-role"}
+	group.Spec.RealmRoles = ptr.To([]string{"nonexistent-role"})
 
 	mockGroups.EXPECT().GetRealmRoleMappings(
 		context.Background(), "test-realm", "group-123",
@@ -242,6 +293,37 @@ func TestSyncRealmRoles_Serve_ErrorGettingRole(t *testing.T) {
 	h := NewSyncRealmRoles()
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	assert.ErrorContains(t, err, "unable to get realm role")
+}
+
+func TestSyncRealmRoles_Serve_ErrorRoleNotFound(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+	mockRoles := mocks.NewMockRolesClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{
+		Groups: mockGroups,
+		Roles:  mockRoles,
+	}
+
+	groupCtx := &GroupContext{
+		RealmName: "test-realm",
+		GroupID:   "group-123",
+	}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.RealmRoles = ptr.To([]string{"ghost-role"})
+
+	mockGroups.EXPECT().GetRealmRoleMappings(
+		context.Background(), "test-realm", "group-123",
+	).Return([]keycloakapi.RoleRepresentation{}, nil, nil)
+
+	// Keycloak answers with no role and no error.
+	mockRoles.EXPECT().GetRealmRole(
+		context.Background(), "test-realm", "ghost-role",
+	).Return(nil, nil, nil)
+
+	h := NewSyncRealmRoles()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.ErrorContains(t, err, `realm role "ghost-role" not found in realm "test-realm"`)
 }
 
 func TestSyncRealmRoles_Serve_ErrorAddingRoles(t *testing.T) {
@@ -259,7 +341,7 @@ func TestSyncRealmRoles_Serve_ErrorAddingRoles(t *testing.T) {
 	}
 
 	group := &keycloakApi.KeycloakRealmGroup{}
-	group.Spec.RealmRoles = []string{"role1"}
+	group.Spec.RealmRoles = ptr.To([]string{"role1"})
 
 	mockGroups.EXPECT().GetRealmRoleMappings(
 		context.Background(), "test-realm", "group-123",
@@ -299,7 +381,7 @@ func TestSyncRealmRoles_Serve_ErrorDeletingRoles(t *testing.T) {
 	}
 
 	group := &keycloakApi.KeycloakRealmGroup{}
-	group.Spec.RealmRoles = []string{} // Remove all
+	group.Spec.RealmRoles = ptr.To([]string{}) // Remove all
 
 	mockGroups.EXPECT().GetRealmRoleMappings(
 		context.Background(), "test-realm", "group-123",

--- a/internal/controller/keycloakrealmgroup/chain/sync_realm_roles_test.go
+++ b/internal/controller/keycloakrealmgroup/chain/sync_realm_roles_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestSyncRealmRoles_Serve_UnmanagedOmittedRolesLeftAlone(t *testing.T) {
-	// Strict mocks with no expectations: any Keycloak call fails this test.
+	// No expectations: any Keycloak call fails this test.
 	mockGroups := mocks.NewMockGroupsClient(t)
 	mockRoles := mocks.NewMockRolesClient(t)
 
@@ -146,8 +146,7 @@ func TestSyncRealmRoles_Serve_EmptyListWithNoCurrentRoles(t *testing.T) {
 		context.Background(), "test-realm", "group-123",
 	).Return([]keycloakapi.RoleRepresentation{}, nil, nil)
 
-	// No AddRealmRoleMappings or DeleteRealmRoleMappings: an empty list over an empty
-	// mapping set must not issue a write.
+	// No add or delete expected: an empty list over an empty mapping set writes nothing.
 
 	h := NewSyncRealmRoles()
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
@@ -316,7 +315,7 @@ func TestSyncRealmRoles_Serve_ErrorRoleNotFound(t *testing.T) {
 		context.Background(), "test-realm", "group-123",
 	).Return([]keycloakapi.RoleRepresentation{}, nil, nil)
 
-	// Keycloak answers with no role and no error.
+	// No role, no error.
 	mockRoles.EXPECT().GetRealmRole(
 		context.Background(), "test-realm", "ghost-role",
 	).Return(nil, nil, nil)
@@ -324,6 +323,37 @@ func TestSyncRealmRoles_Serve_ErrorRoleNotFound(t *testing.T) {
 	h := NewSyncRealmRoles()
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	assert.ErrorContains(t, err, `realm role "ghost-role" not found in realm "test-realm"`)
+}
+
+func TestSyncRealmRoles_Serve_RoleWithoutID(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+	mockRoles := mocks.NewMockRolesClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{
+		Groups: mockGroups,
+		Roles:  mockRoles,
+	}
+
+	groupCtx := &GroupContext{
+		RealmName: "test-realm",
+		GroupID:   "group-123",
+	}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.RealmRoles = ptr.To([]string{"idless-role"})
+
+	mockGroups.EXPECT().GetRealmRoleMappings(
+		context.Background(), "test-realm", "group-123",
+	).Return([]keycloakapi.RoleRepresentation{}, nil, nil)
+
+	// Keycloak answers a name/id mismatch with 404, so no AddRealmRoleMappings may be issued.
+	mockRoles.EXPECT().GetRealmRole(
+		context.Background(), "test-realm", "idless-role",
+	).Return(&keycloakapi.RoleRepresentation{Name: ptr.To("idless-role")}, nil, nil)
+
+	h := NewSyncRealmRoles()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.ErrorContains(t, err, `realm role "idless-role" has no id`)
 }
 
 func TestSyncRealmRoles_Serve_ErrorAddingRoles(t *testing.T) {

--- a/internal/controller/keycloakrealmgroup/chain/sync_sub_groups.go
+++ b/internal/controller/keycloakrealmgroup/chain/sync_sub_groups.go
@@ -69,8 +69,7 @@ func (h *SyncSubGroups) Serve(
 				return fmt.Errorf("unable to find subgroup %q: %w", claimed, err)
 			}
 
-			// GroupsClient guarantees a non-nil group and id on success; the generated mock is a
-			// second implementation of the same interface and does not. Guard before every use.
+			// GroupsClient returns a non-nil group and id on success. Guard anyway.
 			if subGroup == nil {
 				return fmt.Errorf("subgroup %q not found in realm %q", claimed, realm)
 			}
@@ -83,9 +82,9 @@ func (h *SyncSubGroups) Serve(
 			// the documented behavior of this deprecated field: the move keeps the group ID, so
 			// the owning resource still resolves it via status.ID afterwards.
 			//
-			// CreateChildGroup moves an existing group, so a nested match would be taken from
-			// its current parent. Unreachable through Keycloak: the search above returns only
-			// top-level roots. Kept for an alternate GroupsClient or a changed server response.
+			// CreateChildGroup moves an existing group out of its current parent. Refuse a
+			// nested match. FindGroupByName returns top-level groups only, so ParentId is nil
+			// on every match from the real client.
 			if subGroup.ParentId != nil && *subGroup.ParentId != groupID {
 				return fmt.Errorf(
 					"subgroup %q is already nested under a different parent group (id %s); "+

--- a/internal/controller/keycloakrealmgroup/chain/sync_sub_groups.go
+++ b/internal/controller/keycloakrealmgroup/chain/sync_sub_groups.go
@@ -69,13 +69,23 @@ func (h *SyncSubGroups) Serve(
 				return fmt.Errorf("unable to find subgroup %q: %w", claimed, err)
 			}
 
+			// GroupsClient guarantees a non-nil group and id on success; the generated mock is a
+			// second implementation of the same interface and does not. Guard before every use.
+			if subGroup == nil {
+				return fmt.Errorf("subgroup %q not found in realm %q", claimed, realm)
+			}
+
+			if subGroup.Id == nil {
+				return fmt.Errorf("subgroup %q has no id", claimed)
+			}
+
 			// Claiming a group that is itself managed by another KeycloakRealmGroup resource is
 			// the documented behavior of this deprecated field: the move keeps the group ID, so
 			// the owning resource still resolves it via status.ID afterwards.
 			//
-			// CreateChildGroup moves an existing group to a new parent. Only allow this when
-			// the found group is currently top-level (no parent) or already a child of this
-			// group; otherwise we would silently steal it from a different parent group.
+			// CreateChildGroup moves an existing group, so a nested match would be taken from
+			// its current parent. Unreachable through Keycloak: the search above returns only
+			// top-level roots. Kept for an alternate GroupsClient or a changed server response.
 			if subGroup.ParentId != nil && *subGroup.ParentId != groupID {
 				return fmt.Errorf(
 					"subgroup %q is already nested under a different parent group (id %s); "+

--- a/internal/controller/keycloakrealmgroup/chain/sync_sub_groups_test.go
+++ b/internal/controller/keycloakrealmgroup/chain/sync_sub_groups_test.go
@@ -210,6 +210,60 @@ func TestSyncSubGroups_Serve_SubGroupNotFound(t *testing.T) {
 	assert.ErrorContains(t, err, "subgroup \"nonexistent\" not found")
 }
 
+func TestSyncSubGroups_Serve_SubGroupWithoutID(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+
+	groupCtx := &GroupContext{
+		RealmName: "test-realm",
+		GroupID:   "parent-group-123",
+	}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.SubGroups = []string{"subgroup1"}
+
+	mockGroups.EXPECT().GetChildGroups(
+		context.Background(), "test-realm", "parent-group-123", (*keycloakapi.GetChildGroupsParams)(nil),
+	).Return([]keycloakapi.GroupRepresentation{}, nil, nil)
+
+	// A group with no id cannot be moved under a parent. Fail instead of dereferencing it.
+	mockGroups.EXPECT().FindGroupByName(
+		context.Background(), "test-realm", "subgroup1",
+	).Return(&keycloakapi.GroupRepresentation{Name: ptr.To("subgroup1")}, nil, nil)
+
+	h := NewSyncSubGroups()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.ErrorContains(t, err, "subgroup \"subgroup1\" has no id")
+}
+
+func TestSyncSubGroups_Serve_NilSubGroupWithoutError(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+
+	groupCtx := &GroupContext{
+		RealmName: "test-realm",
+		GroupID:   "parent-group-123",
+	}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.SubGroups = []string{"subgroup1"}
+
+	mockGroups.EXPECT().GetChildGroups(
+		context.Background(), "test-realm", "parent-group-123", (*keycloakapi.GetChildGroupsParams)(nil),
+	).Return([]keycloakapi.GroupRepresentation{}, nil, nil)
+
+	// No group and no error. Report it instead of dereferencing nil.
+	mockGroups.EXPECT().FindGroupByName(
+		context.Background(), "test-realm", "subgroup1",
+	).Return(nil, nil, nil)
+
+	h := NewSyncSubGroups()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.ErrorContains(t, err, "subgroup \"subgroup1\" not found in realm \"test-realm\"")
+}
+
 func TestSyncSubGroups_Serve_ErrorFindingSubGroup(t *testing.T) {
 	mockGroups := mocks.NewMockGroupsClient(t)
 

--- a/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller_integration_test.go
+++ b/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller_integration_test.go
@@ -47,7 +47,7 @@ var _ = Describe("KeycloakRealmGroup controller", Ordered, func() {
 					Name: KeycloakRealmCR,
 				},
 				Path:       "/parent-group",
-				RealmRoles: []string{"test-group-role"},
+				RealmRoles: ptr.To([]string{"test-group-role"}),
 			},
 		}
 		Expect(k8sClient.Create(ctx, parentGroup)).Should(Succeed())
@@ -176,7 +176,7 @@ var _ = Describe("KeycloakRealmGroup controller", Ordered, func() {
 					"attr1": {"value1", "value2"},
 					"attr2": {"value3"},
 				},
-				RealmRoles: []string{"test-group-role"},
+				RealmRoles: ptr.To([]string{"test-group-role"}),
 			},
 		}
 		Expect(k8sClient.Create(ctx, group)).Should(Succeed())
@@ -240,7 +240,7 @@ var _ = Describe("KeycloakRealmGroup controller", Ordered, func() {
 			"updated-attr": {"updated-value"},
 			"new-attr":     {"new-value"},
 		}
-		updatableGroup.Spec.RealmRoles = []string{"test-group-role-2"}
+		updatableGroup.Spec.RealmRoles = ptr.To([]string{"test-group-role-2"})
 		Expect(k8sClient.Update(ctx, updatableGroup)).Should(Succeed())
 
 		Eventually(func(g Gomega) {
@@ -334,7 +334,7 @@ var _ = Describe("KeycloakRealmGroup controller", Ordered, func() {
 					Kind: keycloakApi.KeycloakRealmKind,
 					Name: KeycloakRealmCR,
 				},
-				RealmRoles: []string{"test-group-role", "test-group-role-2"},
+				RealmRoles: ptr.To([]string{"test-group-role", "test-group-role-2"}),
 			},
 		}
 		Expect(k8sClient.Create(ctx, group)).Should(Succeed())
@@ -361,7 +361,7 @@ var _ = Describe("KeycloakRealmGroup controller", Ordered, func() {
 		By("Updating KeycloakRealmGroup roles")
 		updatableGroup := &keycloakApi.KeycloakRealmGroup{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: group.Name, Namespace: ns}, updatableGroup)).Should(Succeed())
-		updatableGroup.Spec.RealmRoles = []string{"test-group-role-2", "test-group-role-3"}
+		updatableGroup.Spec.RealmRoles = ptr.To([]string{"test-group-role-2", "test-group-role-3"})
 		Expect(k8sClient.Update(ctx, updatableGroup)).Should(Succeed())
 
 		Eventually(func(g Gomega) {
@@ -645,5 +645,99 @@ var _ = Describe("KeycloakRealmGroup controller", Ordered, func() {
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(groups).Should(HaveLen(1))
 		}, time.Minute, time.Second*5).Should(Succeed())
+	})
+})
+
+// The mapping under test is assigned directly in Keycloak, so it is not the operator's to remove.
+var _ = Describe("KeycloakRealmGroup unmanaged realm roles", Ordered, func() {
+	const (
+		crName    = "unmanaged-realm-roles-group"
+		groupName = "unmanaged-realm-roles-group"
+		roleName  = "unmanaged-realm-roles-role"
+	)
+
+	groupID := func() string {
+		cr := &keycloakApi.KeycloakRealmGroup{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).Should(Succeed())
+		Expect(cr.Status.ID).ShouldNot(BeEmpty())
+
+		return cr.Status.ID
+	}
+
+	roleNames := func() []string {
+		mappings, _, err := keycloakApiClient.Groups.GetRealmRoleMappings(ctx, KeycloakRealmCR, groupID())
+		Expect(err).ShouldNot(HaveOccurred())
+
+		names := make([]string, 0, len(mappings))
+		for _, r := range mappings {
+			names = append(names, ptr.Deref(r.Name, ""))
+		}
+
+		return names
+	}
+
+	It("Should keep a directly-assigned realm role when spec.realmRoles is omitted", func() {
+		_, err := keycloakApiClient.Roles.CreateRealmRole(ctx, KeycloakRealmCR, keycloakapi.RoleRepresentation{
+			Name: ptr.To(roleName),
+		})
+		if err != nil && !keycloakapi.IsConflict(err) {
+			Expect(err).ShouldNot(HaveOccurred())
+		}
+
+		Expect(k8sClient.Create(ctx, &keycloakApi.KeycloakRealmGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: ns},
+			Spec: keycloakApi.KeycloakRealmGroupSpec{
+				Name:     groupName,
+				RealmRef: common.RealmRef{Kind: keycloakApi.KeycloakRealmKind, Name: KeycloakRealmCR},
+			},
+		})).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			got := &keycloakApi.KeycloakRealmGroup{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, got)).Should(Succeed())
+			g.Expect(got.Status.Value).Should(Equal(common.StatusOK))
+			g.Expect(got.Status.ID).ShouldNot(BeEmpty())
+		}, timeout, interval).Should(Succeed())
+
+		role, _, err := keycloakApiClient.Roles.GetRealmRole(ctx, KeycloakRealmCR, roleName)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(role).ShouldNot(BeNil())
+
+		_, err = keycloakApiClient.Groups.AddRealmRoleMappings(
+			ctx, KeycloakRealmCR, groupID(), []keycloakapi.RoleRepresentation{*role},
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(roleNames()).To(ContainElement(roleName), "the mapping must exist before the next reconcile")
+
+		By("Forcing a reconcile with an unrelated spec change")
+		cr := &keycloakApi.KeycloakRealmGroup{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).Should(Succeed())
+		cr.Spec.Description = "force a reconcile"
+		Expect(k8sClient.Update(ctx, cr)).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			got := &keycloakApi.KeycloakRealmGroup{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, got)).Should(Succeed())
+			g.Expect(got.Status.Value).Should(Equal(common.StatusOK))
+
+			groupRep, _, err := keycloakApiClient.Groups.GetGroup(ctx, KeycloakRealmCR, got.Status.ID)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(groupRep).ShouldNot(BeNil())
+			g.Expect(ptr.Deref(groupRep.Description, "")).Should(Equal("force a reconcile"))
+		}, timeout, interval).Should(Succeed())
+
+		Expect(roleNames()).To(ContainElement(roleName),
+			"omitting spec.realmRoles must not revoke a mapping the operator did not create")
+	})
+
+	It("Should remove every realm role when spec.realmRoles is an explicit empty list", func() {
+		cr := &keycloakApi.KeycloakRealmGroup{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).Should(Succeed())
+		cr.Spec.RealmRoles = ptr.To([]string{})
+		Expect(k8sClient.Update(ctx, cr)).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(roleNames()).ShouldNot(ContainElement(roleName))
+		}, timeout, interval).Should(Succeed())
 	})
 })

--- a/internal/controller/keycloakrealmrole/chain/create_or_update_role.go
+++ b/internal/controller/keycloakrealmrole/chain/create_or_update_role.go
@@ -63,9 +63,14 @@ func (h *CreateOrUpdateRole) Serve(
 		}
 	}
 
-	if existingRole.Id != nil {
-		roleCtx.RoleID = *existingRole.Id
+	// MakeDefault maps RoleID as a composite, and Keycloak resolves a composite by id alone.
+	// An unset RoleID would reach it as an empty id.
+	syncedRole, err := keycloakapi.RequireRealmRoleWithID(existingRole, realmName, spec.Name)
+	if err != nil {
+		return fmt.Errorf("realm role is not addressable after sync: %w", err)
 	}
+
+	roleCtx.RoleID = *syncedRole.Id
 
 	log.Info("Realm role has been synced")
 

--- a/internal/controller/keycloakrealmrole/chain/create_or_update_role_test.go
+++ b/internal/controller/keycloakrealmrole/chain/create_or_update_role_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
@@ -112,6 +113,58 @@ func TestCreateOrUpdateRole_Serve_GetRealmRoleError(t *testing.T) {
 	err := h.Serve(context.Background(), role, "test-realm", &RoleContext{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get realm role")
+}
+
+func TestCreateOrUpdateRole_Serve_MissingAfterCreate(t *testing.T) {
+	mockRoles := mocks.NewMockRolesClient(t)
+	kClient := &keycloakapi.KeycloakClient{Roles: mockRoles}
+	roleCtx := &RoleContext{}
+
+	role := &keycloakApi.KeycloakRealmRole{}
+	role.Spec.Name = testRoleName
+
+	mockRoles.EXPECT().GetRealmRole(
+		context.Background(), "test-realm", testRoleName,
+	).Return(nil, nil, keycloakapi.ErrNotFound).Once()
+
+	mockRoles.EXPECT().CreateRealmRole(
+		context.Background(), "test-realm", mock.Anything,
+	).Return(nil, nil)
+
+	// No role and no error on the re-read. Report it instead of dereferencing nil.
+	mockRoles.EXPECT().GetRealmRole(
+		context.Background(), "test-realm", testRoleName,
+	).Return(nil, nil, nil).Once()
+
+	h := NewCreateOrUpdateRole(kClient)
+	err := h.Serve(context.Background(), role, "test-realm", roleCtx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not addressable after sync")
+	assert.Empty(t, roleCtx.RoleID)
+}
+
+func TestCreateOrUpdateRole_Serve_ExistingRoleWithoutID(t *testing.T) {
+	mockRoles := mocks.NewMockRolesClient(t)
+	kClient := &keycloakapi.KeycloakClient{Roles: mockRoles}
+	roleCtx := &RoleContext{}
+
+	role := &keycloakApi.KeycloakRealmRole{}
+	role.Spec.Name = testRoleName
+
+	// The role comes back without an id after the update.
+	mockRoles.EXPECT().GetRealmRole(
+		context.Background(), "test-realm", testRoleName,
+	).Return(&keycloakapi.RoleRepresentation{Name: ptr.To(testRoleName)}, nil, nil)
+
+	mockRoles.EXPECT().UpdateRealmRole(
+		context.Background(), "test-realm", testRoleName, mock.Anything,
+	).Return(nil, nil)
+
+	h := NewCreateOrUpdateRole(kClient)
+	err := h.Serve(context.Background(), role, "test-realm", roleCtx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `realm role "test-role" has no id`)
+	assert.Empty(t, roleCtx.RoleID)
 }
 
 func TestCreateOrUpdateRole_Serve_CreateError(t *testing.T) {

--- a/internal/controller/keycloakrealmrole/chain/sync_composites.go
+++ b/internal/controller/keycloakrealmrole/chain/sync_composites.go
@@ -67,7 +67,12 @@ func (h *SyncComposites) Serve(
 			return fmt.Errorf("failed to get realm role %s: %w", name, err)
 		}
 
-		rolesToAdd = append(rolesToAdd, *realmRole)
+		composable, err := keycloakapi.RequireRealmRoleWithID(realmRole, realmName, name)
+		if err != nil {
+			return err
+		}
+
+		rolesToAdd = append(rolesToAdd, composable)
 	}
 
 	for clientName, composites := range spec.CompositesClientRoles {

--- a/internal/controller/keycloakrealmrole/chain/sync_composites_test.go
+++ b/internal/controller/keycloakrealmrole/chain/sync_composites_test.go
@@ -217,6 +217,32 @@ func TestSyncComposites_Serve_GetRealmRoleError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to get realm role")
 }
 
+func TestSyncComposites_Serve_RealmRoleWithoutID(t *testing.T) {
+	mockRoles := mocks.NewMockRolesClient(t)
+	kClient := &keycloakapi.KeycloakClient{Roles: mockRoles}
+
+	role := &keycloakApi.KeycloakRealmRole{}
+	role.Spec.Name = testParentRoleName
+	role.Spec.Composite = true
+	role.Spec.Composites = []keycloakApi.Composite{
+		{Name: "child-role"},
+	}
+
+	mockRoles.EXPECT().GetRealmRoleComposites(
+		context.Background(), "test-realm", testParentRoleName,
+	).Return([]keycloakapi.RoleRepresentation{}, nil, nil)
+
+	// Keycloak resolves a composite by id alone, so no AddRealmRoleComposites may be issued.
+	mockRoles.EXPECT().GetRealmRole(
+		context.Background(), "test-realm", "child-role",
+	).Return(&keycloakapi.RoleRepresentation{Name: ptr.To("child-role")}, nil, nil)
+
+	h := NewSyncComposites(kClient)
+	err := h.Serve(context.Background(), role, "test-realm", &RoleContext{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `realm role "child-role" has no id`)
+}
+
 func TestSyncComposites_Serve_GetClientRoleError(t *testing.T) {
 	mockRoles := mocks.NewMockRolesClient(t)
 	mockClients := mocks.NewMockClientsClient(t)

--- a/internal/controller/keycloakrealmuser/chain/sync_user_groups.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_groups.go
@@ -44,7 +44,16 @@ func (h *SyncUserGroups) Serve(
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Syncing user groups")
 
-	if len(user.Spec.Groups) == 0 && user.IsReconciliationStrategyAddOnly() {
+	// nil: field omitted, not managed. Empty non-nil: managed, clears every membership.
+	if user.Spec.Groups == nil {
+		log.Info("Groups are not managed by the resource, skipping")
+
+		return nil
+	}
+
+	desiredGroupNames := *user.Spec.Groups
+
+	if len(desiredGroupNames) == 0 && user.IsReconciliationStrategyAddOnly() {
 		log.Info("No groups specified (add-only), skipping")
 		return nil
 	}
@@ -54,9 +63,9 @@ func (h *SyncUserGroups) Serve(
 		return fmt.Errorf("unable to get user groups: %w", err)
 	}
 
-	desired := make([]resolvedGroup, 0, len(user.Spec.Groups))
+	desired := make([]resolvedGroup, 0, len(desiredGroupNames))
 
-	for _, g := range user.Spec.Groups {
+	for _, g := range desiredGroupNames {
 		if strings.HasPrefix(g, "/") {
 			grp, _, err := h.kClient.Groups.GetGroupByPath(ctx, realmName, g)
 			if err != nil {

--- a/internal/controller/keycloakrealmuser/chain/sync_user_groups.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_groups.go
@@ -44,7 +44,7 @@ func (h *SyncUserGroups) Serve(
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Syncing user groups")
 
-	// nil: field omitted, not managed. Empty non-nil: managed, clears every membership.
+	// nil: not managed, leave Keycloak alone. Empty non-nil: managed, clear every membership.
 	if user.Spec.Groups == nil {
 		log.Info("Groups are not managed by the resource, skipping")
 
@@ -69,11 +69,19 @@ func (h *SyncUserGroups) Serve(
 		if strings.HasPrefix(g, "/") {
 			grp, _, err := h.kClient.Groups.GetGroupByPath(ctx, realmName, g)
 			if err != nil {
+				if keycloakapi.IsNotFound(err) {
+					return fmt.Errorf("group not found by path %q", g)
+				}
+
 				return fmt.Errorf("unable to get group by path %q: %w", g, err)
 			}
 
-			if grp == nil || grp.Id == nil {
+			if grp == nil {
 				return fmt.Errorf("group not found by path %q", g)
+			}
+
+			if grp.Id == nil {
+				return fmt.Errorf("group %q has no id", g)
 			}
 
 			desired = append(desired, resolvedGroup{id: *grp.Id, path: g})
@@ -85,6 +93,14 @@ func (h *SyncUserGroups) Serve(
 				}
 
 				return fmt.Errorf("unable to find group by name %q: %w", g, err)
+			}
+
+			if grp == nil {
+				return fmt.Errorf("group not found by name %q", g)
+			}
+
+			if grp.Id == nil {
+				return fmt.Errorf("group %q has no id", g)
 			}
 
 			desired = append(desired, resolvedGroup{id: *grp.Id, name: g})

--- a/internal/controller/keycloakrealmuser/chain/sync_user_groups_test.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_groups_test.go
@@ -29,10 +29,33 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 		wantErr   require.ErrorAssertionFunc
 	}{
 		{
+			name: "unmanaged - omitted groups leave every membership alone",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{},
+			},
+			userCtx: &UserContext{UserID: "user-unmanaged"},
+			// No expectations on the mocks: any Keycloak call fails this case.
+			mockSetup: func(_ *v2mocks.MockUsersClient, _ *v2mocks.MockGroupsClient) {},
+			wantErr:   require.NoError,
+		},
+		{
+			name: "unmanaged - omitted groups skipped under add-only too",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec: keycloakApi.KeycloakRealmUserSpec{
+					ReconciliationStrategy: keycloakApi.ReconciliationStrategyAddOnly,
+				},
+			},
+			userCtx:   &UserContext{UserID: "user-unmanaged-addonly"},
+			mockSetup: func(_ *v2mocks.MockUsersClient, _ *v2mocks.MockGroupsClient) {},
+			wantErr:   require.NoError,
+		},
+		{
 			name: "success - name-style group added when not yet assigned",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
-				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"developers"}},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{"developers"})},
 			},
 			userCtx: &UserContext{UserID: "user-1"},
 			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
@@ -49,7 +72,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			name: "success - path-style group added when not yet assigned",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
-				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"/system/data_admin"}},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{"/system/data_admin"})},
 			},
 			userCtx: &UserContext{UserID: "user-2"},
 			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
@@ -69,7 +92,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			name: "success - group already assigned, no add called",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
-				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"developers"}},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{"developers"})},
 			},
 			userCtx: &UserContext{UserID: "user-3"},
 			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
@@ -86,7 +109,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			name: "success - path-style: correct nested group selected over root with same name",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
-				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"/system/data_admin"}},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{"/system/data_admin"})},
 			},
 			userCtx: &UserContext{UserID: "user-4"},
 			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
@@ -111,7 +134,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
 				Spec: keycloakApi.KeycloakRealmUserSpec{
-					Groups:                 []string{"developers"},
+					Groups:                 ptr.To([]string{"developers"}),
 					ReconciliationStrategy: keycloakApi.ReconciliationStrategyAddOnly,
 				},
 			},
@@ -132,7 +155,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
 				Spec: keycloakApi.KeycloakRealmUserSpec{
-					Groups:                 []string{},
+					Groups:                 ptr.To([]string{}),
 					ReconciliationStrategy: keycloakApi.ReconciliationStrategyAddOnly,
 				},
 			},
@@ -144,7 +167,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			name: "error - FindGroupByName returns nil (group not found)",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
-				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"missing-group"}},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{"missing-group"})},
 			},
 			userCtx: &UserContext{UserID: "user-6"},
 			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
@@ -159,10 +182,42 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			},
 		},
 		{
+			name: "error - FindGroupByName fails for a reason other than not-found",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{"developers"})},
+			},
+			userCtx: &UserContext{UserID: "user-16"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-16").
+					Return(nil, nil, nil)
+				g.EXPECT().FindGroupByName(context.Background(), "test-realm", "developers").
+					Return(nil, nil, errors.New("connection refused"))
+			},
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unable to find group by name")
+			},
+		},
+		{
+			name: "success - empty groups with full strategy and no current groups",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{})},
+			},
+			userCtx: &UserContext{UserID: "user-17"},
+			mockSetup: func(u *v2mocks.MockUsersClient, _ *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-17").
+					Return(nil, nil, nil)
+				// No RemoveUserFromGroup: an empty list over no memberships must not issue a write.
+			},
+			wantErr: require.NoError,
+		},
+		{
 			name: "error - GetGroupByPath returns error",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
-				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"/bad/path"}},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{"/bad/path"})},
 			},
 			userCtx: &UserContext{UserID: "user-7"},
 			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
@@ -180,7 +235,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			name: "error - GetUserGroups fails",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
-				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"developers"}},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{"developers"})},
 			},
 			userCtx: &UserContext{UserID: "user-8"},
 			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
@@ -196,7 +251,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			name: "error - AddUserToGroup fails",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
-				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"developers"}},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{"developers"})},
 			},
 			userCtx: &UserContext{UserID: "user-10"},
 			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
@@ -216,7 +271,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			name: "error - RemoveUserFromGroup fails",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
-				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"developers"}},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{"developers"})},
 			},
 			userCtx: &UserContext{UserID: "user-11"},
 			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
@@ -239,7 +294,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			name: "error - GetGroupByPath returns nil (group not found by path)",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
-				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"/missing/path"}},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{"/missing/path"})},
 			},
 			userCtx: &UserContext{UserID: "user-12"},
 			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
@@ -257,7 +312,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			name: "success - full strategy removes extra groups",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
-				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"developers"}},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{"developers"})},
 			},
 			userCtx: &UserContext{UserID: "user-13"},
 			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
@@ -277,7 +332,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			name: "success - empty groups with full strategy removes all",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
-				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{}},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{})},
 			},
 			userCtx: &UserContext{UserID: "user-14"},
 			mockSetup: func(u *v2mocks.MockUsersClient, _ *v2mocks.MockGroupsClient) {
@@ -297,7 +352,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			name: "success - multiple groups: mixed name-style and path-style",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
-				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: []string{"developers", "/system/admins"}},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{"developers", "/system/admins"})},
 			},
 			userCtx: &UserContext{UserID: "user-15"},
 			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {

--- a/internal/controller/keycloakrealmuser/chain/sync_user_groups_test.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_groups_test.go
@@ -35,7 +35,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 				Spec:       keycloakApi.KeycloakRealmUserSpec{},
 			},
 			userCtx: &UserContext{UserID: "user-unmanaged"},
-			// No expectations on the mocks: any Keycloak call fails this case.
+			// No expectations: any Keycloak call fails this case.
 			mockSetup: func(_ *v2mocks.MockUsersClient, _ *v2mocks.MockGroupsClient) {},
 			wantErr:   require.NoError,
 		},
@@ -182,6 +182,42 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			},
 		},
 		{
+			name: "error - GetGroupByPath reports not found",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{"/missing/group"})},
+			},
+			userCtx: &UserContext{UserID: "user-19"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-19").
+					Return(nil, nil, nil)
+				g.EXPECT().GetGroupByPath(context.Background(), "test-realm", "/missing/group").
+					Return(nil, nil, keycloakapi.ErrNotFound)
+			},
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "group not found by path")
+			},
+		},
+		{
+			name: "error - FindGroupByName returns a group without an id",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec:       keycloakApi.KeycloakRealmUserSpec{Groups: ptr.To([]string{"developers"})},
+			},
+			userCtx: &UserContext{UserID: "user-18"},
+			mockSetup: func(u *v2mocks.MockUsersClient, g *v2mocks.MockGroupsClient) {
+				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-18").
+					Return(nil, nil, nil)
+				g.EXPECT().FindGroupByName(context.Background(), "test-realm", "developers").
+					Return(&keycloakapi.GroupRepresentation{Name: ptr.To("developers")}, nil, nil)
+			},
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), `group "developers" has no id`)
+			},
+		},
+		{
 			name: "error - FindGroupByName fails for a reason other than not-found",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
@@ -209,7 +245,7 @@ func TestSyncUserGroups_Serve(t *testing.T) {
 			mockSetup: func(u *v2mocks.MockUsersClient, _ *v2mocks.MockGroupsClient) {
 				u.EXPECT().GetUserGroups(context.Background(), "test-realm", "user-17").
 					Return(nil, nil, nil)
-				// No RemoveUserFromGroup: an empty list over no memberships must not issue a write.
+				// No remove expected: an empty list over no memberships writes nothing.
 			},
 			wantErr: require.NoError,
 		},

--- a/internal/controller/keycloakrealmuser/chain/sync_user_roles.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_roles.go
@@ -83,7 +83,12 @@ func (h *SyncUserRoles) syncRealmRoles(
 			return fmt.Errorf("unable to get realm role %q: %w", roleName, err)
 		}
 
-		toAdd = append(toAdd, *role)
+		mappable, err := keycloakapi.RequireRealmRoleWithID(role, realmName, roleName)
+		if err != nil {
+			return err
+		}
+
+		toAdd = append(toAdd, mappable)
 	}
 
 	if len(toAdd) > 0 {

--- a/internal/controller/keycloakrealmuser/chain/sync_user_roles_test.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_roles_test.go
@@ -171,6 +171,27 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 			},
 		},
 		{
+			name: "error - GetRealmRole returns a role without an id",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec: keycloakApi.KeycloakRealmUserSpec{
+					Roles: ptr.To([]string{"role1"}),
+				},
+			},
+			userCtx: &UserContext{UserID: "user-idless"},
+			mockSetup: func(u *v2mocks.MockUsersClient, r *v2mocks.MockRolesClient, _ *v2mocks.MockClientsClient) {
+				u.EXPECT().GetUserRealmRoleMappings(context.Background(), "test-realm", "user-idless").
+					Return(nil, nil, nil)
+				// Keycloak matches on name and id together, so no AddUserRealmRoles may follow.
+				r.EXPECT().GetRealmRole(context.Background(), "test-realm", "role1").
+					Return(&keycloakapi.RoleRepresentation{Name: ptr.To("role1")}, nil, nil)
+			},
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), `realm role "role1" has no id`)
+			},
+		},
+		{
 			name: "error - GetRealmRole fails",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},

--- a/internal/controller/keycloakrealmuser/keycloakrealmuser_controller_integration_test.go
+++ b/internal/controller/keycloakrealmuser/keycloakrealmuser_controller_integration_test.go
@@ -713,9 +713,8 @@ var _ = Describe("KeycloakRealmUser unmanaged roles", Ordered, func() {
 	})
 })
 
-// Under the default full strategy an omitted spec.groups must revoke nothing. Both the user and
-// the membership are created outside the operator, so the membership under test is not the
-// operator's to remove.
+// The user and the membership are created outside the operator, so the membership under test is
+// not the operator's to remove.
 var _ = Describe("KeycloakRealmUser unmanaged groups", Ordered, func() {
 	const (
 		crName    = "unmanaged-groups-user"

--- a/internal/controller/keycloakrealmuser/keycloakrealmuser_controller_integration_test.go
+++ b/internal/controller/keycloakrealmuser/keycloakrealmuser_controller_integration_test.go
@@ -138,10 +138,10 @@ var _ = Describe("KeycloakRealmUser controller", Ordered, func() {
 						}),
 					},
 				},
-				Groups: []string{
+				Groups: ptr.To([]string{
 					"test-user-group",
 					"/test-user-group2/test-user-group2-subgroup",
-				},
+				}),
 				AttributesV2: map[string][]string{
 					"attr1": {"test-value"},
 				},
@@ -709,6 +709,90 @@ var _ = Describe("KeycloakRealmUser unmanaged roles", Ordered, func() {
 
 		Eventually(func(g Gomega) {
 			g.Expect(realmRoleNames()).ShouldNot(ContainElement(defaultRole))
+		}, timeout, interval).Should(Succeed())
+	})
+})
+
+// Under the default full strategy an omitted spec.groups must revoke nothing. Both the user and
+// the membership are created outside the operator, so the membership under test is not the
+// operator's to remove.
+var _ = Describe("KeycloakRealmUser unmanaged groups", Ordered, func() {
+	const (
+		crName    = "unmanaged-groups-user"
+		username  = "unmanaged-groups-user"
+		groupName = "unmanaged-groups-group"
+	)
+
+	groupNames := func() []string {
+		found, _, err := keycloakApiClient.Users.FindUserByUsername(ctx, KeycloakRealmCR, username)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(found).ShouldNot(BeNil())
+
+		groups, _, err := keycloakApiClient.Users.GetUserGroups(ctx, KeycloakRealmCR, *found.Id)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		names := make([]string, 0, len(groups))
+		for _, g := range groups {
+			names = append(names, ptr.Deref(g.Name, ""))
+		}
+
+		return names
+	}
+
+	It("Should keep the Keycloak group membership when spec.groups is omitted", func() {
+		_, err := keycloakApiClient.Groups.CreateGroup(ctx, KeycloakRealmCR, keycloakapi.GroupRepresentation{
+			Name: ptr.To(groupName),
+		})
+		if err != nil && !keycloakapi.IsConflict(err) {
+			Expect(err).ShouldNot(HaveOccurred())
+		}
+
+		group, _, err := keycloakApiClient.Groups.FindGroupByName(ctx, KeycloakRealmCR, groupName)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(group).ShouldNot(BeNil())
+
+		_, err = keycloakApiClient.Users.CreateUser(ctx, KeycloakRealmCR, keycloakapi.UserRepresentation{
+			Username: ptr.To(username),
+			Enabled:  ptr.To(true),
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		created, _, err := keycloakApiClient.Users.FindUserByUsername(ctx, KeycloakRealmCR, username)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(created).ShouldNot(BeNil())
+
+		_, err = keycloakApiClient.Users.AddUserToGroup(ctx, KeycloakRealmCR, *created.Id, *group.Id)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(groupNames()).To(ContainElement(groupName), "the membership must exist before the operator runs")
+
+		Expect(k8sClient.Create(ctx, &keycloakApi.KeycloakRealmUser{
+			ObjectMeta: metav1.ObjectMeta{Name: crName, Namespace: ns},
+			Spec: keycloakApi.KeycloakRealmUserSpec{
+				RealmRef:     common.RealmRef{Kind: keycloakApi.KeycloakRealmKind, Name: KeycloakRealmCR},
+				Username:     username,
+				Enabled:      true,
+				KeepResource: true,
+			},
+		})).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			got := &keycloakApi.KeycloakRealmUser{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, got)).Should(Succeed())
+			g.Expect(got.Status.Value).Should(Equal(common.StatusOK))
+		}, timeout, interval).Should(Succeed())
+
+		Expect(groupNames()).To(ContainElement(groupName),
+			"omitting spec.groups must not revoke a membership the operator did not create")
+	})
+
+	It("Should remove every group membership when spec.groups is an explicit empty list", func() {
+		cr := &keycloakApi.KeycloakRealmUser{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crName, Namespace: ns}, cr)).Should(Succeed())
+		cr.Spec.Groups = ptr.To([]string{})
+		Expect(k8sClient.Update(ctx, cr)).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(groupNames()).ShouldNot(ContainElement(groupName))
 		}, timeout, interval).Should(Succeed())
 	})
 })

--- a/pkg/client/keycloakapi/contracts.go
+++ b/pkg/client/keycloakapi/contracts.go
@@ -147,6 +147,11 @@ type RealmClient interface {
 
 // GroupsClient defines operations for managing Keycloak groups including CRUD,
 // hierarchy, role mappings, and member management.
+//
+// Single-group lookups report a missing group as not found, either as the ErrNotFound
+// sentinel or as a 404 ApiError. Test with IsNotFound or errors.Is against ErrNotFound;
+// both forms match. On success the group and its Id are non-nil; a group without an Id
+// counts as no match, because no other call can address it.
 type GroupsClient interface {
 	// GetGroups lists or searches groups in the given realm.
 	GetGroups(ctx context.Context, realm string, params *GetGroupsParams) ([]GroupRepresentation, *Response, error)
@@ -167,11 +172,11 @@ type GroupsClient interface {
 	) ([]GroupRepresentation, *Response, error)
 	// CreateChildGroup creates a child group under the given parent group.
 	CreateChildGroup(ctx context.Context, realm, parentGroupID string, group GroupRepresentation) (*Response, error)
-	// FindGroupByName searches for a group by exact name. Returns ErrNotFound if no match.
+	// FindGroupByName searches for a group by exact name.
 	FindGroupByName(ctx context.Context, realm, groupName string) (*GroupRepresentation, *Response, error)
 	// GetGroupByPath retrieves a group by its path (e.g., "/parent/child").
 	GetGroupByPath(ctx context.Context, realm, path string) (*GroupRepresentation, *Response, error)
-	// FindChildGroupByName searches for a child group by name under the given parent. Returns ErrNotFound if no match.
+	// FindChildGroupByName searches for a child group by name under the given parent.
 	FindChildGroupByName(
 		ctx context.Context,
 		realm string,

--- a/pkg/client/keycloakapi/doc.go
+++ b/pkg/client/keycloakapi/doc.go
@@ -69,7 +69,8 @@
 //   - [IsServerError] — true for any 5xx error
 //
 // Find* methods return [ErrNotFound] (a sentinel error) when the searched resource does
-// not exist, distinct from [ApiError] with a 404 status code.
+// not exist. A 404 from Keycloak arrives as [ApiError] instead. Both match
+// errors.Is(err, ErrNotFound) and [IsNotFound]; errors.As still yields the [ApiError].
 //
 // # Response Type
 //

--- a/pkg/client/keycloakapi/error.go
+++ b/pkg/client/keycloakapi/error.go
@@ -40,6 +40,12 @@ func (e *ApiError) IsNotFound() bool {
 	return e.Code == http.StatusNotFound
 }
 
+// Is matches ErrNotFound against a 404. A 404 does not wrap the sentinel; both name the
+// same condition. errors.As still yields *ApiError.
+func (e *ApiError) Is(target error) bool {
+	return target == ErrNotFound && e.IsNotFound()
+}
+
 // IsConflict returns true if the error is a 409 Conflict
 func (e *ApiError) IsConflict() bool {
 	return e.Code == http.StatusConflict
@@ -102,18 +108,10 @@ func checkResponseError(httpResp *http.Response, body []byte) error {
 
 // Helper functions for error checking
 
-// IsNotFound returns true if the error is ErrNotFound or a 404 Not Found ApiError
+// IsNotFound returns true if the error is ErrNotFound or a 404 Not Found ApiError.
+// ApiError.Is makes both forms match the sentinel.
 func IsNotFound(err error) bool {
-	if errors.Is(err, ErrNotFound) {
-		return true
-	}
-
-	var apiErr *ApiError
-	if errors.As(err, &apiErr) {
-		return apiErr.IsNotFound()
-	}
-
-	return false
+	return errors.Is(err, ErrNotFound)
 }
 
 // IsConflict returns true if the error is a 409 Conflict ApiError

--- a/pkg/client/keycloakapi/error_test.go
+++ b/pkg/client/keycloakapi/error_test.go
@@ -2,6 +2,7 @@ package keycloakapi
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -192,6 +193,18 @@ func TestHelperFunctions(t *testing.T) {
 
 		// Test with nil
 		assert.False(t, IsNotFound(nil))
+
+		// The sentinel and the 404 ApiError name the same condition, and errors.Is sees both.
+		assert.True(t, IsNotFound(ErrNotFound))
+		assert.True(t, errors.Is(error(&ApiError{Code: http.StatusNotFound}), ErrNotFound))
+		assert.True(t, errors.Is(fmt.Errorf("wrapped: %w", &ApiError{Code: http.StatusNotFound}), ErrNotFound))
+		assert.False(t, errors.Is(error(&ApiError{Code: http.StatusBadRequest}), ErrNotFound))
+
+		// errors.As still reaches the ApiError for callers that need the status code.
+		var asErr *ApiError
+
+		require.True(t, errors.As(fmt.Errorf("wrapped: %w", &ApiError{Code: http.StatusNotFound}), &asErr))
+		assert.Equal(t, http.StatusNotFound, asErr.Code)
 	})
 
 	t.Run("IsConflict", func(t *testing.T) {

--- a/pkg/client/keycloakapi/groups.go
+++ b/pkg/client/keycloakapi/groups.go
@@ -67,6 +67,10 @@ func (c *groupsClient) GetGroup(ctx context.Context, realm, groupID string) (*Gr
 		return nil, response, err
 	}
 
+	if res.JSON200 == nil || res.JSON200.Id == nil {
+		return nil, response, ErrNotFound
+	}
+
 	return res.JSON200, response, nil
 }
 
@@ -460,13 +464,17 @@ func (c *groupsClient) GetGroupByPath(
 		return nil, response, err
 	}
 
+	if res.JSON200 == nil || res.JSON200.Id == nil {
+		return nil, response, ErrNotFound
+	}
+
 	return res.JSON200, response, nil
 }
 
-// findGroupInList searches for a group by name in a list of groups.
+// findGroupInList searches for a group by name in a list of groups. Skips groups without an ID.
 func findGroupInList(groups []GroupRepresentation, name string) *GroupRepresentation {
 	for i := range groups {
-		if groups[i].Name != nil && *groups[i].Name == name {
+		if groups[i].Id != nil && groups[i].Name != nil && *groups[i].Name == name {
 			return &groups[i]
 		}
 	}

--- a/pkg/client/keycloakapi/groups_internal_test.go
+++ b/pkg/client/keycloakapi/groups_internal_test.go
@@ -1,0 +1,62 @@
+package keycloakapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+)
+
+func TestFindGroupInList(t *testing.T) {
+	tests := []struct {
+		name   string
+		groups []GroupRepresentation
+		search string
+		wantID string
+	}{
+		{
+			name:   "match returns the group",
+			groups: []GroupRepresentation{{Id: ptr.To("id-1"), Name: ptr.To("developers")}},
+			search: "developers",
+			wantID: "id-1",
+		},
+		{
+			name:   "no match returns nil",
+			groups: []GroupRepresentation{{Id: ptr.To("id-1"), Name: ptr.To("developers")}},
+			search: "ops",
+		},
+		{
+			name:   "nil name is skipped",
+			groups: []GroupRepresentation{{Id: ptr.To("id-1")}},
+			search: "developers",
+		},
+		{
+			name:   "name match without an id is not a usable group",
+			groups: []GroupRepresentation{{Name: ptr.To("developers")}},
+			search: "developers",
+		},
+		{
+			name: "an unusable match does not shadow a usable one",
+			groups: []GroupRepresentation{
+				{Name: ptr.To("developers")},
+				{Id: ptr.To("id-2"), Name: ptr.To("developers")},
+			},
+			search: "developers",
+			wantID: "id-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findGroupInList(tt.groups, tt.search)
+
+			if tt.wantID == "" {
+				assert.Nil(t, got)
+				return
+			}
+
+			assert.NotNil(t, got)
+			assert.Equal(t, tt.wantID, ptr.Deref(got.Id, ""))
+		})
+	}
+}

--- a/pkg/client/keycloakapi/roles.go
+++ b/pkg/client/keycloakapi/roles.go
@@ -2,6 +2,7 @@ package keycloakapi
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi/generated"
 )
@@ -10,6 +11,25 @@ type (
 	RoleRepresentation  = generated.RoleRepresentation
 	GetRealmRolesParams = generated.GetAdminRealmsRealmRolesParams
 )
+
+// RequireRealmRoleWithID validates a GetRealmRole result for work that needs the role's id:
+// role mappings, composites and default-role entries. Keycloak matches a mapping payload on
+// name and id together, and a composite on id alone, and answers either mismatch with 404.
+// The returned representation has a non-nil Id.
+//
+// GetRealmRole itself does not enforce this. A realm role is addressable by name on other
+// endpoints, so a response without an id is incomplete rather than missing.
+func RequireRealmRoleWithID(role *RoleRepresentation, realm, name string) (RoleRepresentation, error) {
+	if role == nil {
+		return RoleRepresentation{}, fmt.Errorf("realm role %q not found in realm %q", name, realm)
+	}
+
+	if role.Id == nil {
+		return RoleRepresentation{}, fmt.Errorf("realm role %q has no id", name)
+	}
+
+	return *role, nil
+}
 
 type rolesClient struct {
 	client generated.ClientWithResponsesInterface

--- a/pkg/client/keycloakapi/roles_internal_test.go
+++ b/pkg/client/keycloakapi/roles_internal_test.go
@@ -1,0 +1,49 @@
+package keycloakapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+func TestRequireRealmRoleWithID(t *testing.T) {
+	tests := []struct {
+		name    string
+		role    *RoleRepresentation
+		wantID  string
+		wantErr string
+	}{
+		{
+			name:   "role with an id is returned",
+			role:   &RoleRepresentation{Id: ptr.To("id-1"), Name: ptr.To("admin")},
+			wantID: "id-1",
+		},
+		{
+			name:    "no role is not found",
+			role:    nil,
+			wantErr: `realm role "admin" not found in realm "test-realm"`,
+		},
+		{
+			name:    "role without an id is incomplete, not missing",
+			role:    &RoleRepresentation{Name: ptr.To("admin")},
+			wantErr: `realm role "admin" has no id`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RequireRealmRoleWithID(tt.role, "test-realm", "admin")
+
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got.Id)
+			assert.Equal(t, tt.wantID, *got.Id)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Two problems. Optional list fields were destructive when omitted, and several Keycloak lookups handed back ids the operator then used without checking.

Three commits, each standing on its own.

### 1. An unset list is unmanaged, not empty

Under the default `full` strategy an unset list read as an empty desired set, so the sweep removed every group membership and every group realm role mapping, including entries assigned outside the operator. `KeycloakRealmGroup` has no `reconciliationStrategy`, so `addOnly` was never a way out.

`KeycloakRealmUser.spec.groups` and `KeycloakRealmGroup.spec.realmRoles` are pointers now:

| value | meaning |
| --- | --- |
| absent | not managed; Keycloak is left alone |
| `[]` | managed; remove every entry |
| `[a, b]` | managed; exactly `a` and `b` |

This is the rule already in force for `spec.roles` and `spec.clientRoles`.

### 2. A group without an id is never resolved

A group lookup could return a group with no id and no error. Callers dereferenced it and panicked the reconcile. A name match without an id also shadowed a usable group later in the same list.

Every single-group lookup now reports a missing id as not found. Callers still guard, because the generated mock is a second implementation of the same interface. A create whose `Location` header carries no id is an error.

`ApiError.Is` matches a 404 against `ErrNotFound`, so `errors.Is` and `IsNotFound` agree on both forms while `errors.As` still yields `*ApiError`.

### 3. An id Keycloak cannot address is rejected

Realm role lookups return whatever the endpoint sent. Seven consumers used the result unchecked, so a body with no role panicked the reconcile, and an id-less role reached a mapping payload or left a default-role id empty.

Keycloak matches a role mapping on name **and** id together, and a composite on id alone, and answers either mismatch with 404. `RequireRealmRoleWithID` states that rule once. The lookup itself is unchanged: a realm role is addressable by name on some endpoints, so an id-less 200 is an incomplete response, not a missing role.

Client scopes and realm components now reject a create whose `Location` header carries no id, which groups, users and auth flows already did.

Fixes #374

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

### Breaking change detail

Omitting `spec.groups` on `KeycloakRealmUser`, or `spec.realmRoles` on `KeycloakRealmGroup`, no longer clears them. Write `[]` to clear.

Helm drops `[]`. Pass `--set-json`, and do not guard the value with `{{ if }}`.

Anyone relying on omission to clear a list must add an explicit `[]`.

## How Has This Been Tested?

```bash
make test                                            # unit
make start-keycloak
TEST_KEYCLOAK_URL=http://localhost:8086 make test    # unit + integration
make lint
make validate-docs
```

- Unit tests pass, all packages.
- Full integration suite passes against live Keycloak **26.7** and **26.3**.
- `make lint` reports 0 issues. `make validate-docs` is clean.

New coverage: nil and id-less results from every group and realm role lookup, a missing `Location` header on create for groups, client scopes and realm components, and the `errors.Is` / `errors.As` behaviour of `ApiError`.

Every claim about Keycloak behaviour above was checked against a running server, not inferred from the spec.

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Pull Request contains one commit. I squash my commits.

The three commits are kept separate because each has its own failure mode and reads on its own. Squash on merge if the project prefers that.

## Additional context

Found while testing this branch, and deliberately **not** fixed here: the group `description` field only exists from Keycloak **26.3**. The operator always sends `"description": ""`, so every `KeycloakRealmGroup` reconcile fails with 400 on 25.0, 26.0, 26.1 and 26.2, including RHBK 26.2. Verified on each of those versions. That is #355.
