### PR TITLE
fix(keycloakrealm): skip deleting the master realm

### DIFF
--- a/api/v1/keycloakrealm_types.go
+++ b/api/v1/keycloakrealm_types.go
@@ -9,6 +9,7 @@ import (
 // KeycloakRealmSpec defines the desired state of KeycloakRealm.
 type KeycloakRealmSpec struct {
 	// RealmName specifies the name of the realm.
+	// The master realm is never deleted from Keycloak; removing its custom resource only stops managing it.
 	// +required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	RealmName string `json:"realmName"`

--- a/api/v1alpha1/clusterkeycloakrealm_types.go
+++ b/api/v1alpha1/clusterkeycloakrealm_types.go
@@ -14,6 +14,7 @@ type ClusterKeycloakRealmSpec struct {
 	ClusterKeycloakRef string `json:"clusterKeycloakRef"`
 
 	// RealmName specifies the name of the realm.
+	// The master realm is never deleted from Keycloak; removing its custom resource only stops managing it.
 	RealmName string `json:"realmName"`
 
 	// FrontendURL Set the frontend URL for the realm.

--- a/config/crd/bases/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/config/crd/bases/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -305,7 +305,9 @@ spec:
                     x-kubernetes-list-type: set
                 type: object
               realmName:
-                description: RealmName specifies the name of the realm.
+                description: |-
+                  RealmName specifies the name of the realm.
+                  The master realm is never deleted from Keycloak; removing its custom resource only stops managing it.
                 type: string
               sessions:
                 description: Sessions defines the session settings for the realm.

--- a/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
+++ b/config/crd/bases/v1.edp.epam.com_keycloakrealms.yaml
@@ -319,7 +319,9 @@ spec:
                     x-kubernetes-list-type: set
                 type: object
               realmName:
-                description: RealmName specifies the name of the realm.
+                description: |-
+                  RealmName specifies the name of the realm.
+                  The master realm is never deleted from Keycloak; removing its custom resource only stops managing it.
                 type: string
                 x-kubernetes-validations:
                 - message: Value is immutable

--- a/deploy-templates/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -305,7 +305,9 @@ spec:
                     x-kubernetes-list-type: set
                 type: object
               realmName:
-                description: RealmName specifies the name of the realm.
+                description: |-
+                  RealmName specifies the name of the realm.
+                  The master realm is never deleted from Keycloak; removing its custom resource only stops managing it.
                 type: string
               sessions:
                 description: Sessions defines the session settings for the realm.

--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
+++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealms.yaml
@@ -319,7 +319,9 @@ spec:
                     x-kubernetes-list-type: set
                 type: object
               realmName:
-                description: RealmName specifies the name of the realm.
+                description: |-
+                  RealmName specifies the name of the realm.
+                  The master realm is never deleted from Keycloak; removing its custom resource only stops managing it.
                 type: string
                 x-kubernetes-validations:
                 - message: Value is immutable

--- a/docs/api.md
+++ b/docs/api.md
@@ -99,7 +99,8 @@ ClusterKeycloakRealmSpec defines the desired state of ClusterKeycloakRealm.
         <td><b>realmName</b></td>
         <td>string</td>
         <td>
-          RealmName specifies the name of the realm.<br/>
+          RealmName specifies the name of the realm.
+The master realm is never deleted from Keycloak; removing its custom resource only stops managing it.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -6352,7 +6353,8 @@ KeycloakRealmSpec defines the desired state of KeycloakRealm.
         <td><b>realmName</b></td>
         <td>string</td>
         <td>
-          RealmName specifies the name of the realm.<br/>
+          RealmName specifies the name of the realm.
+The master realm is never deleted from Keycloak; removing its custom resource only stops managing it.<br/>
           <br/>
             <i>Validations</i>:<li>self == oldSelf: Value is immutable</li>
         </td>

--- a/internal/controller/keycloakrealm/terminator.go
+++ b/internal/controller/keycloakrealm/terminator.go
@@ -9,6 +9,10 @@ import (
 	"github.com/epam/edp-keycloak-operator/pkg/client/keycloakapi"
 )
 
+// masterRealmName is the Keycloak admin realm. Keycloak rejects DELETE on it with 400
+// "Can't remove master realm"; the name is fixed in the Quarkus distribution.
+const masterRealmName = "master"
+
 // Terminator deletes a Keycloak realm during resource cleanup.
 type Terminator struct {
 	realmName                   string
@@ -20,6 +24,11 @@ func (t *Terminator) DeleteResource(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx).WithValues("keycloak_realm", t.realmName)
 	if t.preserveResourcesOnDeletion {
 		log.Info("PreserveResourcesOnDeletion is enabled, skipping deletion.")
+		return nil
+	}
+
+	if t.realmName == masterRealmName {
+		log.Info("Master realm cannot be deleted in Keycloak, skipping deletion.")
 		return nil
 	}
 

--- a/internal/controller/keycloakrealm/terminator_test.go
+++ b/internal/controller/keycloakrealm/terminator_test.go
@@ -57,6 +57,15 @@ func Test_terminator_DeleteResource(t *testing.T) {
 			preserveResourcesOnDeletion: true,
 			wantErr:                     assert.NoError,
 		},
+		{
+			name:      "master realm — skip",
+			realmName: masterRealmName,
+			realmClient: func(t *testing.T) keycloakapi.RealmClient {
+				return v2mocks.NewMockRealmClient(t)
+			},
+			preserveResourcesOnDeletion: false,
+			wantErr:                     assert.NoError,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Keycloak rejects DELETE on the admin realm with 400 "Can't remove master realm". The terminator only tolerated 404, so the error blocked finalizer removal and left a KeycloakRealm for master stuck in Terminating, which in turn wedged namespace deletion during helm uninstall or GitOps pruning.

Skip the API call for master and return nil so the finalizer is removed and only the custom resource goes away. ClusterKeycloakRealm shares the terminator and gets the same behavior.

Closes #404

