### PR TITLE
fix(keycloak): reject a client role that Keycloak cannot address

### DIFF
--- a/internal/controller/keycloakclient/chain/put_client_role.go
+++ b/internal/controller/keycloakclient/chain/put_client_role.go
@@ -133,7 +133,7 @@ func (h *PutClientRole) putKeycloakClientRole(ctx context.Context, keycloakClien
 			continue
 		}
 
-		if err := h.syncRoleComposites(ctx, realmName, clientUUID, role); err != nil {
+		if err := h.syncRoleComposites(ctx, realmName, keycloakClient.Spec.ClientId, clientUUID, role); err != nil {
 			return fmt.Errorf("unable to sync composites for role %s: %w", role.Name, err)
 		}
 	}
@@ -145,7 +145,7 @@ func (h *PutClientRole) putKeycloakClientRole(ctx context.Context, keycloakClien
 
 func (h *PutClientRole) syncRoleComposites(
 	ctx context.Context,
-	realmName, clientUUID string,
+	realmName, clientID, clientUUID string,
 	role keycloakApi.ClientRole,
 ) error {
 	// Get existing composites
@@ -173,7 +173,12 @@ func (h *PutClientRole) syncRoleComposites(
 				return fmt.Errorf("unable to get client role %s for composite: %w", compositeName, err)
 			}
 
-			toAdd = append(toAdd, *compositeRole)
+			composable, err := keycloakapi.RequireClientRoleWithID(compositeRole, clientID, compositeName)
+			if err != nil {
+				return err
+			}
+
+			toAdd = append(toAdd, composable)
 		}
 	}
 

--- a/internal/controller/keycloakclient/chain/put_client_role_test.go
+++ b/internal/controller/keycloakclient/chain/put_client_role_test.go
@@ -286,6 +286,76 @@ func TestPutClientRole_Serve(t *testing.T) {
 			expectedError: "",
 		},
 		{
+			name: "error - composite client role lookup returns no role",
+			keycloakClient: &keycloakApi.KeycloakClient{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-client",
+					Namespace: "default",
+				},
+				Spec: keycloakApi.KeycloakClientSpec{
+					ClientId: "test-client-id",
+					ClientRolesV2: []keycloakApi.ClientRole{
+						{
+							Name:                  "composite-role",
+							Description:           "Composite role",
+							AssociatedClientRoles: []string{"role1"},
+						},
+					},
+				},
+			},
+			kClient: func(t *testing.T) *keycloakapi.KeycloakClient {
+				clientsMock := keycloakapiMocks.NewMockClientsClient(t)
+				clientsMock.On("GetClientRoles", mock.Anything, "test-realm", "client-uuid", (*keycloakapi.GetClientRolesParams)(nil)).
+					Return([]keycloakapi.RoleRepresentation{
+						{Name: ptr.To("composite-role"), Description: ptr.To("Composite role")},
+					}, (*keycloakapi.Response)(nil), nil)
+				clientsMock.On("GetClientRoleComposites", mock.Anything, "test-realm", "client-uuid", "composite-role").
+					Return([]keycloakapi.RoleRepresentation{}, (*keycloakapi.Response)(nil), nil)
+				// No role, no error.
+				clientsMock.On("GetClientRole", mock.Anything, "test-realm", "client-uuid", "role1").
+					Return((*keycloakapi.RoleRepresentation)(nil), (*keycloakapi.Response)(nil), nil)
+
+				return &keycloakapi.KeycloakClient{Clients: clientsMock}
+			},
+			realmName:     "test-realm",
+			expectedError: `client role "role1" not found for client "test-client-id"`,
+		},
+		{
+			name: "error - composite client role has no id",
+			keycloakClient: &keycloakApi.KeycloakClient{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-client",
+					Namespace: "default",
+				},
+				Spec: keycloakApi.KeycloakClientSpec{
+					ClientId: "test-client-id",
+					ClientRolesV2: []keycloakApi.ClientRole{
+						{
+							Name:                  "composite-role",
+							Description:           "Composite role",
+							AssociatedClientRoles: []string{"role1"},
+						},
+					},
+				},
+			},
+			kClient: func(t *testing.T) *keycloakapi.KeycloakClient {
+				clientsMock := keycloakapiMocks.NewMockClientsClient(t)
+				clientsMock.On("GetClientRoles", mock.Anything, "test-realm", "client-uuid", (*keycloakapi.GetClientRolesParams)(nil)).
+					Return([]keycloakapi.RoleRepresentation{
+						{Name: ptr.To("composite-role"), Description: ptr.To("Composite role")},
+					}, (*keycloakapi.Response)(nil), nil)
+				clientsMock.On("GetClientRoleComposites", mock.Anything, "test-realm", "client-uuid", "composite-role").
+					Return([]keycloakapi.RoleRepresentation{}, (*keycloakapi.Response)(nil), nil)
+				// No AddClientRoleComposites expectation: reaching it fails the test.
+				clientsMock.On("GetClientRole", mock.Anything, "test-realm", "client-uuid", "role1").
+					Return(&keycloakapi.RoleRepresentation{Name: ptr.To("role1")}, (*keycloakapi.Response)(nil), nil)
+
+				return &keycloakapi.KeycloakClient{Clients: clientsMock}
+			},
+			realmName:     "test-realm",
+			expectedError: `client role "role1" has no id`,
+		},
+		{
 			name: "success - composites already exist, removes extra",
 			keycloakClient: &keycloakApi.KeycloakClient{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/keycloakclient/chain/service_account.go
+++ b/internal/controller/keycloakclient/chain/service_account.go
@@ -240,7 +240,12 @@ func (h *ServiceAccount) syncClientRoles(
 					return fmt.Errorf("unable to get client role %s/%s: %w", targetClientID, roleName, err)
 				}
 
-				toAdd = append(toAdd, *role)
+				mappable, err := keycloakapi.RequireClientRoleWithID(role, targetClientID, roleName)
+				if err != nil {
+					return err
+				}
+
+				toAdd = append(toAdd, mappable)
 			}
 		}
 

--- a/internal/controller/keycloakclient/chain/service_account_test.go
+++ b/internal/controller/keycloakclient/chain/service_account_test.go
@@ -66,6 +66,80 @@ func TestServiceAccount_Serve(t *testing.T) {
 			expectedError: `realm role "realm-role1" has no id`,
 		},
 		{
+			name: "error - client role lookup returns no role",
+			keycloakClient: &keycloakApi.KeycloakClient{
+				Spec: keycloakApi.KeycloakClientSpec{
+					ClientId: "test-client-id",
+					ServiceAccount: &keycloakApi.ServiceAccount{
+						Enabled: true,
+						ClientRoles: []keycloakApi.UserClientRole{
+							{ClientID: "client1", Roles: ptr.To([]string{"role1"})},
+						},
+					},
+				},
+				Status: keycloakApi.KeycloakClientStatus{ClientID: "client-123"},
+			},
+			kClient: func(t *testing.T) *keycloakapi.KeycloakClient {
+				clientsMock := keycloakapiMocks.NewMockClientsClient(t)
+				usersMock := keycloakapiMocks.NewMockUsersClient(t)
+
+				clientsMock.On("GetServiceAccountUser", mock.Anything, "test-realm", "client-uuid").
+					Return(&keycloakapi.UserRepresentation{Id: ptr.To("sa-user-id")}, (*keycloakapi.Response)(nil), nil)
+				clientsMock.On("GetClientByClientID", mock.Anything, "test-realm", "client1").
+					Return(&keycloakapi.ClientRepresentation{Id: ptr.To("client1-uuid")}, (*keycloakapi.Response)(nil), nil)
+				usersMock.On("GetUserClientRoleMappings", mock.Anything, "test-realm", "sa-user-id", "client1-uuid").
+					Return([]keycloakapi.RoleRepresentation{}, (*keycloakapi.Response)(nil), nil)
+				// No role, no error.
+				clientsMock.On("GetClientRole", mock.Anything, "test-realm", "client1-uuid", "role1").
+					Return((*keycloakapi.RoleRepresentation)(nil), (*keycloakapi.Response)(nil), nil)
+
+				return &keycloakapi.KeycloakClient{
+					Clients: clientsMock,
+					Users:   usersMock,
+					Roles:   keycloakapiMocks.NewMockRolesClient(t),
+				}
+			},
+			realmName:     "test-realm",
+			expectedError: `client role "role1" not found for client "client1"`,
+		},
+		{
+			name: "error - client role has no id",
+			keycloakClient: &keycloakApi.KeycloakClient{
+				Spec: keycloakApi.KeycloakClientSpec{
+					ClientId: "test-client-id",
+					ServiceAccount: &keycloakApi.ServiceAccount{
+						Enabled: true,
+						ClientRoles: []keycloakApi.UserClientRole{
+							{ClientID: "client1", Roles: ptr.To([]string{"role1"})},
+						},
+					},
+				},
+				Status: keycloakApi.KeycloakClientStatus{ClientID: "client-123"},
+			},
+			kClient: func(t *testing.T) *keycloakapi.KeycloakClient {
+				clientsMock := keycloakapiMocks.NewMockClientsClient(t)
+				usersMock := keycloakapiMocks.NewMockUsersClient(t)
+
+				clientsMock.On("GetServiceAccountUser", mock.Anything, "test-realm", "client-uuid").
+					Return(&keycloakapi.UserRepresentation{Id: ptr.To("sa-user-id")}, (*keycloakapi.Response)(nil), nil)
+				clientsMock.On("GetClientByClientID", mock.Anything, "test-realm", "client1").
+					Return(&keycloakapi.ClientRepresentation{Id: ptr.To("client1-uuid")}, (*keycloakapi.Response)(nil), nil)
+				usersMock.On("GetUserClientRoleMappings", mock.Anything, "test-realm", "sa-user-id", "client1-uuid").
+					Return([]keycloakapi.RoleRepresentation{}, (*keycloakapi.Response)(nil), nil)
+				// No AddUserClientRoles expectation: reaching it fails the test.
+				clientsMock.On("GetClientRole", mock.Anything, "test-realm", "client1-uuid", "role1").
+					Return(&keycloakapi.RoleRepresentation{Name: ptr.To("role1")}, (*keycloakapi.Response)(nil), nil)
+
+				return &keycloakapi.KeycloakClient{
+					Clients: clientsMock,
+					Users:   usersMock,
+					Roles:   keycloakapiMocks.NewMockRolesClient(t),
+				}
+			},
+			realmName:     "test-realm",
+			expectedError: `client role "role1" has no id`,
+		},
+		{
 			// No role-mapping expectations on the mocks: any Keycloak read fails this case.
 			name: "unmanaged - omitted realm roles and role-less client entries are left alone",
 			keycloakClient: &keycloakApi.KeycloakClient{

--- a/internal/controller/keycloakrealmgroup/chain/sync_client_roles.go
+++ b/internal/controller/keycloakrealmgroup/chain/sync_client_roles.go
@@ -138,11 +138,12 @@ func (h *SyncClientRoles) syncOneClientRoles(
 				return fmt.Errorf("unable to get client role %q: %w", rn, err)
 			}
 
-			if role == nil {
-				return fmt.Errorf("client role %q not found for client %q in realm %q", rn, clientIDStr, realm)
+			mappable, err := keycloakapi.RequireClientRoleWithID(role, clientIDStr, rn)
+			if err != nil {
+				return err
 			}
 
-			rolesToAdd = append(rolesToAdd, *role)
+			rolesToAdd = append(rolesToAdd, mappable)
 		}
 	}
 

--- a/internal/controller/keycloakrealmgroup/chain/sync_client_roles_test.go
+++ b/internal/controller/keycloakrealmgroup/chain/sync_client_roles_test.go
@@ -427,6 +427,86 @@ func TestSyncClientRoles_Serve_ErrorGettingClientRole(t *testing.T) {
 	assert.ErrorContains(t, err, "unable to get client role")
 }
 
+func TestSyncClientRoles_Serve_ClientRoleMissing(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+	mockClients := mocks.NewMockClientsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{
+		Groups:  mockGroups,
+		Clients: mockClients,
+	}
+
+	groupCtx := &GroupContext{
+		RealmName: "test-realm",
+		GroupID:   "group-123",
+	}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.ClientRoles = []keycloakApi.UserClientRole{
+		{ClientID: "test-client", Roles: ptr.To([]string{"role1"})},
+	}
+
+	mockGroups.EXPECT().GetRoleMappings(
+		context.Background(), "test-realm", "group-123",
+	).Return(&keycloakapi.MappingsRepresentation{}, nil, nil)
+
+	mockClients.EXPECT().GetClients(
+		context.Background(), "test-realm",
+		&keycloakapi.GetClientsParams{ClientId: ptr.To("test-client")},
+	).Return([]keycloakapi.ClientRepresentation{
+		{Id: ptr.To("client-uuid"), ClientId: ptr.To("test-client")},
+	}, nil, nil)
+
+	// No role, no error.
+	mockClients.EXPECT().GetClientRole(
+		context.Background(), "test-realm", "client-uuid", "role1",
+	).Return(nil, nil, nil)
+
+	h := NewSyncClientRoles()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.ErrorContains(t, err, `client role "role1" not found for client "test-client"`)
+}
+
+func TestSyncClientRoles_Serve_ClientRoleWithoutID(t *testing.T) {
+	mockGroups := mocks.NewMockGroupsClient(t)
+	mockClients := mocks.NewMockClientsClient(t)
+
+	kClient := &keycloakapi.KeycloakClient{
+		Groups:  mockGroups,
+		Clients: mockClients,
+	}
+
+	groupCtx := &GroupContext{
+		RealmName: "test-realm",
+		GroupID:   "group-123",
+	}
+
+	group := &keycloakApi.KeycloakRealmGroup{}
+	group.Spec.ClientRoles = []keycloakApi.UserClientRole{
+		{ClientID: "test-client", Roles: ptr.To([]string{"role1"})},
+	}
+
+	mockGroups.EXPECT().GetRoleMappings(
+		context.Background(), "test-realm", "group-123",
+	).Return(&keycloakapi.MappingsRepresentation{}, nil, nil)
+
+	mockClients.EXPECT().GetClients(
+		context.Background(), "test-realm",
+		&keycloakapi.GetClientsParams{ClientId: ptr.To("test-client")},
+	).Return([]keycloakapi.ClientRepresentation{
+		{Id: ptr.To("client-uuid"), ClientId: ptr.To("test-client")},
+	}, nil, nil)
+
+	// No AddClientRoleMappings expectation: reaching it fails the test.
+	mockClients.EXPECT().GetClientRole(
+		context.Background(), "test-realm", "client-uuid", "role1",
+	).Return(&keycloakapi.RoleRepresentation{Name: ptr.To("role1")}, nil, nil)
+
+	h := NewSyncClientRoles()
+	err := h.Serve(context.Background(), group, kClient, groupCtx)
+	assert.ErrorContains(t, err, `client role "role1" has no id`)
+}
+
 func TestSyncClientRoles_Serve_ErrorAddingClientRoleMappings(t *testing.T) {
 	mockGroups := mocks.NewMockGroupsClient(t)
 	mockClients := mocks.NewMockClientsClient(t)

--- a/internal/controller/keycloakrealmrole/chain/sync_composites.go
+++ b/internal/controller/keycloakrealmrole/chain/sync_composites.go
@@ -103,7 +103,12 @@ func (h *SyncComposites) Serve(
 				return fmt.Errorf("failed to get client role %s: %w", roleName, err)
 			}
 
-			rolesToAdd = append(rolesToAdd, *clientRole)
+			composable, err := keycloakapi.RequireClientRoleWithID(clientRole, clientName, roleName)
+			if err != nil {
+				return err
+			}
+
+			rolesToAdd = append(rolesToAdd, composable)
 		}
 	}
 

--- a/internal/controller/keycloakrealmrole/chain/sync_composites_test.go
+++ b/internal/controller/keycloakrealmrole/chain/sync_composites_test.go
@@ -243,6 +243,104 @@ func TestSyncComposites_Serve_RealmRoleWithoutID(t *testing.T) {
 	assert.Contains(t, err.Error(), `realm role "child-role" has no id`)
 }
 
+func TestSyncComposites_Serve_RealmRoleIsAnotherRole(t *testing.T) {
+	mockRoles := mocks.NewMockRolesClient(t)
+	kClient := &keycloakapi.KeycloakClient{Roles: mockRoles}
+
+	role := &keycloakApi.KeycloakRealmRole{}
+	role.Spec.Name = testParentRoleName
+	role.Spec.Composite = true
+	role.Spec.Composites = []keycloakApi.Composite{
+		{Name: "child-role"},
+	}
+
+	mockRoles.EXPECT().GetRealmRoleComposites(
+		context.Background(), "test-realm", testParentRoleName,
+	).Return([]keycloakapi.RoleRepresentation{}, nil, nil)
+
+	// No AddRealmRoleComposites expectation: reaching it fails the test.
+	mockRoles.EXPECT().GetRealmRole(
+		context.Background(), "test-realm", "child-role",
+	).Return(&keycloakapi.RoleRepresentation{Id: ptr.To("other-id"), Name: ptr.To("other-role")}, nil, nil)
+
+	h := NewSyncComposites(kClient)
+	err := h.Serve(context.Background(), role, "test-realm", &RoleContext{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `realm role lookup for "child-role" returned "other-role"`)
+}
+
+func TestSyncComposites_Serve_ClientRoleMissing(t *testing.T) {
+	mockRoles := mocks.NewMockRolesClient(t)
+	mockClients := mocks.NewMockClientsClient(t)
+	kClient := &keycloakapi.KeycloakClient{Roles: mockRoles, Clients: mockClients}
+
+	clientName := testClientName
+
+	role := &keycloakApi.KeycloakRealmRole{}
+	role.Spec.Name = testParentRoleName
+	role.Spec.Composite = true
+	role.Spec.CompositesClientRoles = map[string][]keycloakApi.Composite{
+		clientName: {{Name: "role1"}},
+	}
+
+	mockRoles.EXPECT().GetRealmRoleComposites(
+		context.Background(), "test-realm", testParentRoleName,
+	).Return([]keycloakapi.RoleRepresentation{}, nil, nil)
+
+	mockClients.EXPECT().GetClients(
+		context.Background(), "test-realm",
+		&keycloakapi.GetClientsParams{ClientId: &clientName},
+	).Return([]keycloakapi.ClientRepresentation{
+		{Id: ptr.To("client-uuid-1")},
+	}, nil, nil)
+
+	// No role, no error.
+	mockClients.EXPECT().GetClientRole(
+		context.Background(), "test-realm", "client-uuid-1", "role1",
+	).Return(nil, nil, nil)
+
+	h := NewSyncComposites(kClient)
+	err := h.Serve(context.Background(), role, "test-realm", &RoleContext{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `client role "role1" not found for client "my-client"`)
+}
+
+func TestSyncComposites_Serve_ClientRoleWithoutID(t *testing.T) {
+	mockRoles := mocks.NewMockRolesClient(t)
+	mockClients := mocks.NewMockClientsClient(t)
+	kClient := &keycloakapi.KeycloakClient{Roles: mockRoles, Clients: mockClients}
+
+	clientName := testClientName
+
+	role := &keycloakApi.KeycloakRealmRole{}
+	role.Spec.Name = testParentRoleName
+	role.Spec.Composite = true
+	role.Spec.CompositesClientRoles = map[string][]keycloakApi.Composite{
+		clientName: {{Name: "role1"}},
+	}
+
+	mockRoles.EXPECT().GetRealmRoleComposites(
+		context.Background(), "test-realm", testParentRoleName,
+	).Return([]keycloakapi.RoleRepresentation{}, nil, nil)
+
+	mockClients.EXPECT().GetClients(
+		context.Background(), "test-realm",
+		&keycloakapi.GetClientsParams{ClientId: &clientName},
+	).Return([]keycloakapi.ClientRepresentation{
+		{Id: ptr.To("client-uuid-1")},
+	}, nil, nil)
+
+	// No AddRealmRoleComposites expectation: reaching it fails the test.
+	mockClients.EXPECT().GetClientRole(
+		context.Background(), "test-realm", "client-uuid-1", "role1",
+	).Return(&keycloakapi.RoleRepresentation{Name: ptr.To("role1")}, nil, nil)
+
+	h := NewSyncComposites(kClient)
+	err := h.Serve(context.Background(), role, "test-realm", &RoleContext{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `client role "role1" has no id`)
+}
+
 func TestSyncComposites_Serve_GetClientRoleError(t *testing.T) {
 	mockRoles := mocks.NewMockRolesClient(t)
 	mockClients := mocks.NewMockClientsClient(t)

--- a/internal/controller/keycloakrealmuser/chain/sync_user_roles.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_roles.go
@@ -171,7 +171,12 @@ func (h *SyncUserRoles) syncClientRoles(
 				return fmt.Errorf("unable to get client role %q for client %q: %w", roleName, cr.ClientID, err)
 			}
 
-			toAdd = append(toAdd, *role)
+			mappable, err := keycloakapi.RequireClientRoleWithID(role, cr.ClientID, roleName)
+			if err != nil {
+				return err
+			}
+
+			toAdd = append(toAdd, mappable)
 		}
 
 		if len(toAdd) > 0 {

--- a/internal/controller/keycloakrealmuser/chain/sync_user_roles_test.go
+++ b/internal/controller/keycloakrealmuser/chain/sync_user_roles_test.go
@@ -192,6 +192,81 @@ func TestSyncUserRoles_Serve(t *testing.T) {
 			},
 		},
 		{
+			name: "error - GetClientRole returns no role",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec: keycloakApi.KeycloakRealmUserSpec{
+					ClientRoles: []keycloakApi.UserClientRole{
+						{ClientID: "client1", Roles: ptr.To([]string{"crole1"})},
+					},
+				},
+			},
+			userCtx: &UserContext{UserID: "user-crole-missing"},
+			mockSetup: func(u *v2mocks.MockUsersClient, _ *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
+				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakapi.GetClientsParams{ClientId: ptr.To("client1")}).
+					Return([]keycloakapi.ClientRepresentation{{Id: ptr.To("client-uuid-1")}}, nil, nil)
+				u.EXPECT().GetUserClientRoleMappings(context.Background(), "test-realm", "user-crole-missing", "client-uuid-1").
+					Return(nil, nil, nil)
+				// No role, no error.
+				c.EXPECT().GetClientRole(context.Background(), "test-realm", "client-uuid-1", "crole1").
+					Return(nil, nil, nil)
+			},
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), `client role "crole1" not found for client "client1"`)
+			},
+		},
+		{
+			name: "error - GetClientRole returns a role without an id",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec: keycloakApi.KeycloakRealmUserSpec{
+					ClientRoles: []keycloakApi.UserClientRole{
+						{ClientID: "client1", Roles: ptr.To([]string{"crole1"})},
+					},
+				},
+			},
+			userCtx: &UserContext{UserID: "user-crole-idless"},
+			mockSetup: func(u *v2mocks.MockUsersClient, _ *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
+				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakapi.GetClientsParams{ClientId: ptr.To("client1")}).
+					Return([]keycloakapi.ClientRepresentation{{Id: ptr.To("client-uuid-1")}}, nil, nil)
+				u.EXPECT().GetUserClientRoleMappings(context.Background(), "test-realm", "user-crole-idless", "client-uuid-1").
+					Return(nil, nil, nil)
+				// No AddUserClientRoles expectation: reaching it fails the test.
+				c.EXPECT().GetClientRole(context.Background(), "test-realm", "client-uuid-1", "crole1").
+					Return(&keycloakapi.RoleRepresentation{Name: ptr.To("crole1")}, nil, nil)
+			},
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), `client role "crole1" has no id`)
+			},
+		},
+		{
+			name: "error - GetClientRole returns another role",
+			user: &keycloakApi.KeycloakRealmUser{
+				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+				Spec: keycloakApi.KeycloakRealmUserSpec{
+					ClientRoles: []keycloakApi.UserClientRole{
+						{ClientID: "client1", Roles: ptr.To([]string{"crole1"})},
+					},
+				},
+			},
+			userCtx: &UserContext{UserID: "user-crole-other"},
+			mockSetup: func(u *v2mocks.MockUsersClient, _ *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
+				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakapi.GetClientsParams{ClientId: ptr.To("client1")}).
+					Return([]keycloakapi.ClientRepresentation{{Id: ptr.To("client-uuid-1")}}, nil, nil)
+				u.EXPECT().GetUserClientRoleMappings(context.Background(), "test-realm", "user-crole-other", "client-uuid-1").
+					Return(nil, nil, nil)
+				// No AddUserClientRoles expectation: reaching it fails the test.
+				c.EXPECT().GetClientRole(context.Background(), "test-realm", "client-uuid-1", "crole1").
+					Return(&keycloakapi.RoleRepresentation{Id: ptr.To("crid2"), Name: ptr.To("crole2")}, nil, nil)
+			},
+			wantErr: func(t require.TestingT, err error, _ ...any) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), `client role lookup for "crole1" returned "crole2"`)
+			},
+		},
+		{
 			name: "error - GetRealmRole fails",
 			user: &keycloakApi.KeycloakRealmUser{
 				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},

--- a/pkg/client/keycloakapi/contracts.go
+++ b/pkg/client/keycloakapi/contracts.go
@@ -230,7 +230,8 @@ type GroupsClient interface {
 type RolesClient interface {
 	// GetRealmRoles lists realm-level roles, optionally filtered by params.
 	GetRealmRoles(ctx context.Context, realm string, params *GetRealmRolesParams) ([]RoleRepresentation, *Response, error)
-	// GetRealmRole retrieves a realm-level role by name.
+	// GetRealmRole retrieves a realm-level role by name. A 2xx reply without a JSON body yields
+	// a nil role and a nil error.
 	GetRealmRole(ctx context.Context, realm, roleName string) (*RoleRepresentation, *Response, error)
 	// CreateRealmRole creates a new realm-level role.
 	CreateRealmRole(ctx context.Context, realm string, role RoleRepresentation) (*Response, error)
@@ -280,7 +281,8 @@ type ClientsClient interface {
 		clientID string,
 		params *GetClientRolesParams,
 	) ([]RoleRepresentation, *Response, error)
-	// GetClientRole retrieves a single client role by name; clientID is the Keycloak UUID.
+	// GetClientRole retrieves a single client role by name; clientID is the Keycloak UUID. A 2xx
+	// reply without a JSON body yields a nil role and a nil error.
 	GetClientRole(ctx context.Context, realm, clientID, roleName string) (*RoleRepresentation, *Response, error)
 	// CreateClientRole creates a new role for a client; clientID is the Keycloak UUID.
 	CreateClientRole(ctx context.Context, realm, clientID string, role RoleRepresentation) (*Response, error)

--- a/pkg/client/keycloakapi/roles.go
+++ b/pkg/client/keycloakapi/roles.go
@@ -15,17 +15,37 @@ type (
 // RequireRealmRoleWithID validates a GetRealmRole result for work that needs the role's id:
 // role mappings, composites and default-role entries. Keycloak matches a mapping payload on
 // name and id together, and a composite on id alone, and answers either mismatch with 404.
-// The returned representation has a non-nil Id.
+// The returned representation carries the requested name and a non-empty Id.
 //
 // GetRealmRole itself does not enforce this. A realm role is addressable by name on other
 // endpoints, so a response without an id is incomplete rather than missing.
 func RequireRealmRoleWithID(role *RoleRepresentation, realm, name string) (RoleRepresentation, error) {
+	return requireRoleWithID(role, "realm role", name, "in realm", realm)
+}
+
+// RequireClientRoleWithID validates a GetClientRole result for work that needs the role's id:
+// role mappings and composites. Same rule as [RequireRealmRoleWithID]; GetClientRole does not
+// enforce it. clientID is the human-readable clientId and only names the client in the error.
+// The returned representation carries the requested name and a non-empty Id.
+func RequireClientRoleWithID(role *RoleRepresentation, clientID, name string) (RoleRepresentation, error) {
+	return requireRoleWithID(role, "client role", name, "for client", clientID)
+}
+
+func requireRoleWithID(role *RoleRepresentation, kind, name, containerLabel, containerName string) (RoleRepresentation, error) {
 	if role == nil {
-		return RoleRepresentation{}, fmt.Errorf("realm role %q not found in realm %q", name, realm)
+		return RoleRepresentation{}, fmt.Errorf("%s %q not found %s %q", kind, name, containerLabel, containerName)
 	}
 
-	if role.Id == nil {
-		return RoleRepresentation{}, fmt.Errorf("realm role %q has no id", name)
+	if role.Name == nil {
+		return RoleRepresentation{}, fmt.Errorf("%s %q has no name", kind, name)
+	}
+
+	if *role.Name != name {
+		return RoleRepresentation{}, fmt.Errorf("%s lookup for %q returned %q", kind, name, *role.Name)
+	}
+
+	if role.Id == nil || *role.Id == "" {
+		return RoleRepresentation{}, fmt.Errorf("%s %q has no id", kind, name)
 	}
 
 	return *role, nil

--- a/pkg/client/keycloakapi/roles_internal_test.go
+++ b/pkg/client/keycloakapi/roles_internal_test.go
@@ -30,11 +30,81 @@ func TestRequireRealmRoleWithID(t *testing.T) {
 			role:    &RoleRepresentation{Name: ptr.To("admin")},
 			wantErr: `realm role "admin" has no id`,
 		},
+		{
+			name:    "role without a name is incomplete",
+			role:    &RoleRepresentation{Id: ptr.To("id-2")},
+			wantErr: `realm role "admin" has no name`,
+		},
+		{
+			name:    "role with another name is not the one asked for",
+			role:    &RoleRepresentation{Id: ptr.To("id-3"), Name: ptr.To("other")},
+			wantErr: `realm role lookup for "admin" returned "other"`,
+		},
+		{
+			name:    "role with an empty id is incomplete",
+			role:    &RoleRepresentation{Id: ptr.To(""), Name: ptr.To("admin")},
+			wantErr: `realm role "admin" has no id`,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := RequireRealmRoleWithID(tt.role, "test-realm", "admin")
+
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got.Id)
+			assert.Equal(t, tt.wantID, *got.Id)
+		})
+	}
+}
+
+func TestRequireClientRoleWithID(t *testing.T) {
+	tests := []struct {
+		name    string
+		role    *RoleRepresentation
+		wantID  string
+		wantErr string
+	}{
+		{
+			name:   "role with an id is returned",
+			role:   &RoleRepresentation{Id: ptr.To("id-1"), Name: ptr.To("viewer")},
+			wantID: "id-1",
+		},
+		{
+			name:    "no role is not found",
+			role:    nil,
+			wantErr: `client role "viewer" not found for client "my-client"`,
+		},
+		{
+			name:    "role without an id is incomplete, not missing",
+			role:    &RoleRepresentation{Name: ptr.To("viewer")},
+			wantErr: `client role "viewer" has no id`,
+		},
+		{
+			name:    "role without a name is incomplete",
+			role:    &RoleRepresentation{Id: ptr.To("id-2")},
+			wantErr: `client role "viewer" has no name`,
+		},
+		{
+			name:    "role with another name is not the one asked for",
+			role:    &RoleRepresentation{Id: ptr.To("id-3"), Name: ptr.To("other")},
+			wantErr: `client role lookup for "viewer" returned "other"`,
+		},
+		{
+			name:    "role with an empty id is incomplete",
+			role:    &RoleRepresentation{Id: ptr.To(""), Name: ptr.To("viewer")},
+			wantErr: `client role "viewer" has no id`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RequireClientRoleWithID(tt.role, "my-client", "viewer")
 
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)


### PR DESCRIPTION
- Client role lookups return whatever the endpoint sent. Four consumers used the result unchecked, so a 2xx reply without a JSON body panicked the reconcile. A fifth rejected a missing role but let an id-less role reach a mapping payload.
- RequireClientRoleWithID states the rule once, beside the realm role helper, and returns the requested role with a non-empty id. Keycloak matches a role mapping on name and id together and a composite on id alone, and answers either mismatch with 404. A reply that carries another role's name and id passes both checks and maps that other role, so both helpers now also require the name they asked for.
- Reproduced with a proxy that answers the role lookup with a 200 HTML page, as an SSO ingress does. The same request on the realm role path already returned a clean error.

