### PR TITLE
fix(keycloakrealmgroup): omit an empty description from the group payload

### DIFF
--- a/internal/controller/keycloakrealmgroup/chain/create_or_update_group.go
+++ b/internal/controller/keycloakrealmgroup/chain/create_or_update_group.go
@@ -19,6 +19,15 @@ func NewCreateOrUpdateGroup(k8sClient client.Client) *CreateOrUpdateGroup {
 	return &CreateOrUpdateGroup{k8sClient: k8sClient}
 }
 
+// Keycloak clears the description when the key is absent; servers before 26.3 reject it.
+func optionalDescription(description string) *string {
+	if description == "" {
+		return nil
+	}
+
+	return &description
+}
+
 func (h *CreateOrUpdateGroup) Serve(
 	ctx context.Context,
 	group *keycloakApi.KeycloakRealmGroup,
@@ -102,7 +111,7 @@ func (h *CreateOrUpdateGroup) Serve(
 	if existingGroup == nil {
 		groupRep := keycloakapi.GroupRepresentation{
 			Name:        &spec.Name,
-			Description: &spec.Description,
+			Description: optionalDescription(spec.Description),
 			Path:        &spec.Path,
 			Attributes:  &spec.Attributes,
 		}
@@ -128,7 +137,7 @@ func (h *CreateOrUpdateGroup) Serve(
 	} else {
 		groupCtx.GroupID = existingGroupID
 		existingGroup.Name = &spec.Name
-		existingGroup.Description = &spec.Description
+		existingGroup.Description = optionalDescription(spec.Description)
 		existingGroup.Path = &spec.Path
 		existingGroup.Attributes = &spec.Attributes
 

--- a/internal/controller/keycloakrealmgroup/chain/create_or_update_group_test.go
+++ b/internal/controller/keycloakrealmgroup/chain/create_or_update_group_test.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"testing"
@@ -82,10 +83,9 @@ func TestCreateOrUpdateGroup_Serve_CreateTopLevel(t *testing.T) {
 	mockGroups.EXPECT().CreateGroup(
 		context.Background(), "test-realm",
 		keycloakapi.GroupRepresentation{
-			Name:        ptr.To(testGroupName),
-			Description: ptr.To(""),
-			Path:        ptr.To(testGroupPath),
-			Attributes:  &map[string][]string{"key": {"val"}},
+			Name:       ptr.To(testGroupName),
+			Path:       ptr.To(testGroupPath),
+			Attributes: &map[string][]string{"key": {"val"}},
 		},
 	).Return(&keycloakapi.Response{
 		HTTPResponse: &http.Response{
@@ -208,16 +208,97 @@ func TestCreateOrUpdateGroup_Serve_CreateGroupError(t *testing.T) {
 	mockGroups.EXPECT().CreateGroup(
 		context.Background(), "test-realm",
 		keycloakapi.GroupRepresentation{
-			Name:        ptr.To(testGroupName),
-			Description: ptr.To(""),
-			Path:        ptr.To(testGroupPath),
-			Attributes:  &map[string][]string{"key": {"val"}},
+			Name:       ptr.To(testGroupName),
+			Path:       ptr.To(testGroupPath),
+			Attributes: &map[string][]string{"key": {"val"}},
 		},
 	).Return(nil, errors.New("create failed"))
 
 	h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
 	err := h.Serve(context.Background(), group, kClient, groupCtx)
 	assert.ErrorContains(t, err, "unable to create group")
+}
+
+func assertNoDescriptionOnWire(t *testing.T, rep keycloakapi.GroupRepresentation) {
+	t.Helper()
+
+	body, err := json.Marshal(rep)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), `"description"`)
+}
+
+func TestCreateOrUpdateGroup_Serve_OmitsEmptyDescription(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		mockGroups := mocks.NewMockGroupsClient(t)
+
+		kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+		groupCtx := &GroupContext{RealmName: "test-realm"}
+
+		group := &keycloakApi.KeycloakRealmGroup{}
+		group.Spec.Name = testGroupName
+		group.Spec.Path = testGroupPath
+
+		mockGroups.EXPECT().FindGroupByName(
+			context.Background(), "test-realm", testGroupName,
+		).Return(nil, nil, keycloakapi.ErrNotFound)
+
+		mockGroups.EXPECT().CreateGroup(
+			context.Background(), "test-realm",
+			keycloakapi.GroupRepresentation{
+				Name:       ptr.To(testGroupName),
+				Path:       ptr.To(testGroupPath),
+				Attributes: &group.Spec.Attributes,
+			},
+		).RunAndReturn(func(_ context.Context, _ string, rep keycloakapi.GroupRepresentation) (*keycloakapi.Response, error) {
+			assertNoDescriptionOnWire(t, rep)
+
+			return &keycloakapi.Response{
+				HTTPResponse: &http.Response{
+					Header: http.Header{"Location": []string{"http://localhost/admin/realms/test-realm/groups/group-id-123"}},
+				},
+			}, nil
+		})
+
+		h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
+		require.NoError(t, h.Serve(context.Background(), group, kClient, groupCtx))
+	})
+
+	t.Run("update over a stored description", func(t *testing.T) {
+		mockGroups := mocks.NewMockGroupsClient(t)
+
+		kClient := &keycloakapi.KeycloakClient{Groups: mockGroups}
+		groupCtx := &GroupContext{RealmName: "test-realm"}
+
+		group := &keycloakApi.KeycloakRealmGroup{}
+		group.Spec.Name = testExistingGroup
+		group.Spec.Path = testUpdatedPath
+
+		mockGroups.EXPECT().FindGroupByName(
+			context.Background(), "test-realm", testExistingGroup,
+		).Return(&keycloakapi.GroupRepresentation{
+			Id:          ptr.To("existing-id"),
+			Name:        ptr.To(testExistingGroup),
+			Description: ptr.To("stale description"),
+			Path:        ptr.To("/old-path"),
+		}, nil, nil)
+
+		mockGroups.EXPECT().UpdateGroup(
+			context.Background(), "test-realm", "existing-id",
+			keycloakapi.GroupRepresentation{
+				Id:         ptr.To("existing-id"),
+				Name:       ptr.To(testExistingGroup),
+				Path:       ptr.To(testUpdatedPath),
+				Attributes: &group.Spec.Attributes,
+			},
+		).RunAndReturn(func(_ context.Context, _, _ string, rep keycloakapi.GroupRepresentation) (*keycloakapi.Response, error) {
+			assertNoDescriptionOnWire(t, rep)
+
+			return nil, nil
+		})
+
+		h := NewCreateOrUpdateGroup(newFakeK8sClient(t))
+		require.NoError(t, h.Serve(context.Background(), group, kClient, groupCtx))
+	})
 }
 
 func TestCreateOrUpdateGroup_Serve_UpdateGroupError(t *testing.T) {
@@ -242,11 +323,10 @@ func TestCreateOrUpdateGroup_Serve_UpdateGroupError(t *testing.T) {
 	mockGroups.EXPECT().UpdateGroup(
 		context.Background(), "test-realm", "existing-id",
 		keycloakapi.GroupRepresentation{
-			Id:          ptr.To("existing-id"),
-			Name:        ptr.To(testExistingGroup),
-			Description: ptr.To(""),
-			Path:        ptr.To(testUpdatedPath),
-			Attributes:  &map[string][]string{"key": {"val"}},
+			Id:         ptr.To("existing-id"),
+			Name:       ptr.To(testExistingGroup),
+			Path:       ptr.To(testUpdatedPath),
+			Attributes: &map[string][]string{"key": {"val"}},
 		},
 	).Return(nil, errors.New("update failed"))
 
@@ -277,11 +357,10 @@ func TestCreateOrUpdateGroup_Serve_UpdateExistingChildGroup(t *testing.T) {
 	mockGroups.EXPECT().UpdateGroup(
 		context.Background(), "test-realm", "child-id",
 		keycloakapi.GroupRepresentation{
-			Id:          ptr.To("child-id"),
-			Name:        ptr.To(testChildGroupName),
-			Description: ptr.To(""),
-			Path:        ptr.To(testUpdatedPath),
-			Attributes:  &map[string][]string{"k": {"v"}},
+			Id:         ptr.To("child-id"),
+			Name:       ptr.To(testChildGroupName),
+			Path:       ptr.To(testUpdatedPath),
+			Attributes: &map[string][]string{"k": {"v"}},
 		},
 	).Return(nil, nil)
 
@@ -406,10 +485,9 @@ func TestCreateOrUpdateGroup_Serve_CreateWithoutLocationHeader(t *testing.T) {
 	mockGroups.EXPECT().CreateGroup(
 		context.Background(), "test-realm",
 		keycloakapi.GroupRepresentation{
-			Name:        ptr.To(testGroupName),
-			Description: ptr.To(""),
-			Path:        ptr.To(testGroupPath),
-			Attributes:  &map[string][]string{"key": {"val"}},
+			Name:       ptr.To(testGroupName),
+			Path:       ptr.To(testGroupPath),
+			Attributes: &map[string][]string{"key": {"val"}},
 		},
 	).Return(&keycloakapi.Response{HTTPResponse: &http.Response{Header: http.Header{}}}, nil)
 
@@ -441,10 +519,9 @@ func TestCreateOrUpdateGroup_Serve_ExistingIDNotFound_FallsBackToName(t *testing
 	mockGroups.EXPECT().CreateGroup(
 		context.Background(), "test-realm",
 		keycloakapi.GroupRepresentation{
-			Name:        ptr.To(testGroupName),
-			Description: ptr.To(""),
-			Path:        ptr.To(testGroupPath),
-			Attributes:  &map[string][]string{"key": {"val"}},
+			Name:       ptr.To(testGroupName),
+			Path:       ptr.To(testGroupPath),
+			Attributes: &map[string][]string{"key": {"val"}},
 		},
 	).Return(&keycloakapi.Response{
 		HTTPResponse: &http.Response{
@@ -500,11 +577,10 @@ func TestCreateOrUpdateGroup_Serve_AdoptUnownedGroupByName(t *testing.T) {
 	mockGroups.EXPECT().UpdateGroup(
 		context.Background(), "test-realm", "existing-id",
 		keycloakapi.GroupRepresentation{
-			Id:          ptr.To("existing-id"),
-			Name:        ptr.To(testExistingGroup),
-			Description: ptr.To(""),
-			Path:        ptr.To(testUpdatedPath),
-			Attributes:  &map[string][]string{"key": {"val"}},
+			Id:         ptr.To("existing-id"),
+			Name:       ptr.To(testExistingGroup),
+			Path:       ptr.To(testUpdatedPath),
+			Attributes: &map[string][]string{"key": {"val"}},
 		},
 	).Return(nil, nil)
 
@@ -577,11 +653,10 @@ func TestCreateOrUpdateGroup_Serve_AllowsSameGroupIDOnNamespacedRealmInAnotherNa
 	mockGroups.EXPECT().UpdateGroup(
 		context.Background(), "test-realm", "existing-id",
 		keycloakapi.GroupRepresentation{
-			Id:          ptr.To("existing-id"),
-			Name:        ptr.To(testExistingGroup),
-			Description: ptr.To(""),
-			Path:        ptr.To(testUpdatedPath),
-			Attributes:  &map[string][]string{"key": {"val"}},
+			Id:         ptr.To("existing-id"),
+			Name:       ptr.To(testExistingGroup),
+			Path:       ptr.To(testUpdatedPath),
+			Attributes: &map[string][]string{"key": {"val"}},
 		},
 	).Return(nil, nil)
 
@@ -726,11 +801,10 @@ func TestCreateOrUpdateGroup_Serve_ByIDPathSkipsOwnershipCheck(t *testing.T) {
 	mockGroups.EXPECT().UpdateGroup(
 		context.Background(), "test-realm", "existing-id",
 		keycloakapi.GroupRepresentation{
-			Id:          ptr.To("existing-id"),
-			Name:        ptr.To("new-name"),
-			Description: ptr.To(""),
-			Path:        ptr.To("/new-name"),
-			Attributes:  &map[string][]string{"key": {"val"}},
+			Id:         ptr.To("existing-id"),
+			Name:       ptr.To("new-name"),
+			Path:       ptr.To("/new-name"),
+			Attributes: &map[string][]string{"key": {"val"}},
 		},
 	).Return(nil, nil)
 

--- a/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller_integration_test.go
+++ b/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller_integration_test.go
@@ -277,6 +277,26 @@ var _ = Describe("KeycloakRealmGroup controller", Ordered, func() {
 			g.Expect(*groupRep.RealmRoles).ShouldNot(ContainElement("test-group-role"))
 		}, time.Minute, time.Second*5).Should(Succeed())
 
+		By("Emptying spec.Description clears it in Keycloak")
+		updatableGroup = &keycloakApi.KeycloakRealmGroup{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: group.Name, Namespace: ns}, updatableGroup)).Should(Succeed())
+		updatableGroup.Spec.Description = ""
+		updatableGroup.Spec.Attributes = map[string][]string{"cleared-desc-probe": {"1"}}
+		Expect(k8sClient.Update(ctx, updatableGroup)).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			groupFromK8s := &keycloakApi.KeycloakRealmGroup{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: group.Name, Namespace: ns}, groupFromK8s)).Should(Succeed())
+			g.Expect(groupFromK8s.Status.Value).Should(Equal(common.StatusOK))
+
+			groupRep, _, err := keycloakApiClient.Groups.GetGroup(ctx, KeycloakRealmCR, groupFromK8s.Status.ID)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(groupRep).ShouldNot(BeNil())
+
+			g.Expect(*groupRep.Attributes).Should(HaveKey("cleared-desc-probe"))
+			g.Expect(ptr.Deref(groupRep.Description, "")).Should(BeEmpty())
+		}, time.Minute, time.Second*5).Should(Succeed())
+
 		By("Renaming the group via spec.Name")
 		updatableGroup = &keycloakApi.KeycloakRealmGroup{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: group.Name, Namespace: ns}, updatableGroup)).Should(Succeed())


### PR DESCRIPTION

The group representation always carried a description pointer, so an unset spec.description serialized as "description": "". Keycloak added the field to GroupRepresentation in 26.3; older servers reject the unknown key outright and the group is never created, leaving the resource stuck with a rising failureCount. Reported against operator v1.34.0 on RHBK 26.2.

Send the key only when the spec sets a description. Keycloak clears the description on a write that omits it, so emptying spec.description still propagates to the group. Behaviour on 26.3 and newer is unchanged.

Closes #355

